### PR TITLE
Execute fallback on not found exception

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -6,5 +6,4 @@ Route::middleware('web')->group(function () {
     Route::view('cart', 'rapidez::cart.overview')->name('cart');
     Route::view('checkout', 'rapidez::checkout.overview')->name('checkout');
     Route::view('search', 'rapidez::search.overview')->name('search');
-    Route::fallback(FallbackController::class);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,5 @@
 <?php
 
-use Rapidez\Core\Http\Controllers\FallbackController;
-
 Route::middleware('web')->group(function () {
     Route::view('cart', 'rapidez::cart.overview')->name('cart');
     Route::view('checkout', 'rapidez::checkout.overview')->name('checkout');

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -104,7 +104,8 @@ class RapidezServiceProvider extends ServiceProvider
                     }
 
                     return response($response);
-                } catch (NotFoundHttpException $e) {}
+                } catch (NotFoundHttpException $e) {
+                }
             })
         );
 


### PR DESCRIPTION
As an improvement this handles routes that have been matched but threw a 404 for one reason or another and still allows us to handle that route with a fallback.
So it's a fallback for ANY route instead of just a fallback for routes that aren't defined.

Marking this as draft as a discussion point, and since it's impact hasn't been tested with error-handling libraries like Sentry