### PR TITLE
RAP-469 - Prefix super attributes

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -199,6 +199,11 @@ class Product extends Model
             return $val;
         }
 
-        return $this->transformModelValue($key, parent::getAttribute('super_'.$key));
+        $val = parent::getAttribute('super_'.$key);
+        if($this->hasCast('super_'.$key)) {
+            return $val;
+        }
+
+        return $this->transformModelValue($key, $val);
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -4,6 +4,7 @@ namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
 use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
@@ -189,5 +190,15 @@ class Product extends Model
     public static function exist($productId): bool
     {
         return self::withoutGlobalScopes()->where('entity_id', $productId)->exists();
+    }
+
+    public function getAttribute($key) {
+        $val = parent::getAttribute(...func_get_args());
+
+        if(isset($val) || Str::startsWith($key, 'super_')) {
+            return $val;
+        }
+
+        return $this->transformModelValue($key, parent::getAttribute('super_'.$key));
     }
 }

--- a/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
@@ -33,7 +33,7 @@ class WithProductSuperAttributesScope implements Scope
                 ->whereColumn('parent_id', $model->getTable().'.entity_id')
                 ->whereNotNull($superAttribute);
 
-            $builder->selectSub($query, $superAttribute);
+            $builder->selectSub($query, 'super_'.$superAttribute);
         }
 
         $query = DB::table('catalog_product_super_attribute')


### PR DESCRIPTION
This allows for relatively good backwards compatibility with the old way of working with attributes.
All super variables are available like `super_` but if you ask for the variable without `super_` it will check if it is not null.
If it is, it will attempt to get the `super_` value and cast it according to it's non `super_` casts.

The only limitation is that this does not happen during a `toArray` or `toJson`