### PR TITLE
Remove useMemoize for event, use hacky solution instead

### DIFF
--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -1,14 +1,5 @@
-import { useLocalStorage, useMemoize } from '@vueuse/core'
+import { useLocalStorage } from '@vueuse/core'
 import { user, token, refresh as refreshUser, clear as clearUser } from '../../../stores/useUser'
-
-const onOnce = useMemoize(
-    (self, eventName, callback) => {
-        self.$on(eventName, callback)
-    },
-    {
-        getKey: (eventName, callback) => eventName + callback.toString(),
-    },
-)
 
 export default {
     methods: {
@@ -111,7 +102,9 @@ export default {
     },
 
     created() {
-        onOnce(this.$root, 'logout', this.onLogout)
+        if(!this.$root._events?.logout?.length || !this.$root._events.logout[0].name.includes('onLogout')) {
+            this.$root.$on('logout', this.onLogout)
+        }
     },
 
     asyncComputed: {

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -102,7 +102,7 @@ export default {
     },
 
     created() {
-        if(!this.$root._events?.logout?.length || !this.$root._events.logout[0].name.includes('onLogout')) {
+        if(!this.$root._events?.logout?.some(e => e.name.includes('onLogout'))) {
             this.$root.$on('logout', this.onLogout)
         }
     },


### PR DESCRIPTION
useMemoize caused a problem because the events got unloaded when switching pages (using Turbo), but the memory of useMemoize did not.

The workaround here is to just check if the event already exists, and if not, add it.