### PR TITLE
Add runQuery to slot scope

### DIFF
--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -35,6 +35,7 @@
         render() {
             return this.$scopedSlots.default({
                 data: this.data,
+                runQuery: this.runQuery
             })
         },
 


### PR DESCRIPTION
This is necessary, so that from a child nested mutation the parent query can be run in the callback