### PR TITLE
update history with state so Turbo behaves

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -122,8 +122,7 @@ function init() {
                 }
             },
             setSearchParams(url) {
-                window.history.pushState({ path: url }, '', url)
-                window.Turbo.navigator.history.push(url)
+                window.history.pushState(window.history.state, '', new URL(url))
             }
         },
         asyncComputed: {


### PR DESCRIPTION
By adding the state it's not needed to update Turbo navigator as well and the back button behaves correctly after pagination as well.