### PR TITLE
Prevent full page reload when navigating from listing

### DIFF
--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -118,9 +118,9 @@ class RapidezServiceProvider extends ServiceProvider
 
         View::addExtension('graphql', 'blade');
 
-        Vite::useScriptTagAttributes([
-            'data-turbo-track' => 'reload',
-            'defer'            => true,
+        Vite::useScriptTagAttributes(fn (string $src, string $url, array|null $chunk, array|null $manifest) => [
+            'data-turbo-track' => str_contains($url, 'app') ? 'reload' : false,
+            'defer' => true,
         ]);
 
         Vite::useStyleTagAttributes([

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -120,7 +120,7 @@ class RapidezServiceProvider extends ServiceProvider
 
         Vite::useScriptTagAttributes(fn (string $src, string $url, array|null $chunk, array|null $manifest) => [
             'data-turbo-track' => str_contains($url, 'app') ? 'reload' : false,
-            'defer' => true,
+            'defer'            => true,
         ]);
 
         Vite::useStyleTagAttributes([


### PR DESCRIPTION
This prevents a full page reload when navigating from listing to any other page. The reason this happens at the moment is that we set the data-turbo-track="reload" for all vite tags. This checks only sets it for the main app.js.