### PR TITLE
Remove incorrect check for children_count & add global scopes

### DIFF
--- a/config/rapidez.php
+++ b/config/rapidez.php
@@ -32,6 +32,9 @@ return [
         'customer_fields_show',
     ],
 
+    // Query the categories in the autocomplete & hook into rapidez indexer with categories index
+    'autocomplete_categories' => false,
+
     // Additional searchable attributes with the search weight.
     'searchable' => [
         // 'attribute' => 4.0,

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -1,12 +1,63 @@
 <script>
 import { ReactiveBase, DataSearch } from '@appbaseio/reactivesearch-vue'
+import { useDebounceFn } from '@vueuse/core'
 
 Vue.use(ReactiveBase)
 Vue.use(DataSearch)
 
 export default {
+    props: {
+        additionals: Object,
+        debounce: {
+            type: Number,
+            default: 100,
+        }
+    },
+
     render() {
-        return this.$scopedSlots.default()
+        return this.$scopedSlots.default({
+            results: this.results,
+            searchAdditionals: this.searchAdditionals,
+            additionals: this.additionals,
+        })
+    },
+
+    data() {
+        return {
+            results: { count: 0 }
+        }
+    },
+
+    methods: {
+        searchAdditionals(query) {
+            if(!this.additionals) {
+                return;
+            }
+
+            this.results = { count: 0 }
+
+            Object.entries(this.additionals).forEach(([name, fields]) => {
+                let esQuery = {
+                    query: {
+                        multi_match: {
+                            query: query,
+                            fields: fields,
+                            fuzziness: 'AUTO',
+                        },
+                    },
+                }
+
+                axios({
+                    url: `${config.es_url}/${config.es_prefix}_${name}_${config.store}/_search`,
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    data: JSON.stringify(esQuery),
+                }).then((response) => {
+                    this.results[name] = response.data?.hits ?? []
+                    this.results.count += this.results[name].hits.length;
+                })
+            })
+        }
     },
 }
 </script>

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -9,8 +9,14 @@
     v-if="!$root.loadAutocomplete"
 >
 
-<autocomplete v-if="$root.loadAutocomplete" v-cloak>
-    <x-rapidez::reactive-base>
+<autocomplete
+    v-if="$root.loadAutocomplete"
+    v-cloak
+    @if(config('rapidez.autocomplete_categories'))
+        :additionals="{ categories: ['name^3', 'meta_description^1'] }"
+    @endif
+>
+    <x-rapidez::reactive-base slot-scope="{ results, searchAdditionals, additionals }">
         <data-search
             placeholder="@lang('Search')"
             v-on:value-selected="search"
@@ -22,29 +28,46 @@
             fuzziness="AUTO"
             :debounce="100"
             :size="9"
+            v-on:value-change="searchAdditionals($event)"
         >
             <div
                 slot="render"
                 slot-scope="{ downshiftProps: { isOpen }, data: suggestions }"
             >
-                <ul class="absolute left-2/3 right-auto bg-white border shadow-xl rounded-b-lg lg:rounded-t-lg w-screen sm:w-full lg:w-[960px] xl:ml-0 sm:left-1/2 transform -translate-x-1/2 xl:rounded-t-lg mt-px flex flex-wrap {{ config('rapidez.z-indexes.header-dropdowns') }}" v-if="isOpen && suggestions.length">
-                    <li
-                        class="flex w-1/2 sm:w-1/2 md:w-1/3 px-4 my-4"
-                        v-for="suggestion in suggestions"
-                        :key="suggestion.source._id"
-                    >
-                        <a :href="suggestion.source.url | url" class="flex flex-wrap w-full h-full" key="suggestion.source._id">
-                            <picture class="contents">
-                                <source :srcset="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" type="image/webp">
-                                <img :src="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail" class="object-contain lg:w-3/12 self-center" />
-                            </picture>
-                            <div class="px-2 flex flex-wrap flex-grow lg:w-1/2">
-                                <strong class="block hyphens w-full">@{{ suggestion.source.name }}</strong>
-                                <div class="self-end">@{{ suggestion.source.price | price }}</div>
-                            </div>
-                        </a>
-                    </li>
-                </ul>
+                <div
+                    class="absolute left-2/3 right-auto bg-white border shadow-xl rounded-b-lg lg:rounded-t-lg w-screen sm:w-full lg:w-[960px] xl:ml-0 sm:left-1/2 transform -translate-x-1/2 xl:rounded-t-lg mt-px flex flex-col {{ config('rapidez.z-indexes.header-dropdowns') }}"
+                    v-if="isOpen && (suggestions.length || results.count)"
+                >
+                    @if(config('rapidez.autocomplete_categories'))
+                        <ul class="flex flex-col gap-1 p-2 m-2 rounded-lg bg-gray-100" v-if="results.categories && results.categories.hits.length">
+                            <li class="font-bold">@lang('Categories')</li>
+                            <li v-for="hit in results.categories.hits" class="w-full">
+                                <a :href="hit._source.url" class="w-full hover:text-primary flex gap-1">
+                                    <span class="ml-2">@{{ hit._source.name }}</span>
+                                </a>
+                            </li>
+                        </ul>
+                    @endif
+
+                    <ul class="flex flex-wrap">
+                        <li
+                            class="flex w-1/2 sm:w-1/2 md:w-1/3 px-4 my-4"
+                            v-for="suggestion in suggestions"
+                            :key="suggestion.source._id"
+                        >
+                            <a :href="suggestion.source.url | url" class="flex flex-wrap w-full h-full" key="suggestion.source._id">
+                                <picture class="contents">
+                                    <source :srcset="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" type="image/webp">
+                                    <img :src="'/storage/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail" class="object-contain lg:w-3/12 self-center" />
+                                </picture>
+                                <div class="px-2 flex flex-wrap flex-grow lg:w-1/2">
+                                    <strong class="block hyphens w-full">@{{ suggestion.source.name }}</strong>
+                                    <div class="self-end">@{{ suggestion.source.price | price }}</div>
+                                </div>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </data-search>
     </x-rapidez::reactive-base>

--- a/src/Commands/IndexCategoriesCommand.php
+++ b/src/Commands/IndexCategoriesCommand.php
@@ -27,10 +27,9 @@ class IndexCategoriesCommand extends ElasticsearchIndexCommand
     public function getCategories()
     {
         return config('rapidez.models.category')::query()
-            ->select((new (config('rapidez.models.category')))->qualifyColumns(['entity_id', 'name', 'url_path', 'children_count']))
+            ->select((new (config('rapidez.models.category')))->qualifyColumns(['entity_id', 'name', 'url_path']))
             ->whereNotNull('url_key')
             ->whereNot('url_key', 'default-category')
-            ->where('children_count', '>', 0)
             ->get() ?? [];
     }
 }

--- a/src/Commands/IndexCategoriesCommand.php
+++ b/src/Commands/IndexCategoriesCommand.php
@@ -27,6 +27,7 @@ class IndexCategoriesCommand extends ElasticsearchIndexCommand
     public function getCategories()
     {
         return config('rapidez.models.category')::query()
+            ->withEventyGlobalScopes('index.categories.scopes')
             ->select((new (config('rapidez.models.category')))->qualifyColumns(['entity_id', 'name', 'url_path']))
             ->whereNotNull('url_key')
             ->whereNot('url_key', 'default-category')

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -14,6 +14,7 @@ use Rapidez\Core\Commands\IndexProductsCommand;
 use Rapidez\Core\Commands\InstallCommand;
 use Rapidez\Core\Commands\InstallTestsCommand;
 use Rapidez\Core\Commands\ValidateCommand;
+use Rapidez\Core\Events\IndexBeforeEvent;
 use Rapidez\Core\Events\ProductViewEvent;
 use Rapidez\Core\Facades\Rapidez as RapidezFacade;
 use Rapidez\Core\Http\Controllers\Fallback\CmsPageController;
@@ -59,6 +60,12 @@ class RapidezServiceProvider extends ServiceProvider
             InstallCommand::class,
             InstallTestsCommand::class,
         ]);
+
+        Event::listen(IndexBeforeEvent::class, function ($event) {
+            if (config('rapidez.autocomplete_categories')) {
+                $event->context->call('rapidez:index:categories');
+            }
+        });
 
         return $this;
     }


### PR DESCRIPTION
Children_count is the count of subcategories, not the count of products under this category. This means any category without subcategories doesn't get indexed right now, which is of course wrong.

I've also added the ability to extend the query with global scopes, as this could be quite useful.