### PR TITLE
Improve pagespeed generally, improve lighthouse on category page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "postcss-nested": "^5.0.6",
         "sass": "^1.49.9",
         "sass-loader": "^12.6.0",
+        "simple-web-worker": "^1.2.0",
         "tailwindcss": "^3.0.23",
         "turbolinks": "^5.2.0",
         "vue": "^2.6.14",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,7 @@ require('./filters')
 require('./mixins')
 require('./turbolinks')
 require('./reactivesearch')
+require('./webworker')
 
 Vue.component('cart', require('./components/Cart/Cart.vue').default)
 Vue.component('toggler', require('./components/Elements/Toggler.vue').default)
@@ -32,7 +33,7 @@ Vue.component('coupon', () => import(/* webpackChunkName: "cart" */ './component
 Vue.component('checkout', () => import(/* webpackChunkName: "checkout" */ './components/Checkout/Checkout.vue'))
 Vue.component('checkout-success', () => import(/* webpackChunkName: "checkout" */ './components/Checkout/CheckoutSuccess.vue'))
 
-document.addEventListener('turbolinks:load', () => {
+function init() {
     Vue.prototype.window = window
     Vue.prototype.config = window.config
 
@@ -119,4 +120,9 @@ document.addEventListener('turbolinks:load', () => {
             }
         }
     })
-})
+}
+
+// Run init immedately on first pageload
+init()
+// On subsequent navigation run it after turbolinks:load
+window.addEventListener('load', () => document.addEventListener('turbolinks:load', init), {once: true})

--- a/resources/js/components/Listing/Filters/CategoryFilter.vue
+++ b/resources/js/components/Listing/Filters/CategoryFilter.vue
@@ -13,6 +13,10 @@ export default {
         })
     },
 
+    data: () => ({
+        results: [],
+    }),
+
     created() {
         this.processValue(this.value)
     },
@@ -20,29 +24,17 @@ export default {
     watch: {
         value: function (value) {
             this.processValue(value)
+        },
+        hasResults: function (value) {
+            if (!value) {
+                return;
+            }
+
+            this.createCategoryPaths()
         }
     },
 
     methods: {
-        getCategoryPaths() {
-            const allCategoryPaths = this.aggregations.category_paths.buckets
-
-            if (!this.currentCategory?.entity_id) {
-                return allCategoryPaths
-            }
-
-            // Get children of current category.
-            let categoryPaths = allCategoryPaths.filter(bucket => bucket.key.includes(String(this.currentCategory.entity_id))&& bucket.key.at(-1) !== String(this.currentCategory.entity_id))
-
-            if (categoryPaths.length > 1) {
-                return categoryPaths
-            }
-
-            // No child categories, get siblings instead.
-            let parentCategoryId = categoryPaths[0].key.at(-2)
-            return allCategoryPaths.filter(bucket => bucket.key.includes(parentCategoryId) && bucket.key.at(-1) !== parentCategoryId)
-        },
-
         processValue(value) {
             if (!value) {
                 this.setQuery({})
@@ -55,64 +47,106 @@ export default {
             })
         },
 
-        buildCategoryStructure(categories, results = {children: {}}) {
-            for (const category of categories) {
-                if (!category.structure.length) {
-                    continue
-                }
-
-                let key = category.structure.shift()
-                let [id, label] = key.split('::')
-
-                if(!results.children) {
-                    results.children = {}
-                }
-
-                if (!results?.children?.hasOwnProperty(id)) {
-                    results.children[id] = {
-                        id: id,
-                        key: key,
-                        label: label,
-                        structure: category.structure,
-                        doc_count: category.doc_count,
-                        children: {},
-                    }
-                }
-
-                results.children[id] = this.buildCategoryStructure([category], results.children[id])
+        createCategoryPaths() {
+            if (
+                !this.aggregations?.category_paths?.buckets?.length ||
+                !this.aggregations?.categories?.buckets?.length
+            ) {
+                this.results = []
+                return;
             }
 
-            return results
+            // Calculating and unpacking the category structure is a heavy task.
+            // Hand this down to a webworker thread to free the main thread.
+            WebWorker.run(
+                function (categories, allCategoryPaths, currentCategory) {
+                    function getCategoryStructure(categories, allCategoryPaths, currentCategory) {
+                        const lowestCategories = categories.map((bucket => {
+                            const key = bucket.key.split(' /// ').pop()
+                            let idAndLabel = key.split('::')
+                            // Usually you'd use the Destructuring Assignment, in this case we dont want to.
+                            // Since this will let the webpack polyfill kick in which is not available in the web worker.
+                            let id = idAndLabel[0],
+                                label = idAndLabel[1];
+
+                            return {
+                                id: id,
+                                key: bucket.key,
+                                structure: bucket.key.split(' /// '),
+                                label: label,
+                                doc_count: bucket.doc_count,
+                            }
+                        })).filter(bucket => getCategoryPaths(allCategoryPaths, currentCategory).find(path => path.key.includes(bucket.id)))
+
+                        return buildCategoryStructure(lowestCategories).children;
+                    }
+
+                    function getCategoryPaths(allCategoryPaths, currentCategory) {
+                        if (!currentCategory?.entity_id) {
+                            return allCategoryPaths
+                        }
+
+                        // Get children of current category.
+                        let categoryPaths = allCategoryPaths.filter(bucket => bucket.key.includes(String(currentCategory.entity_id))&& bucket.key.at(-1) !== String(currentCategory.entity_id))
+
+                        if (categoryPaths.length > 1) {
+                            return categoryPaths
+                        }
+
+                        // No child categories, get siblings instead.
+                        let parentCategoryId = categoryPaths[0].key.at(-2)
+                        return allCategoryPaths.filter(bucket => bucket.key.includes(parentCategoryId) && bucket.key.at(-1) !== parentCategoryId)
+                    }
+
+                    function buildCategoryStructure(categories, results = {children: {}}) {
+                        categories.map(category => {
+                            if (!category.structure.length) {
+                                return
+                            }
+
+                            let key = category.structure.shift()
+                            let idAndLabel = key.split('::')
+                            let id = idAndLabel[0],
+                                label = idAndLabel[1];
+
+                            if(!results.children) {
+                                results.children = {}
+                            }
+
+                            if (!results?.children?.hasOwnProperty(id)) {
+                                results.children[id] = {
+                                    id: id,
+                                    key: key,
+                                    label: label,
+                                    structure: category.structure,
+                                    doc_count: category.doc_count,
+                                    children: {},
+                                }
+                            }
+
+                            results.children[id] = buildCategoryStructure([category], results.children[id])
+                        });
+
+                        return results
+                    }
+
+                    return getCategoryStructure(categories, allCategoryPaths, currentCategory);
+                },
+                [
+                    this.aggregations.categories.buckets,
+                    this.aggregations.category_paths.buckets,
+                    this.currentCategory
+                ]
+            )
+            .then(categoryStructure => {
+                this.results = categoryStructure
+            });
         }
     },
 
     computed: {
         hasResults: function () {
             return this.aggregations?.categories?.buckets?.length
-        },
-
-        results: function () {
-            if (
-                !this.aggregations?.category_paths?.buckets?.length ||
-                !this.aggregations?.categories?.buckets?.length
-            ) {
-                return []
-            }
-
-            const lowestCategories = this.aggregations.categories.buckets.map((bucket => {
-                const key = bucket.key.split(' /// ').pop()
-                const [id, label] = key.split('::')
-
-                return {
-                    id: id,
-                    key: bucket.key,
-                    structure: bucket.key.split(' /// '),
-                    label: label,
-                    doc_count: bucket.doc_count,
-                }
-            })).filter(bucket => this.getCategoryPaths().find(path => path.key.includes(bucket.id)))
-
-            return this.buildCategoryStructure(lowestCategories).children
         },
 
         currentCategory: function () {

--- a/resources/js/webworker.js
+++ b/resources/js/webworker.js
@@ -1,0 +1,3 @@
+import WebWorker from 'simple-web-worker'
+
+window.WebWorker = WebWorker

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -1,34 +1,40 @@
 @props(['query'])
 
-<listing :additional-filters="{!! isset($query) ? "['query-filter', 'category']" : "['category']" !!}" v-cloak>
-    <div slot-scope="{ loaded, filters, sortOptions, reactiveFilters }">
-        <reactive-base
-            :app="config.es_prefix + '_products_' + config.store"
-            :url="config.es_url"
-            v-if="loaded"
-        >
-            @isset($query)
-                <reactive-component component-id="query-filter" :show-filter="false">
-                    <div slot-scope="{ setQuery }">
-                        <query-filter :set-query="setQuery" :query="{{ $query }}"></query-filter>
-                    </div>
-                </reactive-component>
-            @endisset
+@pushOnce('head', 'es_url-preconnect')
+    <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
+@endPushOnce
 
-            {{ $before ?? '' }}
-            @if ($slot->isEmpty())
-                <div class="flex flex-col md:flex-row">
-                    <div class="md:w-1/5">
-                        @include('rapidez::listing.filters')
+<div class="min-h-screen">
+    <listing :additional-filters="{!! isset($query) ? "['query-filter', 'category']" : "['category']" !!}" v-cloak>
+        <div slot-scope="{ loaded, filters, sortOptions, reactiveFilters }">
+            <reactive-base
+                :app="config.es_prefix + '_products_' + config.store"
+                :url="config.es_url"
+                v-if="loaded"
+            >
+                @isset($query)
+                    <reactive-component component-id="query-filter" :show-filter="false">
+                        <div slot-scope="{ setQuery }">
+                            <query-filter :set-query="setQuery" :query="{{ $query }}"></query-filter>
+                        </div>
+                    </reactive-component>
+                @endisset
+
+                {{ $before ?? '' }}
+                @if ($slot->isEmpty())
+                    <div class="flex flex-col md:flex-row">
+                        <div class="md:w-1/5">
+                            @include('rapidez::listing.filters')
+                        </div>
+                        <div class="md:w-4/5">
+                            @include('rapidez::listing.products')
+                        </div>
                     </div>
-                    <div class="md:w-4/5">
-                        @include('rapidez::listing.products')
-                    </div>
-                </div>
-            @else
-                 {{ $slot }}
-            @endif
-            {{ $after ?? '' }}
-        </reactive-base>
-    </div>
-</listing>
+                @else
+                     {{ $slot }}
+                @endif
+                {{ $after ?? '' }}
+            </reactive-base>
+        </div>
+    </listing>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,6 +14,7 @@
         <link rel="canonical" href="@yield('canonical')" />
     @endif
 
+    <link href="{{ url(mix('css/app.css')) }}" rel="preload" as="style">
     <link href="{{ url(mix('css/app.css')) }}" rel="stylesheet" data-turbolinks-track="reload">
     <script src="{{ url(mix('js/manifest.js')) }}" defer data-turbolinks-track="reload"></script>
     <script src="{{ url(mix('js/vendor.js')) }}" defer data-turbolinks-track="reload"></script>

--- a/resources/views/listing/filters.blade.php
+++ b/resources/views/listing/filters.blade.php
@@ -8,17 +8,20 @@
     <x-slot name="title">
         @lang('Filters')
     </x-slot>
+    {{-- On mobile the filters aren't immedately visible so we should defer loading --}}
+    <lazy>
+        <template>
+            @include('rapidez::listing.partials.filter.selected')
+            @include('rapidez::listing.partials.filter.category')
 
-    @include('rapidez::listing.partials.filter.selected')
-    @include('rapidez::listing.partials.filter.category')
-
-    <template v-for="filter in filters">
-        @include('rapidez::listing.partials.filter.price')
-        @include('rapidez::listing.partials.filter.swatch')
-        @include('rapidez::listing.partials.filter.boolean')
-        @include('rapidez::listing.partials.filter.select')
-    </template>
-
+            <template v-for="filter in filters">
+                @include('rapidez::listing.partials.filter.price')
+                @include('rapidez::listing.partials.filter.swatch')
+                @include('rapidez::listing.partials.filter.boolean')
+                @include('rapidez::listing.partials.filter.select')
+            </template>
+        </template>
+    </lazy>
     <x-rapidez::button class="md:hidden w-full text-sm" v-on:click="toggle">
         @lang('Show results')
     </x-rapidez::button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5875,6 +5875,11 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-web-worker@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/simple-web-worker/-/simple-web-worker-1.2.0.tgz#2deffd0998976b824b141a27ce504d31d0d99108"
+  integrity sha1-Le/9CZiXa4JLFBonzlBNMdDZkQg=
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"


### PR DESCRIPTION
What has changed to improve performance?
 - Vue initialisation no longer has to wait for turbolinks to be loaded and finished on the initial request
 - Heavy tasks in the category filter have been moved to a webworker saving ~140ms on the main thread
 - On the category page we preconnect with elasticsearch reducing tcp handshake overhead when making the actual requests (since they're running in paralel this handshake used to happen multiple times since there was no existing connection to use)
 - Preload the stylesheet as it's a critical dependency, this enables early hints to serve it early
 - lazily load the filter components since they are not shown on mobile until you click the filter button