### PR TITLE
Add slider loop option

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -93,8 +93,8 @@ export default {
 
         scroll() {
             this.position = this.vertical ? this.slider.scrollTop : this.slider.scrollLeft
-            this.showLeft = this.loop ? this.loop : this.position
-            this.showRight = this.loop ? this.loop : this.slider.offsetWidth + this.position < this.slider.scrollWidth - 1
+            this.showLeft = this.loop || this.position
+            this.showRight = this.loop || this.slider.offsetWidth + this.position < this.slider.scrollWidth - 1
         },
 
         autoScroll() {


### PR DESCRIPTION
This adds a loop capability to the slider. When you slide back to the first slide, the chunk of items is added to the front of the loop. So this also happens immediately when loading, because you start on the first slide.

Similarly, when you go to the last slide, the chunk is placed at the back of the slider. This is the same thing that, for example, Swiper also does for loop generation.