### PR TITLE
Add magentoGraphQL axios instance

### DIFF
--- a/resources/js/axios.js
+++ b/resources/js/axios.js
@@ -10,6 +10,13 @@ window.magentoUser = axios.create()
 window.magentoUser.defaults.baseURL = config.magento_url + '/rest/' + config.store_code + '/V1/'
 window.magentoUser.defaults.headers.common['Authorization'] = `Bearer ${localStorage.token}`
 
+window.magentoGraphQL = axios.create()
+window.magentoGraphQL.defaults.baseURL = config.magento_url
+if (localStorage.token) {
+    window.magentoGraphQL.defaults.headers.common['Authorization'] = `Bearer ${localStorage.token}`
+}
+window.magentoGraphQL.defaults.headers.common['Store'] = config.store_code
+
 // It's not possible to set global interceptors like headers
 // or the base url can; so we set them for all instances.
 // See: https://github.com/axios/axios/issues/510


### PR DESCRIPTION
This adds an instance of Axios that should be used for GraphQL requests. This allows for example the following to be used to send GraphQL requests to Magento:
```
magentoGraphQL.post('graphql', {
query:
`mutation StartTransaction(
    $order_id: String
    $return_url: String
) {
  paynlStartTransaction (
    order_id: $order_id
    return_url: $return_url
  ) {
    redirectUrl
  }
}`,
variables: {
    order_id: data.order.id,
    return_url: window.url('/paynl/finish')
}}).then(response => {
    window.location.replace(response.data.data.paynlStartTransaction.redirectUrl)
})
```

This now always includes a Store header by default and possibly an Authorization Bearer token if the user is logged in.
