### PR TITLE
Fix Key must be object

### DIFF
--- a/src/Commands/InteractsWithElasticsearchCommand.php
+++ b/src/Commands/InteractsWithElasticsearchCommand.php
@@ -20,10 +20,10 @@ abstract class InteractsWithElasticsearchCommand extends Command
     {
         $this->elasticsearch->indices()->create([
             'index' => $index,
-            'body'  => [
+            'body'  => array_filter([
                 'mappings' => $mapping,
                 'settings' => $settings,
-            ],
+            ]),
         ]);
     }
 


### PR DESCRIPTION
Fix key must be object if mappings or settings are empty