### PR TITLE
Add helpers for adding domain to urls

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -122,7 +122,7 @@ function init() {
         methods: {
             search(value) {
                 if (value.length) {
-                    Turbo.visit('/search?q=' + encodeURIComponent(value))
+                    Turbo.visit(window.url('/search?q=' + encodeURIComponent(value)))
                 }
             },
             setSearchParams(url) {
@@ -136,7 +136,7 @@ function init() {
                 }
 
                 return axios
-                    .get('/api/swatches')
+                    .get(window.url('/api/swatches'))
                     .then((response) => {
                         localStorage.swatches = JSON.stringify(response.data)
                         return response.data

--- a/resources/js/components/Cart/mixins/GetCart.js
+++ b/resources/js/components/Cart/mixins/GetCart.js
@@ -35,7 +35,7 @@ export default {
 
             if (localStorage.mask) {
                 try {
-                    let response = await axios.get('/api/cart/' + (localStorage.token ? localStorage.token : localStorage.mask))
+                    let response = await axios.get(window.url('/api/cart/' + (localStorage.token ? localStorage.token : localStorage.mask)))
                     localStorage.cart = JSON.stringify(response.data)
                     window.app.cart = response.data
                     window.app.$emit('cart-refreshed')

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -25,7 +25,7 @@ export default {
 
     created() {
         if (!this.hasItems) {
-            window.location.replace('/')
+            window.location.replace(window.url('/'))
             return
         }
 
@@ -112,7 +112,7 @@ export default {
 
         goToStep(step) {
             if (step === 0) {
-                Turbo.visit('/cart')
+                Turbo.visit(window.url('/cart'))
                 return
             }
 

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -38,7 +38,7 @@ export default {
 
     methods: {
         refreshOrder() {
-            axios.get('/api/order/' + (this.token || this.mask)).then((response) => (this.order = response.data))
+            axios.get(window.url('/api/order/' + (this.token || this.mask))).then((response) => (this.order = response.data))
         },
     },
 }

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -95,7 +95,7 @@ export default {
             if (this.checkoutLogin) {
                 this.$root.checkout.step = 2
             } else if (this.redirect) {
-                Turbo.visit(this.redirect)
+                Turbo.visit(window.url(this.redirect))
             }
         },
     },

--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -88,7 +88,7 @@ export default {
 
                 if (this.check) {
                     if (!eval('response.data.' + this.check)) {
-                        Turbo.visit(this.redirect)
+                        Turbo.visit(window.url(this.redirect))
                         return
                     }
                 }

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -170,7 +170,7 @@ export default {
                         )
                     }
                     this.mutating = false
-                    Turbo.visit(this.redirect)
+                    Turbo.visit(window.url(this.redirect))
                 }
             } catch (e) {
                 this.mutating = false

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -51,7 +51,7 @@ export default {
         }
 
         axios
-            .get('/api/attributes')
+            .get(window.url('/api/attributes'))
             .then((response) => {
                 this.attributes = response.data
                 localStorage.attributes = JSON.stringify(this.attributes)

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -71,7 +71,7 @@ export default {
                 window.location.pathname !== this.product.url &&
                 !config.show_swatches
             ) {
-                Turbo.visit(this.product.url)
+                Turbo.visit(window.url(this.product.url))
                 return
             }
 
@@ -102,10 +102,10 @@ export default {
                         qty: this.qty,
                     })
                     if (this.notifySuccess) {
-                        Notify(this.product.name + ' ' + window.config.translations.cart.add, 'success', [], '/cart')
+                        Notify(this.product.name + ' ' + window.config.translations.cart.add, 'success', [], window.url('/cart'))
                     }
                     if (config.redirect_cart) {
-                        Turbo.visit('/cart')
+                        Turbo.visit(window.url('/cart'))
                     }
                 })
                 .catch((error) => {

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -66,7 +66,7 @@ export default {
             Turbo.cache.clear()
 
             if (data?.redirect) {
-                window.location.href = data?.redirect
+                window.location.href = window.url(data?.redirect)
             }
         },
 

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -12,3 +12,14 @@ Vue.filter('price', function (value) {
         currency: config.currency,
     }).format(value)
 })
+
+window.url = function (path = '') {
+    // Transform urls starting with / into url with domain
+    if(!path.startsWith('/')) {
+        return path
+    }
+
+    return (window.config.base_url || window.origin) + path
+}
+
+Vue.filter('url', window.url)

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -11,7 +11,7 @@
         <div v-if="hasItems" slot-scope="{ cart, hasItems, changeQty, remove }">
             <div class="flex flex-wrap items-center border-b pb-2 mb-2" v-for="(item, productId, index) in cart.items">
                 <div class="w-1/6 sm:w-1/12 pr-3">
-                    <a :href="item.url" class="block">
+                    <a :href="item.url | url" class="block">
                         <picture>
                             <source :srcset="'/storage/resizes/80x80/magento/catalog/product' + item.image + '.webp'" type="image/webp">
                             <img
@@ -24,7 +24,7 @@
                     </a>
                 </div>
                 <div class="w-5/6 sm:w-5/12 lg:w-8/12">
-                    <a :href="item.url" dusk="cart-item-name" class="font-bold">@{{ item.name }}</a>
+                    <a :href="item.url | url" dusk="cart-item-name" class="font-bold">@{{ item.name }}</a>
                     <div v-for="(optionValue, option) in item.options">
                         @{{ option }}: @{{ optionValue }}
                     </div>
@@ -79,7 +79,7 @@
                         <div class="w-1/2 text-right font-bold">@{{ cart.total | price }}</div>
                     </div>
 
-                    <x-rapidez::button href="/checkout" dusk="checkout">
+                    <x-rapidez::button href="{{ route('checkout') }}" dusk="checkout">
                         @lang('Checkout')
                     </x-rapidez::button>
                 </div>

--- a/resources/views/category/partials/breadcrumbs.blade.php
+++ b/resources/views/category/partials/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 <x-rapidez::breadcrumbs>
     @foreach($category->parentcategories as $parentcategory)
         <x-rapidez::breadcrumb
-            :url="to($parentcategory->url)"
+            :url="url($parentcategory->url)"
             :active="$parentcategory->entity_id == $category->entity_id"
             :position="$loop->iteration + 1"
         >

--- a/resources/views/category/partials/breadcrumbs.blade.php
+++ b/resources/views/category/partials/breadcrumbs.blade.php
@@ -1,7 +1,7 @@
 <x-rapidez::breadcrumbs>
     @foreach($category->parentcategories as $parentcategory)
         <x-rapidez::breadcrumb
-            :url="$parentcategory->url"
+            :url="to($parentcategory->url)"
             :active="$parentcategory->entity_id == $category->entity_id"
             :position="$loop->iteration + 1"
         >

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -27,7 +27,7 @@
             </x-rapidez::button>
 
             @if(App::providerIsLoaded('Rapidez\Account\AccountServiceProvider'))
-                <a href="/forgotpassword" class="inline-block text-sm hover:underline mt-5" v-if="!emailAvailable">
+                <a href="{{ route('account.forgotpassword') }}" class="inline-block text-sm hover:underline mt-5" v-if="!emailAvailable">
                     @lang('Forgot your password?')
                 </a>
             @endif

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,4 +1,4 @@
 <ol class="flex mb-3" itemscope itemtype="https://schema.org/BreadcrumbList">
-    <x-rapidez::breadcrumb url="/" position="1">@lang('Home')</x-rapidez::breadcrumb>
+    <x-rapidez::breadcrumb :url="url('/')" position="1">@lang('Home')</x-rapidez::breadcrumb>
     {{ $slot }}
 </ol>

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -5,22 +5,22 @@
         @if(Route::currentRouteName() !== 'checkout')
             <nav class="-mx-5 -my-2 flex flex-wrap justify-center">
                 <div class="px-5 py-2">
-                    <a href="/about-us" class="text-base leading-6 text-gray-600 hover:text-gray-900">
+                    <a href="{{ url('/about-us') }}" class="text-base leading-6 text-gray-600 hover:text-gray-900">
                         @lang('About')
                     </a>
                 </div>
                 <div class="px-5 py-2">
-                    <a href="/customer-service" class="text-base leading-6 text-gray-600 hover:text-gray-900">
+                    <a href="{{ url('/customer-service') }}" class="text-base leading-6 text-gray-600 hover:text-gray-900">
                         @lang('Service')
                     </a>
                 </div>
                 <div class="px-5 py-2">
-                    <a href="/privacy-policy-cookie-restriction-mode" class="text-base leading-6 text-gray-600 hover:text-gray-900">
+                    <a href="{{ url('/privacy-policy-cookie-restriction-mode') }}" class="text-base leading-6 text-gray-600 hover:text-gray-900">
                         @lang('Privacy')
                     </a>
                 </div>
                 <div class="px-5 py-2">
-                    <a href="/enable-cookies" class="text-base leading-6 text-gray-600 hover:text-gray-900">
+                    <a href="{{ url('/enable-cookies') }}" class="text-base leading-6 text-gray-600 hover:text-gray-900">
                         @lang('Cookies')
                     </a>
                 </div>

--- a/resources/views/layouts/partials/footer/newsletter.blade.php
+++ b/resources/views/layouts/partials/footer/newsletter.blade.php
@@ -43,7 +43,7 @@
                             </p>
                             <p class="mt-3 text-sm text-gray-600">
                                 @lang('We care about the protection of your data. Read our')
-                                <a href="/privacy-policy-cookie-restriction-mode" class="underline">
+                                <a href="{{ url('/privacy-policy-cookie-restriction-mode') }}" class="underline">
                                     @lang('Privacy Policy')
                                 </a>
                             </p>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -1,7 +1,7 @@
 <header class="flex flex-wrap items-center mb-5 border-b shadow {{ Route::currentRouteName() == 'checkout' ? 'justify-between' : '' }}">
     <div class="w-1/6 sm:w-3/12">
         <div class="text-xl sm:text-3xl ml-3">
-            <a href="/" aria-label="@lang('Go to home')">
+            <a href="{{ url('/') }}" aria-label="@lang('Go to home')">
                 <span class="hidden sm:inline">
                     <img src="https://raw.githubusercontent.com/rapidez/art/master/logo.svg" height="48" width="152" alt="">
                 </span>

--- a/resources/views/layouts/partials/header/account.blade.php
+++ b/resources/views/layouts/partials/header/account.blade.php
@@ -7,8 +7,8 @@
             </button>
             <div v-if="isOpen" class="absolute bg-white border shadow rounded mr-1 {{ config('rapidez.z-indexes.header-dropdowns') }} {{ Route::currentRouteName() == 'checkout' ? 'right-0' : '' }}">
                 @if(App::providerIsLoaded('Rapidez\Account\AccountServiceProvider'))
-                    <a class="block hover:bg-secondary px-3 py-2" href="/account">@lang('Account')</a>
-                    <a class="block hover:bg-secondary px-3 py-2" href="/account/orders">@lang('Orders')</a>
+                    <a class="block hover:bg-secondary px-3 py-2" href="{{ route('account.overview') }}">@lang('Account')</a>
+                    <a class="block hover:bg-secondary px-3 py-2" href="{{ route('account.orders') }}">@lang('Orders')</a>
                 @endif
                 <user>
                     <a
@@ -26,7 +26,7 @@
     </toggler>
     @if(App::providerIsLoaded('Rapidez\Account\AccountServiceProvider'))
         <div class="my-1" v-else>
-            <a href="/login" aria-label="@lang('Login')">
+            <a href="{{ route('account.login') }}" aria-label="@lang('Login')">
                 <x-heroicon-o-user class="h-6 w-6"/>
             </a>
         </div>

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -33,7 +33,7 @@
                         v-for="suggestion in suggestions"
                         :key="suggestion.source._id"
                     >
-                        <a :href="suggestion.source.url" class="flex flex-wrap w-full h-full" key="suggestion.source._id">
+                        <a :href="suggestion.source.url | url" class="flex flex-wrap w-full h-full" key="suggestion.source._id">
                             <picture class="contents">
                                 <source :srcset="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" type="image/webp">
                                 <img :src="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail" class="object-contain lg:w-3/12 self-center" />

--- a/resources/views/layouts/partials/header/minicart.blade.php
+++ b/resources/views/layouts/partials/header/minicart.blade.php
@@ -18,16 +18,16 @@
                     </tr>
                 </table>
                 <div class="flex justify-between items-center">
-                    <x-rapidez::button href="/cart" variant="outline" class="mr-5">
+                    <x-rapidez::button href="{{ route('cart') }}" variant="outline" class="mr-5">
                         @lang('Show cart')
                     </x-rapidez::button>
-                    <x-rapidez::button href="/checkout">
+                    <x-rapidez::button href="{{ route('checkout') }}">
                         @lang('Checkout')
                     </x-rapidez::button>
                 </div>
             </div>
         </div>
-        <a href="/cart" aria-label="@lang('Cart')" class="my-1" v-else>
+        <a href="{{ route('cart') }}" aria-label="@lang('Cart')" class="my-1" v-else>
             <x-heroicon-o-shopping-cart class="h-6 w-6"/>
         </a>
     </toggler>

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -1,7 +1,7 @@
 <template {!! isset($slider) ? '' : 'slot="renderItem" slot-scope="{ item, count }"' !!}>
     <div class="flex-none w-1/2 sm:w-1/3 lg:w-1/4 px-1 my-1 snap-start">
         <div class="w-full bg-white rounded hover:shadow group relative" :key="item.id">
-            <a :href="item.url" class="block">
+            <a :href="item.url | url" class="block">
                 <picture v-if="item.thumbnail">
                     <source :srcset="'/storage/resizes/200/magento/catalog/product' + item.thumbnail + '.webp'" type="image/webp">
                     <img :src="'/storage/resizes/200/magento/catalog/product' + item.thumbnail" class="object-contain rounded-t h-48 w-full mb-3" :alt="item.name" :loading="config.category && count <= 4 ? 'eager' : 'lazy'" width="200" height="200" />

--- a/resources/views/product/partials/breadcrumbs.blade.php
+++ b/resources/views/product/partials/breadcrumbs.blade.php
@@ -1,6 +1,6 @@
 <x-rapidez::breadcrumbs>
     @foreach($product->breadcrumb_categories as $category)
-        <x-rapidez::breadcrumb :url="to($category->url)" :position="$loop->iteration + 1">
+        <x-rapidez::breadcrumb :url="url($category->url)" :position="$loop->iteration + 1">
             {{ $category->name }}
         </x-rapidez::breadcrumb>
     @endforeach

--- a/resources/views/product/partials/breadcrumbs.blade.php
+++ b/resources/views/product/partials/breadcrumbs.blade.php
@@ -1,6 +1,6 @@
 <x-rapidez::breadcrumbs>
     @foreach($product->breadcrumb_categories as $category)
-        <x-rapidez::breadcrumb :url="$category->url" :position="$loop->iteration + 1">
+        <x-rapidez::breadcrumb :url="to($category->url)" :position="$loop->iteration + 1">
             {{ $category->name }}
         </x-rapidez::breadcrumb>
     @endforeach

--- a/src/Http/Middleware/DetermineAndSetShop.php
+++ b/src/Http/Middleware/DetermineAndSetShop.php
@@ -29,6 +29,7 @@ class DetermineAndSetShop
         config()->set('rapidez.website', $store['website_id']);
         config()->set('rapidez.website_code', $store['website_code']);
         config()->set('rapidez.root_category_id', $store['root_category_id']);
+        config()->set('frontend.base_url', url('/'));
 
         return $next($request);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,6 +12,25 @@ if (! function_exists('price')) {
     }
 }
 
+if (! function_exists('to')) {
+    /**
+     * Generate a relative safe url for the application.
+     *
+     * @param  string|null  $path
+     * @param  mixed  $parameters
+     * @param  bool|null  $secure
+     * @return \Illuminate\Contracts\Routing\UrlGenerator|string
+     */
+    function to($path = null, $parameters = [], $secure = null)
+    {
+        if (!str_starts_with($path ?? '/', '/')) {
+            return $path;
+        }
+
+        return url(...func_get_args());
+    }
+}
+
 if (! function_exists('vite_filename_with_chunkhash')) {
     function vite_filename_with_chunkhash($file)
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,25 +12,6 @@ if (! function_exists('price')) {
     }
 }
 
-if (! function_exists('to')) {
-    /**
-     * Generate a relative safe url for the application.
-     *
-     * @param  string|null  $path
-     * @param  mixed  $parameters
-     * @param  bool|null  $secure
-     * @return \Illuminate\Contracts\Routing\UrlGenerator|string
-     */
-    function to($path = null, $parameters = [], $secure = null)
-    {
-        if (!str_starts_with($path ?? '/', '/')) {
-            return $path;
-        }
-
-        return url(...func_get_args());
-    }
-}
-
 if (! function_exists('vite_filename_with_chunkhash')) {
     function vite_filename_with_chunkhash($file)
     {


### PR DESCRIPTION
Turned named urls into `route()` calls
use the `url()` helper when we're certain the url starts with a `/`
use the `to()` helper if the url might start with a relative path

How Laravel generates the domain for the url can be done in multiple ways:
```php
\Illuminate\Support\Facades\Url::formatHostUsing(fn($root, $route) => 'https://example.com');
\Illuminate\Support\Facades\Url::forceRootUrl('https://example.com');
```
or if you simply want to add a prefix to the url that is possible by using the `X-Forwarded-Prefix` header

As there are multiple ways to set this domain, like getting it from Magento, setting it in configuration, passing it from your reverse proxy i have not made any opinionated code on this.
Depending on the requirements of the project one of these can be used on a per-project basis.

Most projects will not need to change the host for url generation.