### PR TITLE
Add Eventy hooks for before/after rapidez indexer

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -21,6 +21,8 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
 
     public function handle()
     {
+        Eventy::action('rapidez.index.before', $this);
+        
         $this->call('cache:clear');
         $productModel = config('rapidez.models.product');
         $storeModel = config('rapidez.models.store');
@@ -86,6 +88,8 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
             $bar->finish();
             $this->line('');
         }
+        
+        Eventy::action('rapidez.index.after', $this);
         $this->info('Done!');
     }
 

--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -21,7 +21,7 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
 
     public function handle()
     {
-        Eventy::action('rapidez.index.before', $this);
+        Eventy::action('index.before', $this);
         
         $this->call('cache:clear');
         $productModel = config('rapidez.models.product');
@@ -89,7 +89,7 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
             $this->line('');
         }
         
-        Eventy::action('rapidez.index.after', $this);
+        Eventy::action('index.after', $this);
         $this->info('Done!');
     }
 


### PR DESCRIPTION
Simple solution to being able to quickly hook in multiple actions around the indexer

Can be used like this (e.g. in `App\Providers\AppServiceProvider:boot`):

```php
Eventy::addAction('index.before', function($context) {
    $context->call('rapidez:index:sortings');
});
Eventy::addAction('index.after', function($context) {
    $context->call('rapidez:index:additionals');
});
```