### PR TITLE
Prevent the indexer from indexing invisible products

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -59,7 +59,7 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
 
                 $productQuery->chunk($this->chunkSize, function ($products) use ($store, $bar, $categories, $showOutOfStock) {
                     $this->indexer->index($products, function ($product) use ($store, $categories, $showOutOfStock) {
-                        if ($product->visibility == 1) {
+                        if ($product->visibility === 1) {
                             return;
                         }
 

--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -59,6 +59,10 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
 
                 $productQuery->chunk($this->chunkSize, function ($products) use ($store, $bar, $categories, $showOutOfStock) {
                     $this->indexer->index($products, function ($product) use ($store, $categories, $showOutOfStock) {
+                        if ($product->visibility == 1) {
+                            return;
+                        }
+
                         if (! $showOutOfStock && ! $product->in_stock) {
                             return;
                         }


### PR DESCRIPTION
In theory, you'd think that magento should automatically remove products with visibility 1 from the flat table. However, there are still some circumstances where it does get put in there.

I'm uncertain about the exact specifics of this as I've had trouble consistently reproducing the different scenarios.