### PR TITLE
Add useEventListener to imports in Slider.vue

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -1,5 +1,5 @@
 <script>
-    import { useElementHover, useIntervalFn } from '@vueuse/core'
+    import { useElementHover, useIntervalFn, useEventListener } from '@vueuse/core'
 
     export default {
         render() {


### PR DESCRIPTION
The function was used without being imported 😇 