### PR TITLE
Swap directionKey & directionLabel

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -71,7 +71,7 @@ export default {
                         return [
                             ['asc', window.config.translations.asc],
                             ['desc', window.config.translations.desc],
-                        ].map(function ([directionLabel, directionKey]) {
+                        ].map(function ([directionKey, directionLabel]) {
                             return {
                                 label:
                                     window.config.translations.sorting?.[sorting.code]?.[directionKey] ??


### PR DESCRIPTION
Currently it tries to sort by the translated string in elasticsearch while displaying the non-translated string on the frontend. This should be swapped 😇 