### PR TITLE
Catch Exceptions resembling 404

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -2,6 +2,9 @@
 
 namespace Rapidez\Core\Http\Controllers;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\RecordsNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Facades\App;
 use Rapidez\Core\Facades\Rapidez;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -21,7 +24,7 @@ class FallbackController
                 }
 
                 return $response;
-            } catch (RouteNotFoundException|NotFoundHttpException $e) {
+            } catch (RouteNotFoundException|NotFoundHttpException|BackedEnumCaseNotFoundException|ModelNotFoundException|RecordsNotFoundException $e) {
             }
         }
 


### PR DESCRIPTION
See:
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Exceptions/Handler.php#L407-L408
https://github.com/laravel/framework/blob/10.x/src/Illuminate/Foundation/Exceptions/Handler.php#L415
These are exceptions that get translated to 404 not found exceptions once they get to the handler.

If we run into them while going over the Fallback Routes we should go to the next Fallback Route instead of letting it bubble up and showing a 404 page.