### PR TITLE
Use KeyName of Model als identifier for joining tables in ForCurrentS…

### DIFF
--- a/src/Models/Scopes/ForCurrentStoreScope.php
+++ b/src/Models/Scopes/ForCurrentStoreScope.php
@@ -19,11 +19,11 @@ class ForCurrentStoreScope implements Scope
     {
         $currentTable = $builder->getQuery()->from;
         $joinTable = $this->joinTable ?: $currentTable.'_store';
-        $type = explode('_', $currentTable)[1];
+        $primaryKey = $model->getKeyName();
 
         $builder
-            ->leftJoin($joinTable, function ($join) use ($currentTable, $type, $joinTable) {
-                $join->on($currentTable.'.'.$type.'_id', '=', $joinTable.'.'.$type.'_id');
+            ->leftJoin($joinTable, function ($join) use ($currentTable, $primaryKey, $joinTable) {
+                $join->on($currentTable.'.'.$primaryKey, '=', $joinTable.'.'.$primaryKey);
             })
             ->whereIn('store_id', [0, config('rapidez.store')])
             ->orderByDesc('store_id')


### PR DESCRIPTION
…toreScope class

This is changed so we can make it compatible with for example https://github.com/rapidez/mirasvit-advanced-seo-suite/blob/master/src/Models/Redirect.php#L14

The current Models in Core Rapidez who use this class as a Global Scope all have a primaryKey attribute.