### PR TITLE
Load Vue as ES Module

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -21,7 +21,13 @@ export default defineConfig({
         alias: {
             '@': path.resolve(__dirname, './resources/js'),
             'Vendor': path.resolve(__dirname, './vendor'),
-            'vue': path.resolve(__dirname, './node_modules/vue/dist/vue.js')
+            'vue': path.resolve(__dirname, './node_modules/vue/dist/vue.esm.js')
         }
-    }
+    },
+    build: {
+        commonjsOptions: {
+            // Since vue-slider-component is not esm and receives vue esm this is required.
+            requireReturnsDefault: 'preferred',
+        },
+    },
 });


### PR DESCRIPTION
This helps with compiling Vue smaller as now NODE_ENV get correctly figured out within vue.esm.js
vue.js has development hardcoded, and vue.min.js has production hardcoded.