### PR TITLE
Add ability to remove fallback route by action

### DIFF
--- a/src/Facades/Rapidez.php
+++ b/src/Facades/Rapidez.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static self addFallbackRoute($action, $position = 9999)
+ * @method static self removeFallbackRoute($action)
  * @method static Collection getAllFallbackRoutes()
  * @method static ?string config(string $path, $default = null, bool $sensitive = false)
  * @method static ?string content($content)

--- a/src/Rapidez.php
+++ b/src/Rapidez.php
@@ -21,6 +21,14 @@ class Rapidez
         return $this;
     }
 
+    public function removeFallbackRoute($action)
+    {
+        $action = RouteAction::parse('', $action);
+        $this->routes = $this->routes->reject(fn ($route) => $route['action'] === $action);
+
+        return $this;
+    }
+
     public function getAllFallbackRoutes()
     {
         return $this->routes->sortBy('position');


### PR DESCRIPTION
This does have the limitation of not being able to remove closures (`addFallbackRoute(fn() => 'test')`) unless you have access to the exact closure.
All other methods like invokable functions, a specific function on a class etc. get removed correctly.