### PR TITLE
Fix reactivity issue when uploading file in productoptions

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -145,7 +145,7 @@ export default {
             let file = event.target.files[0]
             let reader = new FileReader()
             reader.onerror = (error) => alert(error)
-            reader.onload = () => (this.customOptions[optionId] = 'FILE;' + file.name + ';' + reader.result)
+            reader.onload = () => Vue.set(this.customOptions, optionId, 'FILE;' + file.name + ';' + reader.result)
             reader.readAsDataURL(file)
         },
 


### PR DESCRIPTION
This caused a file field to not be updated in the computed property when it is replaced by a different one. Vue reactivity with objects/arrays tends to be fickle like that :) 