### PR TITLE
Double check on localStorage.token existing

### DIFF
--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -8,7 +8,11 @@ let isRefreshing = false
 
 export const refresh = async function () {
     if (!token.value) {
-        userStorage.value = {}
+        if (localStorage.token) {
+            token.value = localStorage.token
+        } else {
+            userStorage.value = {}
+        }
         return false
     }
 


### PR DESCRIPTION
This is a quick fix for `useLocalStorage` not seeing a direct write to `localStorage.token`.

In my case, the issue arose stemming from https://github.com/rapidez/login-as-customer/blob/master/resources/js/components/LoginAsCustomer.vue#L45, causing the login-as-customer package to not work properly.

This can also be fixed by changing the login-as-customer package to import `useUser` and use `token.value`, however that is not backwards compatible with old rapidez.