### PR TITLE
Directive as a simplistic way to get rid of references

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -117,6 +117,24 @@ function init() {
                 doNotGoToTheNextStep: false,
             },
         },
+        directives: {
+            element: {
+                inserted: function(el) {
+                    // Try to find the containing component by looking through the parent chain
+                    let parent = el.parentElement;
+                    while(!parent.__vue__?.$vnode?.componentInstance) {
+                        parent = parent.parentElement;
+                        if(!parent) {
+                            // No component found in the parent chain
+                            return;
+                        }
+                    }
+
+                    // Set a magic $element variable
+                    parent.__vue__.$vnode.componentInstance.$element = el;
+                }
+            }
+        },
         methods: {
             search(value) {
                 if (value.length) {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -10,10 +10,6 @@
             })
         },
         props: {
-            reference: {
-                type: String,
-                default: 'slider'
-            },
             vertical: {
                 type: Boolean,
                 default: false
@@ -50,7 +46,7 @@
         },
         computed: {
             slider() {
-                return this.$scopedSlots.default()[0].context.$refs[this.reference]
+                return this.$element;
             },
             currentSlide() {
                 if (this.mounted) {

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -27,7 +27,7 @@
                     <div class="relative" slot="render" slot-scope="{ data, loading }" v-if="!loading">
                         <slider>
                             <div slot-scope="{ navigate, showLeft, showRight, currentSlide, slidesTotal }">
-                                <div class="flex mt-5 overflow-x-auto snap-x scrollbar-hide scroll-smooth snap-mandatory" ref="slider">
+                                <div class="flex mt-5 overflow-x-auto snap-x scrollbar-hide scroll-smooth snap-mandatory" v-element>
                                     <template v-for="item in data">
                                         @include('rapidez::listing.partials.item', ['slider' => true])
                                     </template>


### PR DESCRIPTION
This feels very dirty but I couldn't find a better way to grab the component instance in the directive.

Maybe there's a better name to use than v-element?