### PR TITLE
Use Laravel events for indexer before/after

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -6,6 +6,8 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Rapidez\Core\Events\IndexAfterEvent;
+use Rapidez\Core\Events\IndexBeforeEvent;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Jobs\IndexProductJob;
 use Rapidez\Core\Models\Category;
@@ -21,7 +23,7 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
 
     public function handle()
     {
-        Eventy::action('index.before', $this);
+        IndexBeforeEvent::dispatch($this);
 
         $this->call('cache:clear');
         $productModel = config('rapidez.models.product');
@@ -89,7 +91,7 @@ class IndexProductsCommand extends InteractsWithElasticsearchCommand
             $this->line('');
         }
 
-        Eventy::action('index.after', $this);
+        IndexAfterEvent::dispatch($this);
         $this->info('Done!');
     }
 

--- a/src/Events/IndexAfterEvent.php
+++ b/src/Events/IndexAfterEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\Core\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class IndexAfterEvent
+{
+    use Dispatchable;
+
+    public $context;
+
+    public function __construct($context)
+    {
+        $this->context = $context;
+    }
+}

--- a/src/Events/IndexBeforeEvent.php
+++ b/src/Events/IndexBeforeEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\Core\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class IndexBeforeEvent
+{
+    use Dispatchable;
+
+    public $context;
+
+    public function __construct($context)
+    {
+        $this->context = $context;
+    }
+}


### PR DESCRIPTION
Instead now it should be used as such:

```php
Event::listen(IndexBeforeEvent::class, fn($event) => $event->context->call('rapidez:index:categories'));
Event::listen(IndexAfterEvent::class, fn($event) => $event->context->call('rapidez:index:additionals'));
```