### PR TITLE
Mobile site update

### DIFF
--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -26,7 +26,12 @@
         @if(Route::currentRouteName() !== 'checkout')
             <nav class="w-full">
                 {{-- Because the lack of an @includeIf or @includeWhen equivalent for Blade components we're using a placeholder --}}
-                <x-dynamic-component :component="App::providerIsLoaded('Rapidez\Menu\MenuServiceProvider') ? 'menu' : 'placeholder'" />
+                <div class="hidden md:block">
+                    <x-dynamic-component :component="App::providerIsLoaded('Rapidez\Menu\MenuServiceProvider') ? 'menu' : 'placeholder'" />
+                </div>
+                <div class="md:hidden">
+                    <x-dynamic-component :component="App::providerIsLoaded('Rapidez\Menu\MenuServiceProvider') ? 'menu-mobile' : 'placeholder'" />
+                </div>
             </nav>
         @endif
     </div>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -6,7 +6,9 @@
                     <span class="hidden sm:inline">
                         <img src="https://raw.githubusercontent.com/rapidez/art/master/logo.svg" height="48" width="152" alt="">
                     </span>
-                    <span class="inline sm:hidden">🚀</span>
+                    <span class="inline sm:hidden">
+                        <img src="https://raw.githubusercontent.com/rapidez/art/master/r.svg" height="48" width="48" alt="">
+                    </span>
                 </a>
             </div>
         </div>

--- a/resources/views/page/overview.blade.php
+++ b/resources/views/page/overview.blade.php
@@ -9,7 +9,9 @@
             <h1 class="font-bold text-4xl mb-5">{{ $page->content_heading }}</h1>
         @endif
         @includeIf('pages.'.$page->identifier)
-        @widget('content', 'pages', ($page->identifier == 'home' ? 'cms' : $page->identifier).'_index_index')
+        <div class="hidden lg:block">
+            @widget('content', 'pages', ($page->identifier == 'home' ? 'cms' : $page->identifier).'_index_index')
+        </div>
         @if($page->content)
             <div class="mb-5 prose prose-green">
                 @content($page->content)


### PR DESCRIPTION
- Changed mobile logo to be the smaller `R` logo
- Removed the content block widget things on mobile because they got way too messy
- Added the mobile version of the category menu (see also [this PR in the menu repo](https://github.com/rapidez/menu/pull/3))