### PR TITLE
Default to using this.$el for slider

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -12,10 +12,7 @@
             })
         },
         props: {
-            reference: {
-                type: String,
-                default: 'slider'
-            },
+            reference: String,
             vertical: {
                 type: Boolean,
                 default: false
@@ -91,6 +88,9 @@
         },
         computed: {
             slider() {
+                if(!this.reference) {
+                    return this.$el;
+                }
                 return this.$scopedSlots.default()[0].context.$refs[this.reference]
             },
             currentSlide() {

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -25,7 +25,7 @@
                     <div slot="renderNoResults"></div>
 
                     <div class="relative" slot="render" slot-scope="{ data, loading }" v-if="!loading">
-                        <slider>
+                        <slider reference="slider">
                             <div slot-scope="{ navigate, showLeft, showRight, currentSlide, slidesTotal }">
                                 <div class="flex mt-5 overflow-x-auto snap-x scrollbar-hide scroll-smooth snap-mandatory" ref="slider">
                                     <template v-for="item in data">


### PR DESCRIPTION
We can't always use just `this.$el`, even in the example given in the core. However, we can default to it and let people use the ref in case it's necessary :)