### PR TITLE
Remove error parameters from successful response

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -97,7 +97,7 @@
                         qty: this.qty,
                     })
                     if (this.notifySuccess) {
-                        Notify(this.product.name + ' ' + window.config.translations.cart.add, 'success', error.response.data?.parameters)
+                        Notify(this.product.name + ' ' + window.config.translations.cart.add, 'success')
                     }
                     if (config.redirect_cart) {
                         Turbolinks.visit('/cart')


### PR DESCRIPTION
Currently the loader on the category pages for add to cart does not disappear since it throws an error that error is not defined