### PR TITLE
Implement basic version of input field component

### DIFF
--- a/resources/views/checkout/partials/address.blade.php
+++ b/resources/views/checkout/partials/address.blade.php
@@ -15,7 +15,7 @@
     </graphql>
 </div>
 
-<div class="contents" v-if="!$root.loggedIn || !checkout.{{ $type }}_address.customer_address_id">
+<div class="contents [&>div>input]:w-full" v-if="!$root.loggedIn || !checkout.{{ $type }}_address.customer_address_id">
     <div class="col-span-12 {{ Rapidez::config('customer/address/middlename_show', 0) ? 'sm:col-span-4' : 'sm:col-span-6' }}">
         <x-rapidez::input
             label="Firstname"
@@ -86,6 +86,7 @@
     </div>
     <div class="col-span-12 sm:col-span-6">
         <x-rapidez::country-select
+            class="w-full"
             name="{{ $type }}_country"
             label="Country"
             v-model="checkout.{{ $type }}_address.country_id"

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -4,6 +4,7 @@
             <h1 class="font-bold text-4xl text-center mb-5">@lang('Checkout')</h1>
 
             <x-rapidez::input
+                class="w-full"
                 :label="false"
                 name="email"
                 type="email"
@@ -13,6 +14,7 @@
                 required
             />
             <x-rapidez::input
+                class="w-full"
                 v-if="!emailAvailable"
                 :label="false"
                 class="mt-3"

--- a/resources/views/components/input-field/checkbox.blade.php
+++ b/resources/views/components/input-field/checkbox.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez::components.input-field.index', ['type' => 'checkbox'])

--- a/resources/views/components/input-field/index.blade.php
+++ b/resources/views/components/input-field/index.blade.php
@@ -1,0 +1,27 @@
+@props(['name', 'label', 'type' => 'text', 'disabled' => false, 'required' => false, 'placeholder' => false, 'dusk' => null])
+@slots(['input', 'label'])
+
+@php
+    $componentType = match($type) {
+        'select', 'textarea', 'checkbox' => 'rapidez::' . $type,
+        default => 'rapidez::input',
+    };
+    $labelClasses = match($type) {
+        'radio', 'checkbox' => '!flex-row',
+        default => '',
+    }
+@endphp
+
+<x-rapidez::label :attributes="$attributes->class($labelClasses)" :$label>
+    <x-dynamic-component :component="$componentType" :attributes="$input->attributes->merge([
+        'name' => $name ?? null,
+        'type' => $type,
+        'placeholder' => $placeholder,
+        'dusk' => $dusk,
+        'disabled' => $disabled,
+        'required' => $required,
+    ])">
+        {{ $input }}
+    </x-dynamic-component>
+    {{ $slot }}
+</x-rapidez::label>

--- a/resources/views/components/input-field/radio.blade.php
+++ b/resources/views/components/input-field/radio.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez::components.input-field.index', ['type' => 'radio'])

--- a/resources/views/components/input-field/select.blade.php
+++ b/resources/views/components/input-field/select.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez::components.input-field.index', ['type' => 'select'])

--- a/resources/views/components/input-field/textarea.blade.php
+++ b/resources/views/components/input-field/textarea.blade.php
@@ -1,0 +1,1 @@
+@include('rapidez::components.input-field.index', ['type' => 'textarea'])

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,19 +1,7 @@
-@props(['name', 'label', 'wrapperClass', 'labelClass'])
+@props(['name' => null])
 
-<div class="{{ $wrapperClass ?? '' }}">
-    @if (!isset($label) || (isset($label) && $label))
-        <x-rapidez::label for="{{ $name }}" class="{{ $labelClass ?? '' }}">
-            @lang($label ?? ucfirst($name))
-        </x-rapidez::label>
-    @endif
-    <input
-        {{ $attributes->merge([
-            'id' => $name,
-            'name' => $name,
-            'type' => 'text',
-            'placeholder' => __($placeholder ?? ''),
-            'dusk' => $attributes->get('v-bind:dusk') ? null : $name,
-            'class' => 'w-full py-2 px-3 border-border rounded !ring-0 focus:!border-inactive sm:text-sm text-neutral',
-        ]) }}
-    >
-</div>
+<input {{ $attributes->merge([
+    'class' => 'peer rounded border border-border bg-white py-4 px-5 text-sm outline-none !ring-0 transition-all placeholder:text-inactive disabled:bg-gray-50 disabled:cursor-not-allowed font-medium',
+    'id' => $name,
+    'name' => $name,
+]) }}>

--- a/resources/views/components/label.blade.php
+++ b/resources/views/components/label.blade.php
@@ -1,3 +1,8 @@
-<label {{ $attributes->merge(['class' => 'font-semibold text-inactive text-sm block mb-2']) }}>
+@slots(['label'])
+
+<label {{ $attributes->class('flex flex-col-reverse gap-y-2 text-sm relative') }}>
     {{ $slot }}
+    <span {{ $label->attributes->merge(['class' => "text-sm peer-required:after:content-['*']"]) }}>
+        {{ $label }}
+    </span>
 </label>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,17 +1,9 @@
-@props(['name', 'label', 'wrapperClass', 'labelClass'])
+@props(['name' => null])
 
-<div class="{{ $wrapperClass ?? '' }}">
-    @if(!isset($label) || (isset($label) && $label))
-        <x-rapidez::label for="{{ $name ?? '' }}" class="{{ $labelClass ?? '' }}">
-            @lang($label ?? ucfirst($name ?? ''))
-        </x-rapidez::label>
-    @endif
-    <select {{ $attributes->merge([
-        'id' => $name ?? null,
-        'name' => $name ?? null,
-        'dusk' => $attributes->get('v-bind:dusk') ? null : $name ?? null,
-        'class' => 'w-full py-2 pl-3 pr-8 border-gray-200 rounded focus:ring-neutral focus:border-neutral sm:text-sm'
-    ]) }}>
-        {{ $slot }}
-    </select>
-</div>
+<select {{ $attributes->merge([
+    'class' => 'peer rounded border border-border bg-white py-4 px-5 text-sm outline-none !ring-0 transition-all placeholder:text-inactive disabled:bg-gray-50 disabled:cursor-not-allowed font-medium',
+    'id' => $name,
+    'name' => $name,
+]) }}>
+    {{ $slot }}
+</select>

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,16 +1,9 @@
-@props(['name', 'label', 'wrapperClass'])
+@props(['name' => null])
 
-<div class="{{ $wrapperClass ?? '' }}">
-    @if (!isset($label) || (isset($label) && $label))
-        <x-rapidez::label for="{{ $name }}" class="{{ $labelClass ?? '' }} mb-2 block text-inactive">
-            @lang($label ?? ucfirst($name))
-        </x-rapidez::label>
-    @endif
-    <textarea {{ $attributes->merge([
-        'id' => $name,
-        'name' => $name,
-        'placeholder' => __($placeholder ?? ucfirst($name)),
-        'dusk' => $attributes->get('v-bind:dusk') ? null : $name,
-        'class' => 'w-full py-2 px-3 border-border rounded !ring-0 focus:!border-inactive sm:text-sm text-neutral',
-    ]) }}></textarea>
-</div>
+<textarea  {{ $attributes->merge([
+    'class' => 'peer rounded border border-border bg-white py-4 px-5 text-sm outline-none !ring-0 transition-all placeholder:text-inactive disabled:bg-gray-50 disabled:cursor-not-allowed font-medium',
+    'id' => $name,
+    'name' => $name,
+]) }}>
+    {{ $slot }}
+</textarea>

--- a/resources/views/product/partials/addtocart.blade.php
+++ b/resources/views/product/partials/addtocart.blade.php
@@ -28,7 +28,6 @@
                     </div>
                 </div>
                 <x-rapidez::select
-                    class="w-auto"
                     name="qty"
                     label="Quantity"
                     v-model="addToCartSlotProps.qty"


### PR DESCRIPTION
Draft PR until the new version is implemented everywhere

Note that this is not 1-to-1 backwards compatible with previous installations of rapidez, not sure what the best approach is as you probably don't want `w-full` as a standard class on every input.