### PR TITLE
Import vue-slider-component

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -7,12 +7,14 @@
         MultiList,
         DynamicRangeSlider
     } from '@appbaseio/reactivesearch-vue'
+    import VueSlider from 'vue-slider-component'
 
     Vue.use(ReactiveBase)
     Vue.use(ReactiveList)
     Vue.use(ReactiveComponent)
     Vue.use(SelectedFilters)
     Vue.use(MultiList)
+    Vue.component('vue-slider-component', VueSlider)
     Vue.use(DynamicRangeSlider)
 
     export default {

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig({
         alias: {
             '@': '/resources/js',
             'Vendor': '/vendor',
-            'vue': 'node_modules/vue/dist/vue.esm.js',
+            'vue': 'vue/dist/vue.esm.js',
         }
     }
 });


### PR DESCRIPTION
It is now possible to import the slider component because of https://vitejs.dev/guide/dep-pre-bundling.html
So CommonJS and UMD packages work as well.

The rangeslider now throws warnings when you use it but it does function properly.
I've narrowed it down to it being an issue in Reactivesearch and not the range slider. As the rangeslider functions as expected when used on it's own

Update: 
the warnings were caused by vue being loaded twice, which was due to https://github.com/rapidez/core/pull/157/files#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L25
This has now been fixed!