### PR TITLE
Add theme support in Rapidez

### DIFF
--- a/config/rapidez.php
+++ b/config/rapidez.php
@@ -51,6 +51,12 @@ return [
     // below will not be used anymore when disabled.
     'routes' => true,
 
+    // Link store codes to theme folders
+    // The structure is `'store_code' => 'folder_path'`
+    'themes' => [
+        'default' => resource_path('themes/default'),
+    ],
+
     // The fully qualified class names of the controllers.
     'controllers' => [
         'page'     => Rapidez\Core\Http\Controllers\PageController::class,

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -83,7 +83,7 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function bootThemes(): self
     {
-        $path = config('rapidez.themes.' . env('MAGE_RUN_CODE', 'default'), false);
+        $path = config('rapidez.themes.'.request()->server('MAGE_RUN_CODE', 'default'), false);
 
         if (!$path) {
             return $this;
@@ -92,7 +92,7 @@ class RapidezServiceProvider extends ServiceProvider
         config([
             'view.paths' => [
                 $path,
-                ...config('view.paths')
+                ...config('view.paths'),
             ]
         ]);
 

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -22,6 +22,7 @@ class RapidezServiceProvider extends ServiceProvider
             ->bootCommands()
             ->bootPublishables()
             ->bootRoutes()
+            ->bootThemes()
             ->bootViews()
             ->bootBladeComponents()
             ->bootMiddleware()
@@ -76,6 +77,24 @@ class RapidezServiceProvider extends ServiceProvider
             $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
             $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
         }
+
+        return $this;
+    }
+
+    protected function bootThemes(): self
+    {
+        $path = config('rapidez.themes.' . env('MAGE_RUN_CODE', 'default'), false);
+
+        if (!$path) {
+            return $this;
+        }
+
+        config([
+            'view.paths' => [
+                $path,
+                ...config('view.paths')
+            ]
+        ]);
 
         return $this;
     }

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -93,7 +93,7 @@ class RapidezServiceProvider extends ServiceProvider
             'view.paths' => [
                 $path,
                 ...config('view.paths'),
-            ]
+            ],
         ]);
 
         return $this;


### PR DESCRIPTION
This PR will add support for seperate themes in Rapidez defined per store_code

The reason this is not set in the config itself is because you loose the dynamic switching between themes once the config is cached causing every store to get the same theme.

Documentation PR: https://github.com/rapidez/docs/pull/20