### PR TITLE
Add additional info for payment providers to use in the checkout

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -225,7 +225,12 @@
                     })
 
                     this.$root.cart = null
-                    this.$root.$emit('CheckoutPaymentSaved')
+                    this.$root.$emit('CheckoutPaymentSaved', {
+                        order: {
+                            id: response.data,
+                            payment_method_code: this.checkout.payment_method
+                        }
+                    })
                     return true
                 } catch (error) {
                     Notify(error.response.data.message, 'error')


### PR DESCRIPTION
This will allow payment providers to check if their payment provider has been used.
And it will then allow them to use the order id which is returned after converting the quote