### PR TITLE
Replace REST API with Graphql for Cart

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -24,6 +24,7 @@ require('./axios')
 require('./filters')
 require('./mixins')
 require('./turbolinks')
+require('./callbacks')
 
 /**
  * The following block of code may be used to automatically register your
@@ -77,6 +78,12 @@ document.addEventListener('turbolinks:load', () => {
             guestEmail: null,
             user: null,
             cart: null,
+            get mask() {
+                return localStorage.getItem('mask')
+            },
+            set mask(value) {
+                return localStorage.setItem('mask', value)
+            },
             checkout: {
                 step: 1,
                 shipping_address: {

--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -1,0 +1,7 @@
+Vue.prototype.processCartData = async function (data) {
+    return this.$root.cart = data.cart
+}
+
+Vue.prototype.refreshCart = async function () {
+    return this.$root.$emit('refresh-cart')
+}

--- a/resources/js/components/Cart/Cart.vue
+++ b/resources/js/components/Cart/Cart.vue
@@ -6,31 +6,9 @@
         render() {
             return this.$scopedSlots.default({
                 cart: this.cart,
-                hasItems: this.hasItems,
-                changeQty: this.changeQty,
-                remove: this.remove,
+                cartCrossells: this.cartCrossells,
+                refreshCart: this.refreshCart,
             })
         },
-        methods: {
-            changeQty(item) {
-                this.magentoCart('put', 'items/' + item.item_id, {
-                    cartItem: {
-                        quote_id: localStorage.mask,
-                        qty: item.qty
-                    }
-                })
-                .then((response) => this.refreshCart())
-                .catch((error) => Notify(error.response.data.message, 'error'))
-            },
-
-            remove(item) {
-                this.magentoCart('delete', 'items/' + item.item_id)
-                    .then((response) => {
-                        this.refreshCart()
-                        Notify(item.name + ' ' + window.config.translations.cart.remove, 'info')
-                    })
-                    .catch((error) => Notify(error.response.data.message, 'error'))
-            },
-        }
     }
 </script>

--- a/resources/js/components/Cart/Minicart.vue
+++ b/resources/js/components/Cart/Minicart.vue
@@ -1,0 +1,22 @@
+<script>
+    import GetCart from './../Cart/mixins/GetCart'
+    import Graphql from './../Graphql'
+
+    export default {
+        mixins: [GetCart, Graphql],
+        created() {
+            this.getMask()
+            this.resolveData()
+        },
+        mounted() {
+            this.$root.$on('refresh-cart', this.refreshCart)
+        },
+        methods: {
+            async refreshCart()
+            {
+                await this.getMask()
+                this.resolveData({'skip_cache': true})
+            }
+        }
+    }
+</script>

--- a/resources/js/components/Cart/mixins/GetCart.js
+++ b/resources/js/components/Cart/mixins/GetCart.js
@@ -58,7 +58,7 @@ export default {
         cartCrossells: function () {
             let crossellSet = new Set()
 
-            for (let item of Object.values(this.cart.items)) {
+            for (let item of Object.values(this.cart.items ? this.cart.items : [])) {
                 for (let crossell_product of item.product.crosssell_products) {
                     crossellSet.add(crossell_product.id)
                 }

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -141,7 +141,7 @@
                         await this.login(this.$root.user.email, this.checkout.password, async () => {
                             if (self.$root.cart) {
                                 await self.linkUserToCart()
-                                localStorage.mask = self.$root.cart.entity_id
+                                this.$root.mask = self.$root.cart.id
                             }
                         });
                     }

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -47,7 +47,7 @@
                     await this.login(this.email, this.password, async () => {
                         if (self.$root.cart) {
                             await self.linkUserToCart()
-                            localStorage.mask = self.$root.cart.entity_id
+                            this.$root.mask = self.$root.cart.id
                         } else {
                             await self.refreshCart()
                         }

--- a/resources/js/components/Coupon/Coupon.vue
+++ b/resources/js/components/Coupon/Coupon.vue
@@ -13,7 +13,7 @@
 
         render() {
             return this.$scopedSlots.default({
-                cart: this.$root.cart,
+                cart: this.cart,
                 removeCoupon: this.removeCoupon,
                 applyCoupon: this.applyCoupon,
                 couponCode: this.couponCode,

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -5,6 +5,10 @@
                 type: String,
                 required: true,
             },
+            variables: {
+                type: Object,
+                default: () => {},
+            },
             changes: {
                 type: Object,
                 default: () => ({}),
@@ -54,7 +58,8 @@
 
                 try {
                     let response = await axios.post(config.magento_url + '/graphql', {
-                        query: this.query.replace('changes', this.queryfy(this.changes))
+                        query: this.query.replace('changes', this.queryfy(this.changes)),
+                        variables: this.variables
                     }, this.$root.user ? { headers: { Authorization: `Bearer ${localStorage.token}` }} : null)
 
                     if (response.data.errors) {

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -50,7 +50,7 @@
                 this.magentoCart('post', 'items', {
                     cartItem: {
                         sku: this.product.sku,
-                        quote_id: localStorage.mask,
+                        quote_id: this.$root.mask,
                         qty: this.qty,
                         product_option: this.productOptions
                     }

--- a/resources/js/mixins.js
+++ b/resources/js/mixins.js
@@ -10,7 +10,7 @@ Vue.mixin({
             if (this.$root.user) {
                 return await magentoUser[method]('carts/mine/' + endpoint, data)
             } else {
-                return await magento[method]('guest-carts/' + localStorage.mask + '/' + endpoint, data)
+                return await magento[method]('guest-carts/' + this.$root.mask + '/' + endpoint, data)
             }
         }
     }

--- a/resources/views/cart/coupon.blade.php
+++ b/resources/views/cart/coupon.blade.php
@@ -20,12 +20,12 @@
                     </x-rapidez::button>
                 </form>
                 <p class="text-red-500 text-xs italic w-3/4 mt-3" v-if="submitError">@{{ submitError }}</p>
-                <div class="relative rounded-md" v-if="cart.discount_name && cart.discount_amount > 0">
+                <div class="relative rounded-md" v-if="cart.applied_coupons">
                     <div class="flex items-center">
                         <button v-on:click="removeCoupon">
                             <x-heroicon-s-x class="h-4 w-4 text-black-400"/>
                         </button>
-                        @lang('Discount'): @{{ cart.discount_name }}
+                        @lang('Discount'): @{{ cart.applied_coupons[0].code }}
                     </div>
                 </div>
             </div>

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -30,7 +30,7 @@
                     @{{ item.prices.price.value | price }}
                 </div>
                 <graphql-mutation :callback="refreshCart" :changes="{cart_id: cart.id, cart_items: {cart_item_id: Number(item.id), quantity: Number(item.quantity)}}" query='@include("rapidez::cart.queries.changeQty")'>
-                    <div class="w-2/6 sm:w-1/6 lg:w-1/12" slot-scope="{ changes, mutate, mutated }">
+                    <div class="w-2/6 sm:w-1/6 lg:w-1/12" slot-scope="{ mutate }">
                         <div class="inline-flex">
                             <x-rapidez::input
                                 :label="false"
@@ -55,7 +55,7 @@
                 <div class="w-2/6 sm:w-1/6 lg:w-1/12 flex justify-end items-center text-right">
                     @{{ item.prices.price.value * item.quantity | price }}
                     <graphql-mutation :callback="refreshCart" :changes="{ cart_id: cart.id, cart_item_id: Number(item.id) }" query="@include('rapidez::cart.queries.removeItemFromCart')">
-                        <a :disabled="$root.loading" slot-scope="{changes, mutate}" href="#" v-on:click.prevent="mutate()" class="ml-2" title="@lang('Remove')" :dusk="'item-delete-'+index">
+                        <a :disabled="$root.loading" slot-scope="{ mutate }" href="#" v-on:click.prevent="mutate()" class="ml-2" title="@lang('Remove')" :dusk="'item-delete-'+index">
                             <x-heroicon-s-x class="w-4 h-4"/>
                         </a>
                     </graphql-mutation>

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -4,17 +4,16 @@
 
 @section('content')
     <h1 class="font-bold text-4xl mb-5">@lang('Cart')</h1>
-
-    <cart v-cloak>
-        <div v-if="hasItems" slot-scope="{ cart, hasItems, changeQty, remove }">
-            <div class="flex flex-wrap items-center border-b pb-2 mb-2" v-for="(item, productId, index) in cart.items">
+    <cart v-if="mask" v-cloak>
+        <div v-if="cart && cart.items && Object.keys(cart.items).length" slot-scope="{ data, refreshCart, cartCrossells }">
+            <div class="flex flex-wrap items-center border-b pb-2 mb-2" v-for="(item, index) in cart.items">
                 <div class="w-1/6 sm:w-1/12 pr-3">
-                    <a :href="item.url" class="block">
+                    <a :href="item.product.url_key + item.product.url_suffix" class="block">
                         <picture>
-                            <source :srcset="'/storage/resizes/100x100/catalog/product' + item.image + '.webp'" type="image/webp">
+                            <source :srcset="'/storage/resizes/100x100/catalog/product' + item.product.image.url.replace(config.media_url + '/catalog/product', '') + '.webp'" type="image/webp">
                             <img
-                                :alt="item.name"
-                                :src="'/storage/resizes/100x100/catalog/product' + item.image"
+                                :alt="item.product.name"
+                                :src="'/storage/resizes/100x100/catalog/product' + item.product.image.url.replace(config.media_url + '/catalog/product', '')"
                                 height="100"
                                 class="mx-auto"
                             />
@@ -22,40 +21,44 @@
                     </a>
                 </div>
                 <div class="w-5/6 sm:w-5/12 lg:w-8/12">
-                    <a :href="item.url" dusk="cart-item-name" class="font-bold">@{{ item.name }}</a>
-                    <div v-for="(optionValue, option) in item.options">
-                        @{{ option }}: @{{ optionValue }}
+                    <a :href="item.product.url_key + item.product.url_suffix" dusk="cart-item-name" class="font-bold">@{{ item.product.name }}</a>
+                    <div v-for="(option) in item.configurable_options">
+                        @{{ option.option_label }}: @{{ option.value_label }}
                     </div>
                 </div>
                 <div class="w-2/6 sm:w-1/6 lg:w-1/12 text-right pr-5">
-                    @{{ item.price | price }}
+                    @{{ item.prices.price.value | price }}
                 </div>
-                <div class="w-2/6 sm:w-1/6 lg:w-1/12">
-                    <div class="inline-flex">
-                        <x-rapidez::input
-                            :label="false"
-                            class="text-right"
-                            type="number"
-                            min="1"
-                            name="qty"
-                            v-model="item.qty"
-                            v-bind:dusk="'qty-'+index"
-                        />
-                        <x-rapidez::button
-                            class="ml-1"
-                            :title="__('Update')"
-                            v-on:click="changeQty(item)"
-                            v-bind:dusk="'item-update-'+index"
-                        >
-                            <x-heroicon-s-refresh class="w-4 h-4"/>
-                        </x-rapidez::button>
+                <graphql-mutation :callback="refreshCart" :changes="{cart_id: cart.id, cart_items: {cart_item_id: Number(item.id), quantity: Number(item.quantity)}}" query='@include("rapidez::cart.queries.changeQty")'>
+                    <div class="w-2/6 sm:w-1/6 lg:w-1/12" slot-scope="{ changes, mutate, mutated }">
+                        <div class="inline-flex">
+                            <x-rapidez::input
+                                :label="false"
+                                class="text-right"
+                                type="number"
+                                min="1"
+                                name="qty"
+                                v-model="item.quantity"
+                                v-bind:dusk="'qty-'+index"
+                            />
+                            <x-rapidez::button
+                                class="ml-1"
+                                :title="__('Update')"
+                                v-on:click="mutate()"
+                                v-bind:dusk="'item-update-'+index"
+                            >
+                                <x-heroicon-s-refresh class="w-4 h-4"/>
+                            </x-rapidez::button>
+                        </div>
                     </div>
-                </div>
+                </graphql-mutation>
                 <div class="w-2/6 sm:w-1/6 lg:w-1/12 flex justify-end items-center text-right">
-                    @{{ item.total | price }}
-                    <a href="#" @click.prevent="remove(item)" class="ml-2" title="@lang('Remove')" :dusk="'item-delete-'+index">
-                        <x-heroicon-s-x class="w-4 h-4"/>
-                    </a>
+                    @{{ item.prices.price.value * item.quantity | price }}
+                    <graphql-mutation :callback="refreshCart" :changes="{ cart_id: cart.id, cart_item_id: Number(item.id) }" query="@include('rapidez::cart.queries.removeItemFromCart')">
+                        <a :disabled="$root.loading" slot-scope="{changes, mutate}" href="#" v-on:click.prevent="mutate()" class="ml-2" title="@lang('Remove')" :dusk="'item-delete-'+index">
+                            <x-heroicon-s-x class="w-4 h-4"/>
+                        </a>
+                    </graphql-mutation>
                 </div>
             </div>
 
@@ -64,14 +67,13 @@
                 <div class="flex flex-wrap justify-end sm:w-64">
                     <div class="flex flex-wrap w-full p-3 mb-5 bg-secondary rounded-lg">
                         <div class="w-1/2">@lang('Subtotal')</div>
-                        <div class="w-1/2 text-right">@{{ cart.subtotal | price }}</div>
-                        <div class="w-1/2">@lang('Tax')</div>
-                        <div class="w-1/2 text-right">@{{ cart.tax | price }}</div>
-                        <div class="w-1/2" v-if="cart.discount_name && cart.discount_amount > 0">@lang('Discount'): @{{ cart.discount_name }}</div>
-                        <div class="w-1/2" v-if="!cart.discount_name && cart.discount_amount > 0">@lang('Discount')</div>
-                        <div class="w-1/2 text-right" v-if="cart.discount_amount > 0">@{{ cart.discount_amount | price }}</div>
-                        <div class="w-1/2 font-bold">@lang('Total')</div>
-                        <div class="w-1/2 text-right font-bold">@{{ cart.total | price }}</div>
+                        <div class="w-1/2 text-right">@{{ cart.prices.subtotal_excluding_tax.value | price }}</div>
+                        <div v-if="cart.prices.applied_taxes.length" class="w-1/2">@lang('Tax')</div>
+                        <div v-if="cart.prices.applied_taxes.length" v-for="(tax) in cart.prices.applied_taxes" class="w-1/2 text-right">@{{ tax | price }}</div>
+                        <div class="w-1/2" v-if="cart.prices.discounts.length" v-for="(discount) in cart.prices.discounts">@{{ discount.label }}:</div>
+                        <div class="w-1/2 text-right" v-if="cart.prices.discounts.length" v-for="(discount) in cart.prices.discounts">@{{ discount.amount.value | price }}</div>
+                        <div class="w-1/2 font-bold">@lang('Total'):</div>
+                        <div class="w-1/2 text-right font-bold">@{{ cart.prices.grand_total.value | price }}</div>
                     </div>
 
                     <x-rapidez::button href="/checkout" dusk="checkout">
@@ -80,10 +82,13 @@
                 </div>
             </div>
 
-            <x-rapidez::productlist title="More choices to go with your product" field="id" value="cart.cross_sells"/>
+            <x-rapidez::productlist title="More choices to go with your product" field="id" value="cartCrossells"/>
         </div>
         <div v-else>
             @lang('You don\'t have anything in your cart.')
         </div>
     </cart>
+    <div v-else>
+        @lang('You don\'t have anything in your cart.')
+    </div>
 @endsection

--- a/resources/views/cart/queries/cart.graphql
+++ b/resources/views/cart/queries/cart.graphql
@@ -1,0 +1,86 @@
+query getCart($cart_id: String!) {
+  cart ( cart_id: $cart_id) {
+    id
+    items
+    {
+      id
+      product
+      {
+        name
+        sku
+        id
+        image
+        {
+            url
+        }
+        url_key
+        url_suffix
+        crosssell_products {
+          id
+          name
+        }
+      }
+      __typename
+      ... on SimpleCartItem {
+        customizable_options {
+          id
+          is_required
+          values {
+            price {
+              type
+              units
+              value
+            }
+            value
+          }
+        }
+      }
+      ... on ConfigurableCartItem {
+        configurable_options {
+          id
+          option_label
+          value_label
+        }
+      }
+      quantity
+      prices
+      {
+        price
+        {
+          value
+        }
+      }
+    }
+    applied_coupons {
+      code
+    }
+    prices
+    {
+      applied_taxes
+      {
+        label
+        amount
+        {
+          value
+        }
+      }
+      grand_total
+      {
+        value
+      }
+      subtotal_excluding_tax
+      {
+        value
+      }
+      discounts
+      {
+        label
+        amount
+        {
+          value
+        }
+      }
+    }
+    total_quantity
+  }
+}

--- a/resources/views/cart/queries/changeQty.graphql
+++ b/resources/views/cart/queries/changeQty.graphql
@@ -1,0 +1,22 @@
+mutation {
+  updateCartItems(
+    input: changes
+  )
+  {
+    cart {
+      items {
+        id
+        product {
+          name
+        }
+        quantity
+      }
+      prices {
+        grand_total{
+          value
+          currency
+        }
+      }
+    }
+  }
+}

--- a/resources/views/cart/queries/removeItemFromCart.graphql
+++ b/resources/views/cart/queries/removeItemFromCart.graphql
@@ -1,0 +1,22 @@
+mutation {
+  removeItemFromCart(
+    input: changes
+  )
+ {
+  cart {
+    items {
+      id
+      product {
+        name
+      }
+      quantity
+    }
+    prices {
+      grand_total{
+        value
+        currency
+      }
+    }
+  }
+ }
+}

--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -1,9 +1,9 @@
 <div v-if="cart" class="p-3 border rounded">
     <table class="mb-3">
         <tr class="py-3" v-for="item in cart.items">
-            <td>@{{ item.name }}</td>
-            <td class="text-right font-mono text-xs px-4">@{{ item.qty }}</td>
-            <td class="text-right font-mono text-xs">@{{ item.price | price }}</td>
+            <td>@{{ item.product.name }}</td>
+            <td class="text-right font-mono text-xs px-4">@{{ item.quantity }}</td>
+            <td class="text-right font-mono text-xs">@{{ item.prices.price.value | price }}</td>
         </tr>
         <tr class="py-3" v-for="total_segment in checkout.totals.total_segments" v-if="total_segment.value">
             <td>@{{ total_segment.title }}</td>

--- a/resources/views/layouts/partials/header/minicart.blade.php
+++ b/resources/views/layouts/partials/header/minicart.blade.php
@@ -3,7 +3,7 @@
         <div v-if="data && data.cart && data.cart.items && Object.keys(data.cart.items).length" v-on-click-away="close" slot-scope="{toggle, close, isOpen}">
             <button class="flex my-1 focus:outline-none" v-on:click="toggle">
                 <x-heroicon-o-shopping-cart class="h-6 w-6"/>
-                <span class="bg-primary rounded-full w-6 h-6 text-white text-center">@{{ Math.round(data.cart.total_quantity) }}</span>
+                <span class="bg-primary rounded-full w-6 h-6 text-white text-center" dusk="minicart-qty">@{{ Math.round(data.cart.total_quantity) }}</span>
             </button>
             <div v-if="isOpen" class="absolute right-0 bg-white border shadow rounded p-3 mr-1 z-10">
                 <table class="mb-3">

--- a/resources/views/layouts/partials/header/minicart.blade.php
+++ b/resources/views/layouts/partials/header/minicart.blade.php
@@ -1,20 +1,20 @@
-<cart v-cloak >
-    <toggler slot-scope="{ cart, hasItems }">
-        <div v-if="hasItems" v-on-click-away="close" slot-scope="{toggle, close, isOpen}">
+<minicart v-cloak v-if="mask" query='@include("rapidez::cart.queries.cart")' :variables='{cart_id: mask}' cache="cart" :after-resolved-data="processCartData">
+    <toggler slot-scope="{ data }">
+        <div v-if="data && data.cart && data.cart.items && Object.keys(data.cart.items).length" v-on-click-away="close" slot-scope="{toggle, close, isOpen}">
             <button class="flex my-1 focus:outline-none" v-on:click="toggle">
                 <x-heroicon-o-shopping-cart class="h-6 w-6"/>
-                <span class="bg-primary rounded-full w-6 h-6 text-white text-center">@{{ Math.round(cart.items_qty) }}</span>
+                <span class="bg-primary rounded-full w-6 h-6 text-white text-center">@{{ Math.round(data.cart.total_quantity) }}</span>
             </button>
             <div v-if="isOpen" class="absolute right-0 bg-white border shadow rounded p-3 mr-1 z-10">
                 <table class="mb-3">
-                    <tr class="py-3" v-for="item in cart.items">
-                        <td>@{{ item.name }}</td>
-                        <td class="text-right px-4">@{{ item.qty }}</td>
-                        <td class="text-right">@{{ item.price | price }}</td>
+                    <tr class="py-3" v-for="item in data.cart.items">
+                        <td>@{{ item.product.name }}</td>
+                        <td class="text-right px-4">@{{ item.quantity }}</td>
+                        <td class="text-right">@{{ item.prices.price.value | price }}</td>
                     </tr>
                     <tr class="py-3">
                         <td colspan="2">@lang('Total')</td>
-                        <td class="text-right">@{{ cart.total | price }}</td>
+                        <td class="text-right">@{{ cart.prices.grand_total.value | price }}</td>
                     </tr>
                 </table>
                 <div class="flex justify-between items-center">
@@ -31,4 +31,4 @@
             <x-heroicon-o-shopping-cart class="h-6 w-6"/>
         </a>
     </toggler>
-</cart>
+</minicart>

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,15 +17,6 @@ Route::middleware('api')->prefix('api')->group(function () {
         return $optionswatchModel::getCachedSwatchValues();
     });
 
-    Route::get('cart/{quoteIdMaskOrCustomerToken}', function ($quoteIdMaskOrCustomerToken) {
-        $quoteModel = config('rapidez.models.quote');
-
-        return $quoteModel::where(function ($query) use ($quoteIdMaskOrCustomerToken) {
-            $query->where('masked_id', $quoteIdMaskOrCustomerToken)
-                  ->orWhere('token', $quoteIdMaskOrCustomerToken);
-        })->firstOrFail();
-    });
-
     Route::prefix('admin')->middleware(VerifyAdminToken::class)->group(function () {
         Route::get('cache/clear', fn () => Artisan::call('cache:clear'));
         Route::get('index/products', function () {

--- a/tests/Browser/CartTest.php
+++ b/tests/Browser/CartTest.php
@@ -13,7 +13,7 @@ class CartTest extends DuskTestCase
             $browser->visit($this->testProduct->url)
                     ->waitUntilAllAjaxCallsAreFinished()
                     ->click('@add-to-cart')
-                    ->waitFor('@minicart-qty')
+                    ->waitFor('@minicart-qty', 10)
                     ->waitUntilAllAjaxCallsAreFinished()
                     ->visit('/cart')
                     ->waitFor('@cart-item-name')

--- a/tests/Browser/CartTest.php
+++ b/tests/Browser/CartTest.php
@@ -13,8 +13,10 @@ class CartTest extends DuskTestCase
             $browser->visit($this->testProduct->url)
                     ->waitUntilAllAjaxCallsAreFinished()
                     ->click('@add-to-cart')
+                    ->waitFor('@minicart-qty')
                     ->waitUntilAllAjaxCallsAreFinished()
                     ->visit('/cart')
+                    ->waitFor('@cart-item-name')
                     ->assertSee($this->testProduct->name);
         });
     }
@@ -37,7 +39,7 @@ class CartTest extends DuskTestCase
             $browser->visit('/cart')
                     ->waitUntilAllAjaxCallsAreFinished()
                     ->click('@item-delete-0')
-                    ->waitUntilAllAjaxCallsAreFinished()
+                    ->waitUntilMissing('@item-delete-0')
                     ->assertDontSee('@cart-item-name');
         });
     }

--- a/tests/Browser/CheckoutTest.php
+++ b/tests/Browser/CheckoutTest.php
@@ -13,7 +13,7 @@ class CheckoutTest extends DuskTestCase
             $browser->visit($this->testProduct->url)
                 ->waitUntilAllAjaxCallsAreFinished()
                 ->click('@add-to-cart')
-                ->waitFor('@minicart-qty')
+                ->waitFor('@minicart-qty', 10)
                 ->waitUntilAllAjaxCallsAreFinished()
                 ->visit('/checkout')
                 ->waitUntilAllAjaxCallsAreFinished()

--- a/tests/Browser/CheckoutTest.php
+++ b/tests/Browser/CheckoutTest.php
@@ -13,6 +13,7 @@ class CheckoutTest extends DuskTestCase
             $browser->visit($this->testProduct->url)
                 ->waitUntilAllAjaxCallsAreFinished()
                 ->click('@add-to-cart')
+                ->waitFor('@minicart-qty')
                 ->waitUntilAllAjaxCallsAreFinished()
                 ->visit('/checkout')
                 ->waitUntilAllAjaxCallsAreFinished()


### PR DESCRIPTION
This PR aims to get rid of the REST API for updating the cart, updating product qtys and removing products, and instead opt to use graphql for this.

In this case the minicart is the brains of the operation since it is loaded on any page that requires the cart information to be updated. 
It listens to an event fired to refresh the cart and then calls the graphql endpoint again to get updated information.