### PR TITLE
Add race condition fallback in onOnce

### DIFF
--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -2,13 +2,8 @@ import { useLocalStorage, useMemoize } from '@vueuse/core'
 import { user, token, refresh as refreshUser, clear as clearUser } from '../../../stores/useUser'
 
 const onOnce = useMemoize(
-    (eventName, callback) => {
-        if(window.app?.$on) {
-            window.app.$on(eventName, callback)
-        } else {
-            // App isn't available yet, wait for vue to load in and then try.
-            window.setTimeout(() => window.app.$on(eventName, callback))
-        }
+    (self, eventName, callback) => {
+        self.$root.$on(eventName, callback)
     },
     {
         getKey: (eventName, callback) => eventName + callback.toString(),
@@ -116,7 +111,7 @@ export default {
     },
 
     created() {
-        onOnce('logout', this.onLogout)
+        onOnce(this, 'logout', this.onLogout)
     },
 
     asyncComputed: {

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -3,7 +3,12 @@ import { user, token, refresh as refreshUser, clear as clearUser } from '../../.
 
 const onOnce = useMemoize(
     (eventName, callback) => {
-        window.app.$on(eventName, callback)
+        if(window.app?.$on) {
+            window.app.$on(eventName, callback)
+        } else {
+            // App isn't available yet, wait for vue to load in and then try.
+            window.setTimeout(() => window.app.$on(eventName, callback))
+        }
     },
     {
         getKey: (eventName, callback) => eventName + callback.toString(),

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -3,7 +3,7 @@ import { user, token, refresh as refreshUser, clear as clearUser } from '../../.
 
 const onOnce = useMemoize(
     (self, eventName, callback) => {
-        self.$root.$on(eventName, callback)
+        self.$on(eventName, callback)
     },
     {
         getKey: (eventName, callback) => eventName + callback.toString(),
@@ -111,7 +111,7 @@ export default {
     },
 
     created() {
-        onOnce(this, 'logout', this.onLogout)
+        onOnce(this.$root, 'logout', this.onLogout)
     },
 
     asyncComputed: {


### PR DESCRIPTION
Right now, logging out usually doesn't work because the `logout` event isn't captured---`window.app.$on` appears to be unavailable available in the created hook, nor in the mounted hook, of a mixin like this.

This was the cleanest workaround I could come up with, this will wait until every other thread is completed by basically putting a new thread at the bottom of the stack.