### PR TITLE
Add a callback before the requests gets sent to be able to change variable and options

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -35,6 +35,9 @@
             callback: {
                 type: Function,
             },
+            beforeRequest: {
+                type: Function,
+            },
             mutateEvent: {
                 type: String,
                 required: false
@@ -95,9 +98,16 @@
                         options['headers']['X-ReCaptcha'] = await this.getReCaptchaToken()
                     }
 
+                    let variables = this.data,
+                        query = this.query;
+
+                    if (this.beforeRequest) {
+                        [query, variables, options] = await this.beforeRequest(this.query, this.variables, options);
+                    }
+
                     let response = await axios.post(config.magento_url + '/graphql', {
-                        query: this.query,
-                        variables: this.data,
+                        query: query,
+                        variables: variables,
                     }, options)
 
                     if (response.data.errors) {


### PR DESCRIPTION
This can by used with 
```javascript
<graphqlmutation
...
    :before-request="beforeRequestFunction"
...
```
Where the `beforeRequestFunction` must at least contain
```javascript
function (query, variables, options) {

    return [query, variables, options];
}
```

the `query` and `variables` are still observables so it is the functions responsibility to turn these to regular objects if they don't want it to change the original value.