### PR TITLE
Update RapidezServiceProvider.php

### DIFF
--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -31,7 +31,6 @@ class RapidezServiceProvider extends ServiceProvider
             ->bootCommands()
             ->bootPublishables()
             ->bootRoutes()
-            ->bootThemes()
             ->bootViews()
             ->bootBladeComponents()
             ->bootMiddleware()
@@ -43,7 +42,8 @@ class RapidezServiceProvider extends ServiceProvider
     {
         $this
             ->registerConfigs()
-            ->registerBindings();
+            ->registerBindings()
+            ->registerThemes();
     }
 
     public function bootTranslations(): self
@@ -98,7 +98,7 @@ class RapidezServiceProvider extends ServiceProvider
         return $this;
     }
 
-    protected function bootThemes(): self
+    protected function registerThemes(): self
     {
         $path = config('rapidez.themes.' . request()->server('MAGE_RUN_CODE', request()->has('_store') && ! app()->isProduction() ? request()->get('_store') : 'default'), false);
 


### PR DESCRIPTION
When a view composer is executed in a ServiceProvider of another package, it does not always go well. An example is https://github.com/rapidez/amasty-promo-banners/blob/master/src/AmastyPromoBannersServiceProvider.php#L65. Because this starts alphabetically earlier, it is executed before the Themes are booted. Moving it to a registry fixes it.