### PR TITLE
Set `mutating` to false in a finally

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -163,7 +163,6 @@ export default {
                 }, 2500)
 
                 if (!this.redirect && this.notify.message) {
-                    this.mutating = false
                     Notify(this.notify.message, this.notify.type ?? 'success')
                 }
 
@@ -177,12 +176,12 @@ export default {
                             { once: true },
                         )
                     }
-                    this.mutating = false
                     Turbo.visit(window.url(this.redirect))
                 }
             } catch (e) {
-                this.mutating = false
                 Notify(window.config.translations.errors.wrong, 'warning')
+            } finally {
+                this.mutating = false
             }
         },
 


### PR DESCRIPTION
As it stands now, mutating will for some unknown reason not be set back to false if you don't have a redirect or a notification. Using a `finally` we can make sure this always works properly.