### PR TITLE
Overwrite robots meta tag from pages

### DIFF
--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -2,6 +2,8 @@
 
 @section('title', 'Cart')
 
+@section('robots', 'NOINDEX,NOFOLLOW')
+
 @section('content')
     <h1 class="font-bold text-4xl mb-5">@lang('Cart')</h1>
 

--- a/resources/views/checkout/overview.blade.php
+++ b/resources/views/checkout/overview.blade.php
@@ -2,6 +2,8 @@
 
 @section('title', 'Checkout')
 
+@section('robots', 'NOINDEX,NOFOLLOW')
+
 @section('content')
     <div class="container mx-auto">
         <checkout v-cloak v-slot="{ checkout, cart, hasItems, save, goToStep }">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,7 +8,7 @@
 
     <title>@yield('title', '')</title>
     <meta name="description" content="@yield('description', '')"/>
-    <meta name="robots" content="@config('design/search_engine_robots/default_robots', 'INDEX,FOLLOW')"/>
+    <meta name="robots" content="@yield('robots', Rapidez::config('design/search_engine_robots/default_robots', 'INDEX,FOLLOW'))"/>
 
     @hasSection('canonical')
         <link rel="canonical" href="@yield('canonical')" />


### PR DESCRIPTION
This PR adds the ability to overwrite the `robots` meta tag and adds noindex,nofollow to the cart and checkout by default