### PR TITLE
Fix error when adding certain kinds of item to the cart

### DIFF
--- a/src/Models/QuoteItemOption.php
+++ b/src/Models/QuoteItemOption.php
@@ -25,6 +25,7 @@ class QuoteItemOption extends Model
         return Attribute::make(
             get: fn (string $value) => match ($this->code) {
                 'info_buyRequest' => json_decode($value),
+                'attributes'      => json_decode($value),
                 'option_ids'      => explode(',', $value),
                 default           => (function () use ($value) {
                     if (! $this->option) {
@@ -57,7 +58,7 @@ class QuoteItemOption extends Model
     protected function option(): Attribute
     {
         return Attribute::make(
-            get: fn () => config('rapidez.models.product_option')::find(explode('_', $this->code)[1])
+            get: fn () => config('rapidez.models.product_option')::find(explode('_', $this->code)[1] ?? '')
         )->shouldCache();
     }
 }

--- a/src/Models/QuoteItemOption.php
+++ b/src/Models/QuoteItemOption.php
@@ -58,7 +58,7 @@ class QuoteItemOption extends Model
     protected function option(): Attribute
     {
         return Attribute::make(
-            get: fn () => config('rapidez.models.product_option')::find(explode('_', $this->code)[1] ?? '')
+            get: fn () => config('rapidez.models.product_option')::find(explode('_', $this->code)[1] ?? $this->code)
         )->shouldCache();
     }
 }


### PR DESCRIPTION
...and avoid hard-erroring out of adding items in the future. In theory this should catch everything.

This broke the rapidez demo because it tried to split "attributes"