### PR TITLE
Add Store header to GraphQL queries and mutations

### DIFF
--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -58,7 +58,16 @@
 
             async runQuery() {
                 try {
-                    let options = this.$root.user ? { headers: { Authorization: `Bearer ${localStorage.token}` }} : null
+                    let options = { headers: {} }
+
+                    if (this.$root.user) {
+                        options['headers']['Authorization'] = `Bearer ${localStorage.token}`
+                    }
+
+                    if (window.config.store_code) {
+                        options['headers']['Store'] = window.config.store_code
+                    }
+
                     let response = await axios.post(config.magento_url + '/graphql', {
                         query: this.query,
                         variables: this.variables,

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -98,6 +98,10 @@
                         options['headers']['X-ReCaptcha'] = await this.getReCaptchaToken()
                     }
 
+                    if (window.config.store_code) {
+                        options['headers']['Store'] = window.config.store_code
+                    }
+
                     let variables = this.data,
                         query = this.query;
 


### PR DESCRIPTION
This adds the `Store` header to the GraphQL queries and mutations so that the correct store is used for the requests. 

See: https://devdocs.magento.com/guides/v2.4/graphql/send-request.html#:~:text=The%20store%20view%20code%20on%20which%20to%20perform%20the%20request.%20The%20value%20can%20be%20default%20or%20the%20code%20that%20is%20defined%20when%20a%20store%20view%20is%20created.

Make sure the `Store` header is added to `CONFIG__DEFAULT__WEB__GRAPHQL__CORS_ALLOWED_HEADERS` in your Magento installation.

