### PR TITLE
Fire scroll event after site is fully loaded

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -25,7 +25,11 @@
         },
         mounted() {
             this.slider.addEventListener('scroll', this.scroll)
-            this.slider.dispatchEvent(new CustomEvent('scroll'))
+            document.onreadystatechange = () => {
+                if (document.readyState == "complete") {
+                    this.slider.dispatchEvent(new CustomEvent('scroll'))
+                }
+            }
             this.mounted = true
         },
         beforeDestroy() {


### PR DESCRIPTION
When a hard refresh is done the scrollWidth and offsetWidth are equal.

This causes the slider to think there is 1 slide available.

This PR will make a scroll event when the page is fully loaded to make sure the width is correctly passed to the slider.