### PR TITLE
Prevent loading turning false when one of multiple simultaneous finishes

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,7 @@ if (!window.process) {
 
 import './lodash'
 import './vue'
+import { computed } from 'vue';
 import './axios'
 import './filters'
 import './mixins'
@@ -67,7 +68,8 @@ function init() {
         data: {
             custom: {},
             config: window.config,
-            loading: false,
+            loadingCount: 0,
+            loading: computed(() => window.app?.$data?.loadingCount > 0),
             guestEmail: localStorage.email ?? null,
             user: null,
             cart: null,

--- a/resources/js/axios.js
+++ b/resources/js/axios.js
@@ -16,17 +16,17 @@ window.magentoUser.defaults.headers.common['Authorization'] = `Bearer ${localSto
 const instances = [window.axios, window.magento, window.magentoUser]
 instances.forEach(function (instance) {
     instance.interceptors.request.use(function (config) {
-        window.app.$data.loading = true
+        window.app.$data.loadingCount++
         return config;
     }, function (error) {
         return Promise.reject(error);
     });
 
     instance.interceptors.response.use(function (response) {
-        window.app.$data.loading = false
+        window.app.$data.loadingCount--
         return response
     }, function(error) {
-        window.app.$data.loading = false
+        window.app.$data.loadingCount--
         return Promise.reject(error)
     });
 })


### PR DESCRIPTION
In the old situation the first request that finishes would set loading to false while not every request has finished.
in normal situations this is probably no issue, but during tests or slow connections this could mean running into bugs since not all data has been processed.