### PR TITLE
Log notifications to debug if debug mode is on

### DIFF
--- a/phpunit.dusk.xml.dist
+++ b/phpunit.dusk.xml.dist
@@ -25,6 +25,7 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
         <env name="APP_DEBUG" value="true"/>
+        <env name="VITE_DEBUG" value="true"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3307"/>
         <env name="DB_DATABASE" value="magento"/>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -139,6 +139,10 @@ function init() {
             }
         }
     })
+
+    if(window.debug) {
+        window.app.$on('notification-message', console.debug);
+    }
 }
 
 document.addEventListener('turbolinks:load', init)


### PR DESCRIPTION
This helps debug potential problems during development or during tests, as notifications automatically disappear after a few seconds