### PR TITLE
Fix the slider to properly calculate slides when there's more than 1 child visible at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog 
 
-[Unreleased changes](https://github.com/rapidez/core/compare/0.85.1...master)
+[Unreleased changes](https://github.com/rapidez/core/compare/0.86.0...master)
+## [0.86.0](https://github.com/rapidez/core/releases/tag/0.86.0) - 2023-04-14
+
+#### Changed
+
+- Prefix super attributes (#234)
+
+#### Fixed
+
+- Update reactivesearch to the latest version fixing u-r-l-params (#232)
+- Prevent loading turning false when one of multiple simultaneous finishes (#233)
+- Change onLogout usage to avoid unnecessarily clearing email (#239)
+
 ## [0.85.1](https://github.com/rapidez/core/releases/tag/0.85.1) - 2023-03-31
 
 #### Fixed

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -25,7 +25,7 @@
                 position: 0,
                 showLeft: false,
                 showRight: false,
-                mounted: false
+                mounted: false,
             }
         },
         mounted() {
@@ -55,21 +55,29 @@
             },
             currentSlide() {
                 if (this.mounted) {
-                    return this.vertical
-                        ? Math.round(this.position / (this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight))
-                        : Math.round(this.position / (this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth))
+                    return Math.round(this.position / this.childSpan)
                 }
             },
             slidesVisible() {
                 if(this.mounted) {
-                    return this.vertical
-                        ? Math.round(this.slider.offsetHeight / (this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight))
-                        : Math.round(this.slider.offsetWidth / (this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth))
+                    return Math.round(this.sliderSpan / this.childSpan)
                 }
             },
             slidesTotal() {
                 if (this.mounted) {
                     return (this.slider.children?.length ?? 1) - this.slidesVisible + 1;
+                }
+            },
+            childSpan() {
+                if(this.mounted) {
+                    return this.vertical
+                        ? this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight
+                        : this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth
+                }
+            },
+            sliderSpan() {
+                if(this.mounted) {
+                    return this.vertical ? this.slider.offsetHeight : this.slider.offsetWidth
                 }
             }
         }

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -6,6 +6,7 @@
                 showLeft: this.showLeft,
                 showRight: this.showRight,
                 currentSlide: this.currentSlide,
+                slidesVisible: this.slidesVisible,
                 slidesTotal: this.slidesTotal
             })
         },
@@ -55,15 +56,20 @@
             currentSlide() {
                 if (this.mounted) {
                     return this.vertical
-                        ? Math.round(this.position / this.slider.children[0]?.offsetHeight)
-                        : Math.round(this.position / this.slider.children[0]?.offsetWidth)
+                        ? Math.round(this.position / (this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight))
+                        : Math.round(this.position / (this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth))
+                }
+            },
+            slidesVisible() {
+                if(this.mounted) {
+                    return this.vertical
+                        ? Math.round(this.slider.offsetHeight / (this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight))
+                        : Math.round(this.slider.offsetWidth / (this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth))
                 }
             },
             slidesTotal() {
                 if (this.mounted) {
-                    return this.vertical
-                        ? Math.round(this.slider.scrollHeight / this.slider.offsetHeight)
-                        : Math.round(this.slider.scrollWidth / this.slider.offsetWidth)
+                    return (this.slider.children?.length ?? 1) - this.slidesVisible + 1;
                 }
             }
         }


### PR DESCRIPTION
Not sure what to do with edge cases yet. For example, say 3 children are visible and one child is 70% visible, do we want to round down and say only 3 are actually visible? We can't always round down of course, as in many cases you might get 3.99 which obviously rounds up to 4.