### PR TITLE
Define carrier code and methode code and use them when setting the sh…

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -49,8 +49,6 @@
                     this.checkout.shipping_methods = response.data
 
                     if (response.data.length === 1) {
-                        this.checkout.shipping_carrier_code = response.data[0].carrier_code
-                        this.checkout.shipping_method_code = response.data[0].method_code
                         this.checkout.shipping_method = response.data[0].carrier_code+'_'+response.data[0].method_code
                     }
 
@@ -135,8 +133,9 @@
                     }
 
                     if (!this.hasOnlyVirtualItems) {
-                        addressInformation.shipping_carrier_code = this.checkout.shipping_carrier_code
-                        addressInformation.shipping_method_code = this.checkout.shipping_method_code
+                        let currentShippingMethod = this.currentShipmentMethod();
+                        addressInformation.shipping_carrier_code = currentShippingMethod.carrier_code
+                        addressInformation.shipping_method_code = currentShippingMethod.method_code
                     }
 
                     if (this.checkout.create_account && this.checkout.password) {
@@ -200,12 +199,13 @@
             },
 
             async selectShippingMethod() {
+                let currentShippingMethod = this.currentShipmentMethod();
                 let response = await this.magentoCart('post', 'shipping-information', {
                     addressInformation: {
                         shipping_address: this.shippingAddress,
                         billing_address: this.billingAddress,
-                        shipping_carrier_code: this.checkout.shipping_carrier_code,
-                        shipping_method_code: this.checkout.shipping_method_code,
+                        shipping_carrier_code: currentShippingMethod.carrier_code,
+                        shipping_method_code: currentShippingMethod.method_code
                     }
                 })
                 this.checkout.totals = response.data.totals
@@ -291,6 +291,10 @@
                 }, false)
 
                 history.replaceState(null, null, '#'+ this.steps[this.checkout.step])
+            },
+
+            currentShipmentMethod() {
+                return this.checkout.shipping_methods.find(obj => obj.carrier_code+'_'+ obj.method_code === this.checkout.shipping_method)
             }
         },
 

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -133,9 +133,8 @@
                     }
 
                     if (!this.hasOnlyVirtualItems) {
-                        let currentShippingMethod = this.currentShipmentMethod();
-                        addressInformation.shipping_carrier_code = currentShippingMethod.carrier_code
-                        addressInformation.shipping_method_code = currentShippingMethod.method_code
+                        addressInformation.shipping_carrier_code = this.currentShipmentMethod.carrier_code
+                        addressInformation.shipping_method_code = this.currentShipmentMethod.method_code
                     }
 
                     if (this.checkout.create_account && this.checkout.password) {
@@ -199,13 +198,12 @@
             },
 
             async selectShippingMethod() {
-                let currentShippingMethod = this.currentShipmentMethod();
                 let response = await this.magentoCart('post', 'shipping-information', {
                     addressInformation: {
                         shipping_address: this.shippingAddress,
                         billing_address: this.billingAddress,
-                        shipping_carrier_code: currentShippingMethod.carrier_code,
-                        shipping_method_code: currentShippingMethod.method_code
+                        shipping_carrier_code: this.currentShipmentMethod.carrier_code,
+                        shipping_method_code: this.currentShipmentMethod.method_code
                     }
                 })
                 this.checkout.totals = response.data.totals
@@ -291,10 +289,6 @@
                 }, false)
 
                 history.replaceState(null, null, '#'+ this.steps[this.checkout.step])
-            },
-
-            currentShipmentMethod() {
-                return this.checkout.shipping_methods.find(obj => obj.carrier_code+'_'+ obj.method_code === this.checkout.shipping_method)
             }
         },
 
@@ -317,6 +311,9 @@
                 }
 
                 return this.removeUnusedAddressInfo(this.$root.checkout.billing_address)
+            },
+            currentShipmentMethod: function () {
+                return this.checkout.shipping_methods.find(obj => obj.carrier_code+'_'+ obj.method_code === this.checkout.shipping_method)
             }
         },
         watch: {

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -313,7 +313,9 @@
                 return this.removeUnusedAddressInfo(this.$root.checkout.billing_address)
             },
             currentShipmentMethod: function () {
-                return this.checkout.shipping_methods.find(obj => obj.carrier_code+'_'+ obj.method_code === this.checkout.shipping_method)
+                return this.checkout.shipping_methods.find((method) => {
+                    return method.carrier_code + '_' + method.method_code === this.checkout.shipping_method
+                })
             }
         },
         watch: {

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -49,6 +49,8 @@
                     this.checkout.shipping_methods = response.data
 
                     if (response.data.length === 1) {
+                        this.checkout.shipping_carrier_code = response.data[0].carrier_code
+                        this.checkout.shipping_method_code = response.data[0].method_code
                         this.checkout.shipping_method = response.data[0].carrier_code+'_'+response.data[0].method_code
                     }
 
@@ -133,8 +135,8 @@
                     }
 
                     if (!this.hasOnlyVirtualItems) {
-                        addressInformation.shipping_carrier_code = this.checkout.shipping_method.split('_')[0]
-                        addressInformation.shipping_method_code = this.checkout.shipping_method.split('_')[1]
+                        addressInformation.shipping_carrier_code = this.checkout.shipping_carrier_code
+                        addressInformation.shipping_method_code = this.checkout.shipping_method_code
                     }
 
                     if (this.checkout.create_account && this.checkout.password) {
@@ -202,8 +204,8 @@
                     addressInformation: {
                         shipping_address: this.shippingAddress,
                         billing_address: this.billingAddress,
-                        shipping_carrier_code: this.checkout.shipping_method.split('_')[0],
-                        shipping_method_code: this.checkout.shipping_method.split('_')[1],
+                        shipping_carrier_code: this.checkout.shipping_carrier_code,
+                        shipping_method_code: this.checkout.shipping_method_code,
                     }
                 })
                 this.checkout.totals = response.data.totals

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -133,8 +133,8 @@
                     }
 
                     if (!this.hasOnlyVirtualItems) {
-                        addressInformation.shipping_carrier_code = this.currentShipmentMethod.carrier_code
-                        addressInformation.shipping_method_code = this.currentShipmentMethod.method_code
+                        addressInformation.shipping_carrier_code = this.currentShippingMethod.carrier_code
+                        addressInformation.shipping_method_code = this.currentShippingMethod.method_code
                     }
 
                     if (this.checkout.create_account && this.checkout.password) {
@@ -202,8 +202,8 @@
                     addressInformation: {
                         shipping_address: this.shippingAddress,
                         billing_address: this.billingAddress,
-                        shipping_carrier_code: this.currentShipmentMethod.carrier_code,
-                        shipping_method_code: this.currentShipmentMethod.method_code
+                        shipping_carrier_code: this.currentShippingMethod.carrier_code,
+                        shipping_method_code: this.currentShippingMethod.method_code
                     }
                 })
                 this.checkout.totals = response.data.totals
@@ -312,7 +312,7 @@
 
                 return this.removeUnusedAddressInfo(this.$root.checkout.billing_address)
             },
-            currentShipmentMethod: function () {
+            currentShippingMethod: function () {
                 return this.checkout.shipping_methods.find((method) => {
                     return method.carrier_code + '_' + method.method_code === this.checkout.shipping_method
                 })


### PR DESCRIPTION
…ipment_method

This prevents problems with resolving  `shipping_carrier_code` and `shipping_method_code` when a carrier / methode code contains extra `_` characters. Example shipment method with carrier_code`tig_postnl` and method_code `regular`.