### PR TITLE
Fix for saving 'same_as_billing' is always set to 1

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -290,9 +290,7 @@ export default {
         shippingAddress: function () {
             let address = this.removeUnusedAddressInfo(this.$root.checkout.shipping_address)
 
-            if (this.checkout.hide_billing) {
-                address.same_as_billing = 1
-            }
+            address.same_as_billing = Number(this.checkout.hide_billing)
 
             return address
         },


### PR DESCRIPTION
This is the same as this fix: https://github.com/rapidez/core/pull/311, but to the master branch.