### PR TITLE
Add fallback for having a trailing slash as suffix

### DIFF
--- a/src/Http/Controllers/Fallback/UrlRewriteController.php
+++ b/src/Http/Controllers/Fallback/UrlRewriteController.php
@@ -9,7 +9,9 @@ class UrlRewriteController
     public function __invoke(Request $request)
     {
         $rewriteModel = config('rapidez.models.rewrite');
-        if (!$rewrite = $rewriteModel::firstWhere('request_path', $request->path())) {
+        if (!$rewrite = $rewriteModel::where('request_path', $request->path())
+            ->orWhere('request_path', $request->path().'/')
+            ->first()) {
             return;
         }
 


### PR DESCRIPTION
Currently the Product Overview / Detail page doesn't work when Magento is configured to use a "/" as suffix for category / product pages. This is saved to the `url_rewrite` entries (request_path). When fetching a `url_rewrite` we use the `path` function which trims the slash from the beginning and end. This results in a 404.

This change will fix the 404 by using `/` as fallback. But it also creates 2 entry points in the proces for both category and product pages (if configured with using `/` as suffix. This should not be a problem because in Rapidez we have a canonical tag that stays the same.