### PR TITLE
Use suggestion.source._id in data-search component

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -31,9 +31,9 @@
                     <li
                         class="flex w-1/2 sm:w-1/2 md:w-1/3 px-4 my-4"
                         v-for="suggestion in suggestions"
-                        :key="suggestion._id"
+                        :key="suggestion.source._id"
                     >
-                        <a :href="suggestion.source.url" class="flex flex-wrap w-full h-full" key="suggestion._id">
+                        <a :href="suggestion.source.url" class="flex flex-wrap w-full h-full" key="suggestion.source._id">
                             <picture class="contents">
                                 <source :srcset="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" type="image/webp">
                                 <img :src="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail" class="object-contain lg:w-3/12 self-center" />


### PR DESCRIPTION
For some strange reason, reactivesearch has inconsistent behavior here.

When using suggestions (e.g. DataSearch), `_id` is placed under the `source` object.  
However, this is not the case when using hits (e.g. ReactiveList) in a product listing of sorts.

The result of this is that suggestions weren't given a proper key in the v-for here causing a few issues you might expect from that (images not being unloaded, for example).