### PR TITLE
Ensure the cart has been cleared on logout

### DIFF
--- a/resources/js/components/Cart/mixins/GetCart.js
+++ b/resources/js/components/Cart/mixins/GetCart.js
@@ -59,10 +59,6 @@ export default {
         },
     },
 
-    created() {
-        this.$root.$on('logout', () => this.clearCart())
-    },
-
     computed: {
         cart: function () {
             return this.getCart()

--- a/resources/js/stores/useMask.js
+++ b/resources/js/stores/useMask.js
@@ -23,7 +23,7 @@ export const refresh = async function () {
 }
 
 export const clear = async function () {
-    mask.value = {}
+    mask.value = ''
 }
 
 export default () => mask

--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -23,7 +23,7 @@ export const refresh = async function () {
         let response = await magentoUser.get('customers/me').finally(() => {
             isRefreshing = false
         })
-        userStorage.value = response.data
+        userStorage.value = !token.value ? {} : response.data
     } catch (error) {
         if (error.response.status == 401) {
             token.value = ''


### PR DESCRIPTION
The cart wouldn't get cleared properly since the redirect happened before the cart had been properly cleared.
We now await the clearing before we redirect in the next tick, so watchers have time to respond to changes.

I also noticed that the onLogout event listener was added per instance of interactWithUser, causing this function to be called multiple times. This has been prevented using memoization.

And just in case we now check the current state of tokens before setting the data to the received response, to deter possible race conditions.