### PR TITLE
Get order information on checkout success page

### DIFF
--- a/config/rapidez.php
+++ b/config/rapidez.php
@@ -83,6 +83,19 @@ return [
         'store'        => Rapidez\Core\Models\Store::class,
         'widget'       => Rapidez\Core\Models\Widget::class,
         'block'        => Rapidez\Core\Models\Block::class,
+        'sales'        => [
+            'quote_id_mask' => Rapidez\Core\Models\Quote\QuoteIdMask::class,
+            'order'         => Rapidez\Core\Models\Sales\SalesOrder::class,
+            'order_address' => Rapidez\Core\Models\Sales\SalesOrderAddress::class,
+            'order_item'    => Rapidez\Core\Models\Sales\SalesOrderItem::class,
+            'order_payment' => Rapidez\Core\Models\Sales\SalesOrderPayment::class,
+        ],
+        'customer' => [
+            'entity' => Rapidez\Core\Models\Customer\CustomerEntity::class,
+        ],
+        'oauth' => [
+            'token' => Rapidez\Core\Models\Oauth\OauthToken::class,
+        ]
     ],
 
     // The fully qualified class names of the widgets.

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -4,12 +4,44 @@
     export default {
         mixins: [GetCart],
 
+        props: {
+            token: {
+                type: String,
+                default: null,
+            },
+            mask: {
+                type: String,
+                default: null
+            }
+        },
+
+        data() {
+            return {
+                order: {}
+            }
+        },
+
         render() {
-            return this.$scopedSlots.default()
+            return this.$scopedSlots.default({
+                order: this.order,
+                refreshOrder: this.refreshOrder,
+            })
         },
 
         created() {
+            this.token ??= localStorage.token;
+            this.mask ??= localStorage.mask;
+
+            this.refreshOrder();
             this.clearCart()
+        },
+
+        methods: {
+            refreshOrder()
+            {
+                axios.get('/api/cart/order/' + (this.token ? this.token : this.mask))
+                    .then((response) => this.order = response.data);
+            }
         }
     }
 </script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Rapidez\Core\Http\Controllers\CartOrderController;
 use Rapidez\Core\Http\Middleware\VerifyAdminToken;
 
 Route::middleware('api')->prefix('api')->group(function () {
@@ -18,6 +19,8 @@ Route::middleware('api')->prefix('api')->group(function () {
 
         return $optionswatchModel::getCachedSwatchValues();
     });
+
+    Route::get('cart/order/{quoteIdMaskOrCustomerToken}', CartOrderController::class);
 
     Route::get('cart/{quoteIdMaskOrCustomerToken}', function ($quoteIdMaskOrCustomerToken) {
         $quoteModel = config('rapidez.models.quote');

--- a/src/Http/Controllers/CartOrderController.php
+++ b/src/Http/Controllers/CartOrderController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rapidez\Core\Http\Controllers;
+
+use Rapidez\Core\Models\Sales\SalesOrder;
+
+class CartOrderController
+{
+    public function __invoke($quoteIdMaskOrCustomerToken = '')
+    {
+        $salesOrder = config('rapidez.models.sales.order')::with('sales_order_addresses', 'sales_order_items', 'sales_order_payments')
+            ->whereQuoteIdOrCustomerToken($quoteIdMaskOrCustomerToken)
+            ->latest()
+            ->firstOrFail();
+
+        return $salesOrder;
+    }
+}

--- a/src/Models/Customer/CustomerEntity.php
+++ b/src/Models/Customer/CustomerEntity.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rapidez\Core\Models\Customer;
+
+use Illuminate\Database\Eloquent\Model;
+use Rapidez\Core\Models\Oauth\OauthToken;
+use Rapidez\Core\Models\Sales\SalesOrder;
+
+class CustomerEntity extends Model
+{
+    protected $table = 'customer_entity';
+
+    protected $primaryKey = 'entity_id';
+
+    protected $casts = [
+        'website_id' => 'int',
+        'group_id' => 'int',
+        'store_id' => 'int',
+        'is_active' => 'int',
+        'disable_auto_group_change' => 'int',
+        'default_billing' => 'int',
+        'default_shipping' => 'int',
+        'gender' => 'int',
+        'failures_num' => 'int',
+    ];
+
+    protected $dates = [
+        'dob',
+        'rp_token_created_at',
+        'first_failure',
+        'lock_expires',
+    ];
+
+    protected $hidden = [
+        'rp_token',
+    ];
+
+    public function oauth_tokens()
+    {
+        return $this->hasMany(config('rapidez.models.oauth.token'), 'customer_id');
+    }
+
+    public function sales_orders()
+    {
+        return $this->hasMany(config('rapidez.models.sales.order'), 'customer_id');
+    }
+}

--- a/src/Models/Oauth/OauthToken.php
+++ b/src/Models/Oauth/OauthToken.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rapidez\Core\Models\Oauth;
+
+use Illuminate\Database\Eloquent\Model;
+use Rapidez\Core\Models\Customer\CustomerEntity;
+
+class OauthToken extends Model
+{
+    protected $table = 'oauth_token';
+
+    protected $primaryKey = 'entity_id';
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'consumer_id' => 'int',
+        'admin_id' => 'int',
+        'customer_id' => 'int',
+        'revoked' => 'int',
+        'authorized' => 'int',
+        'user_type' => 'int',
+    ];
+
+    protected $hidden = [
+        'token',
+        'secret',
+    ];
+
+    public function customer_entity()
+    {
+        return $this->belongsTo(config('rapidez.models.customer.entity'), 'customer_id');
+    }
+}

--- a/src/Models/Quote.php
+++ b/src/Models/Quote.php
@@ -17,6 +17,37 @@ class Quote extends Model
     protected $casts = [
         'items'       => QuoteItems::class,
         'cross_sells' => CommaSeparatedToIntegerArray::class,
+        'store_id' => 'int',
+        'is_active' => 'int',
+        'is_virtual' => 'int',
+        'is_multi_shipping' => 'int',
+        'items_count' => 'int',
+        'items_qty' => 'float',
+        'orig_order_id' => 'int',
+        'store_to_base_rate' => 'float',
+        'store_to_quote_rate' => 'float',
+        'grand_total' => 'float',
+        'base_grand_total' => 'float',
+        'customer_id' => 'int',
+        'customer_tax_class_id' => 'int',
+        'customer_group_id' => 'int',
+        'customer_note_notify' => 'int',
+        'customer_is_guest' => 'int',
+        'base_to_global_rate' => 'float',
+        'base_to_quote_rate' => 'float',
+        'subtotal' => 'float',
+        'base_subtotal' => 'float',
+        'subtotal_with_discount' => 'float',
+        'base_subtotal_with_discount' => 'float',
+        'is_changed' => 'int',
+        'trigger_recollect' => 'int',
+        'gift_message_id' => 'int',
+        'is_persistent' => 'int',
+    ];
+
+    protected $dates = [
+        'converted_at',
+        'customer_dob',
     ];
 
     protected static function booting()
@@ -79,5 +110,15 @@ class Quote extends Model
                 })
                 ->groupBy('quote.entity_id');
         });
+    }
+
+    public function quote_id_masks()
+    {
+        return $this->hasMany(config('rapidez.models.sales.quote_id_mask'), 'quote_id');
+    }
+
+    public function sales_order()
+    {
+        return $this->belongsTo(config('rapidez.models.sales.order'));
     }
 }

--- a/src/Models/Quote/QuoteIdMask.php
+++ b/src/Models/Quote/QuoteIdMask.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rapidez\Core\Models\Quote;
+
+use Illuminate\Database\Eloquent\Model;
+
+class QuoteIdMask extends Model
+{
+    protected $table = 'quote_id_mask';
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'quote_id' => 'int',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(config('rapidez.models.quote'));
+    }
+}

--- a/src/Models/Sales/SalesOrder.php
+++ b/src/Models/Sales/SalesOrder.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Rapidez\Core\Models\Sales;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Rapidez\Core\Models\Customer\CustomerEntity;
+use Rapidez\Core\Models\Quote\Quote;
+use Rapidez\Core\Models\Scopes\IsActiveScope;
+
+class SalesOrder extends Model
+{
+    protected $table = 'sales_order';
+
+    protected $primaryKey = 'entity_id';
+
+    protected $casts = [
+        'is_virtual' => 'int',
+        'store_id' => 'int',
+        'customer_id' => 'int',
+        'base_discount_amount' => 'float',
+        'base_discount_canceled' => 'float',
+        'base_discount_invoiced' => 'float',
+        'base_discount_refunded' => 'float',
+        'base_grand_total' => 'float',
+        'base_shipping_amount' => 'float',
+        'base_shipping_canceled' => 'float',
+        'base_shipping_invoiced' => 'float',
+        'base_shipping_refunded' => 'float',
+        'base_shipping_tax_amount' => 'float',
+        'base_shipping_tax_refunded' => 'float',
+        'base_subtotal' => 'float',
+        'base_subtotal_canceled' => 'float',
+        'base_subtotal_invoiced' => 'float',
+        'base_subtotal_refunded' => 'float',
+        'base_tax_amount' => 'float',
+        'base_tax_canceled' => 'float',
+        'base_tax_invoiced' => 'float',
+        'base_tax_refunded' => 'float',
+        'base_to_global_rate' => 'float',
+        'base_to_order_rate' => 'float',
+        'base_total_canceled' => 'float',
+        'base_total_invoiced' => 'float',
+        'base_total_invoiced_cost' => 'float',
+        'base_total_offline_refunded' => 'float',
+        'base_total_online_refunded' => 'float',
+        'base_total_paid' => 'float',
+        'base_total_qty_ordered' => 'float',
+        'base_total_refunded' => 'float',
+        'discount_amount' => 'float',
+        'discount_canceled' => 'float',
+        'discount_invoiced' => 'float',
+        'discount_refunded' => 'float',
+        'grand_total' => 'float',
+        'shipping_amount' => 'float',
+        'shipping_canceled' => 'float',
+        'shipping_invoiced' => 'float',
+        'shipping_refunded' => 'float',
+        'shipping_tax_amount' => 'float',
+        'shipping_tax_refunded' => 'float',
+        'store_to_base_rate' => 'float',
+        'store_to_order_rate' => 'float',
+        'subtotal' => 'float',
+        'subtotal_canceled' => 'float',
+        'subtotal_invoiced' => 'float',
+        'subtotal_refunded' => 'float',
+        'tax_amount' => 'float',
+        'tax_canceled' => 'float',
+        'tax_invoiced' => 'float',
+        'tax_refunded' => 'float',
+        'total_canceled' => 'float',
+        'total_invoiced' => 'float',
+        'total_offline_refunded' => 'float',
+        'total_online_refunded' => 'float',
+        'total_paid' => 'float',
+        'total_qty_ordered' => 'float',
+        'total_refunded' => 'float',
+        'can_ship_partially' => 'int',
+        'can_ship_partially_item' => 'int',
+        'customer_is_guest' => 'int',
+        'customer_note_notify' => 'int',
+        'billing_address_id' => 'int',
+        'customer_group_id' => 'int',
+        'edit_increment' => 'int',
+        'email_sent' => 'int',
+        'send_email' => 'int',
+        'forced_shipment_with_invoice' => 'int',
+        'payment_auth_expiration' => 'int',
+        'quote_address_id' => 'int',
+        'quote_id' => 'int',
+        'shipping_address_id' => 'int',
+        'adjustment_negative' => 'float',
+        'adjustment_positive' => 'float',
+        'base_adjustment_negative' => 'float',
+        'base_adjustment_positive' => 'float',
+        'base_shipping_discount_amount' => 'float',
+        'base_subtotal_incl_tax' => 'float',
+        'base_total_due' => 'float',
+        'payment_authorization_amount' => 'float',
+        'shipping_discount_amount' => 'float',
+        'subtotal_incl_tax' => 'float',
+        'total_due' => 'float',
+        'weight' => 'float',
+        'total_item_count' => 'int',
+        'customer_gender' => 'int',
+        'discount_tax_compensation_amount' => 'float',
+        'base_discount_tax_compensation_amount' => 'float',
+        'shipping_discount_tax_compensation_amount' => 'float',
+        'base_shipping_discount_tax_compensation_amnt' => 'float',
+        'discount_tax_compensation_invoiced' => 'float',
+        'base_discount_tax_compensation_invoiced' => 'float',
+        'discount_tax_compensation_refunded' => 'float',
+        'base_discount_tax_compensation_refunded' => 'float',
+        'shipping_incl_tax' => 'float',
+        'base_shipping_incl_tax' => 'float',
+        'gift_message_id' => 'int',
+    ];
+
+    protected $dates = [
+        'customer_dob',
+    ];
+
+    protected $hidden = [
+        'protect_code',
+        'remote_ip',
+        'x_forwarded_for',
+        'paypal_ipn_customer_notified',
+    ];
+
+    public function quote()
+    {
+        return $this->belongsTo(config('rapidez.models.quote'), 'quote_id');
+    }
+
+    public function customer_entity()
+    {
+        return $this->belongsTo(config('rapidez.models.customer.entity'), 'customer_id');
+    }
+
+    public function sales_order_addresses()
+    {
+        return $this->hasMany(config('rapidez.models.sales.order_address'), 'parent_id');
+    }
+
+    public function sales_order_items()
+    {
+        return $this->hasMany(config('rapidez.models.sales.order_item'), 'order_id');
+    }
+
+    public function sales_order_payments()
+    {
+        return $this->hasMany(config('rapidez.models.sales.order_payment'), 'parent_id');
+    }
+
+    public function scopeWhereQuoteIdMask(Builder $query, $quoteIdMask)
+    {
+        $query->whereHas(
+            'quote',
+            fn ($query) => $query
+            ->withoutGlobalScope(IsActiveScope::class)
+            ->whereHas(
+                'quote_id_masks',
+                fn ($query) => $query
+                ->where('masked_id', $quoteIdMask)
+            )
+        );
+    }
+
+    public function scopeWhereCustomerToken(Builder $query, $customerToken)
+    {
+        $query->whereHas(
+            'customer_entity',
+            fn ($query) => $query
+            ->whereHas(
+                'oauth_tokens',
+                fn ($query) => $query
+                ->where('token', $customerToken)
+            )
+        );
+    }
+
+    public function scopeWhereQuoteIdOrCustomerToken(Builder $query, $quoteIdMaskOrCustomerToken)
+    {
+        $query->where(
+            fn ($query) => $query
+                ->whereQuoteIdMask($quoteIdMaskOrCustomerToken)
+                ->orWhere(fn ($query) => $query->whereCustomerToken($quoteIdMaskOrCustomerToken))
+        );
+    }
+}

--- a/src/Models/Sales/SalesOrderAddress.php
+++ b/src/Models/Sales/SalesOrderAddress.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rapidez\Core\Models\Sales;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderAddress extends Model
+{
+    protected $table = 'sales_order_address';
+
+    protected $primaryKey = 'entity_id';
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'parent_id' => 'int',
+        'customer_address_id' => 'int',
+        'quote_address_id' => 'int',
+        'region_id' => 'int',
+        'customer_id' => 'int',
+        'vat_is_valid' => 'int',
+        'vat_request_success' => 'int',
+    ];
+
+    public function sales_order()
+    {
+        return $this->belongsTo(config('rapidez.models.sales.order'), 'parent_id');
+    }
+}

--- a/src/Models/Sales/SalesOrderItem.php
+++ b/src/Models/Sales/SalesOrderItem.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Rapidez\Core\Models\Sales;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderItem extends Model
+{
+    protected $table = 'sales_order_item';
+
+    protected $primaryKey = 'item_id';
+
+    protected $casts = [
+        'order_id' => 'int',
+        'parent_item_id' => 'int',
+        'quote_item_id' => 'int',
+        'store_id' => 'int',
+        'product_id' => 'int',
+        'product_options' => 'collection',
+        'weight' => 'float',
+        'is_virtual' => 'int',
+        'is_qty_decimal' => 'int',
+        'no_discount' => 'int',
+        'qty_backordered' => 'float',
+        'qty_canceled' => 'float',
+        'qty_invoiced' => 'float',
+        'qty_ordered' => 'float',
+        'qty_refunded' => 'float',
+        'qty_shipped' => 'float',
+        'base_cost' => 'float',
+        'price' => 'float',
+        'base_price' => 'float',
+        'original_price' => 'float',
+        'base_original_price' => 'float',
+        'tax_percent' => 'float',
+        'tax_amount' => 'float',
+        'base_tax_amount' => 'float',
+        'tax_invoiced' => 'float',
+        'base_tax_invoiced' => 'float',
+        'discount_percent' => 'float',
+        'discount_amount' => 'float',
+        'base_discount_amount' => 'float',
+        'discount_invoiced' => 'float',
+        'base_discount_invoiced' => 'float',
+        'amount_refunded' => 'float',
+        'base_amount_refunded' => 'float',
+        'row_total' => 'float',
+        'base_row_total' => 'float',
+        'row_invoiced' => 'float',
+        'base_row_invoiced' => 'float',
+        'row_weight' => 'float',
+        'base_tax_before_discount' => 'float',
+        'tax_before_discount' => 'float',
+        'locked_do_invoice' => 'int',
+        'locked_do_ship' => 'int',
+        'price_incl_tax' => 'float',
+        'base_price_incl_tax' => 'float',
+        'row_total_incl_tax' => 'float',
+        'base_row_total_incl_tax' => 'float',
+        'discount_tax_compensation_amount' => 'float',
+        'base_discount_tax_compensation_amount' => 'float',
+        'discount_tax_compensation_invoiced' => 'float',
+        'base_discount_tax_compensation_invoiced' => 'float',
+        'discount_tax_compensation_refunded' => 'float',
+        'base_discount_tax_compensation_refunded' => 'float',
+        'tax_canceled' => 'float',
+        'discount_tax_compensation_canceled' => 'float',
+        'tax_refunded' => 'float',
+        'base_tax_refunded' => 'float',
+        'discount_refunded' => 'float',
+        'base_discount_refunded' => 'float',
+        'gift_message_id' => 'int',
+        'gift_message_available' => 'int',
+        'free_shipping' => 'int',
+        'weee_tax_applied_amount' => 'float',
+        'weee_tax_applied_row_amount' => 'float',
+        'weee_tax_disposition' => 'float',
+        'weee_tax_row_disposition' => 'float',
+        'base_weee_tax_applied_amount' => 'float',
+        'base_weee_tax_applied_row_amnt' => 'float',
+        'base_weee_tax_disposition' => 'float',
+        'base_weee_tax_row_disposition' => 'float',
+    ];
+
+    public function sales_order()
+    {
+        return $this->belongsTo(config('rapidez.models.sales.order'), 'order_id');
+    }
+}

--- a/src/Models/Sales/SalesOrderPayment.php
+++ b/src/Models/Sales/SalesOrderPayment.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rapidez\Core\Models\Sales;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SalesOrderPayment extends Model
+{
+    protected $table = 'sales_order_payment';
+
+    protected $primaryKey = 'entity_id';
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'parent_id' => 'int',
+        'base_shipping_captured' => 'float',
+        'shipping_captured' => 'float',
+        'amount_refunded' => 'float',
+        'base_amount_paid' => 'float',
+        'amount_canceled' => 'float',
+        'base_amount_authorized' => 'float',
+        'base_amount_paid_online' => 'float',
+        'base_amount_refunded_online' => 'float',
+        'base_shipping_amount' => 'float',
+        'shipping_amount' => 'float',
+        'amount_paid' => 'float',
+        'amount_authorized' => 'float',
+        'base_amount_ordered' => 'float',
+        'base_shipping_refunded' => 'float',
+        'shipping_refunded' => 'float',
+        'base_amount_refunded' => 'float',
+        'amount_ordered' => 'float',
+        'base_amount_canceled' => 'float',
+        'quote_payment_id' => 'int',
+        'additional_information' => 'collection',
+    ];
+
+    protected $hidden = [
+        'cc_debug_request_body',
+        'cc_secure_verify',
+        'cc_approval',
+        'cc_last_4',
+        'cc_status_description',
+        'cc_debug_response_serialized',
+        'cc_ss_start_month',
+        'cc_cid_status',
+        'cc_owner',
+        'cc_exp_year',
+        'cc_exp_month',
+        'cc_debug_response_body',
+        'cc_number_enc',
+        'cc_trans_id',
+        'echeck_type',
+    ];
+
+    public function sales_order()
+    {
+        return $this->belongsTo(config('rapidez.models.sales.order'), 'parent_id');
+    }
+}


### PR DESCRIPTION
This PR adds an api endpoint that allows you to get the latest order attached to the quote using the quote mask or customer token.

This also implements that endpoint for the checkoutSuccess page so we can reliably show order info on the success page.