### PR TITLE
Fixed wrong step number event being emitted

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -37,7 +37,7 @@ export default {
         this.setCheckoutCredentialsFromDefaultUserAddresses()
         this.getShippingMethods()
         this.getTotalsInformation()
-        this.$root.$emit('checkout-step', 1)
+        this.$root.$emit('checkout-step', 2)
     },
 
     methods: {


### PR DESCRIPTION
This is also hardcoded and we need to get rid of hardcoded stuff, but for now this is a solution to incorrect dataLayer information.