### PR TITLE
Respect the position per category

### DIFF
--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -10,7 +10,7 @@
 
 <div class="min-h-screen">
     <listing
-        :additional-filters="{!! isset($query) ? "['query-filter', 'category']" : "['category']" !!}"
+        :additional-filters="{!! isset($query) ? "['query-filter', 'category', 'score-position']" : "['category', 'score-position']" !!}"
         :additional-sorting="[{
             label: window.config.translations.newest,
             dataField: 'created_at',
@@ -27,6 +27,26 @@
                         :show-filter="false"
                     ></reactive-component>
                 @endisset
+                <reactive-component
+                    component-id="score-position"
+                    :custom-query="function () {
+                        if (!window.config.category?.entity_id) {
+                            return;
+                        }
+
+                        return {
+                            query: {
+                                function_score: {
+                                    field_value_factor: {
+                                        field: 'positions.'+window.config.category.entity_id,
+                                        missing: 0
+                                    }
+                                }
+                            }
+                        }
+                    }"
+                    :show-filter="false"
+                ></reactive-component>
 
                 {{ $before ?? '' }}
                 @if ($slot->isEmpty())

--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -88,7 +88,7 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
                         $data['positions'] = $product->categoryProducts
                             ->pluck('position', 'category_id')
                             // Turn all positions positive
-                            ->mapWithKeys(fn($position, $category_id) => [$category_id => (($position * -1) + $maxPositions[$category_id])]);
+                            ->mapWithKeys(fn ($position, $category_id) => [$category_id => (($position * -1) + $maxPositions[$category_id])]);
 
                         return Eventy::filter('index.product.data', $data, $product);
                     });

--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -88,7 +88,7 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
                         $data['positions'] = $product->categoryProducts
                             ->pluck('position', 'category_id')
                             // Turn all positions positive
-                            ->mapWithKeys(fn ($position, $category_id) => [$category_id => (($position * -1) + $maxPositions[$category_id])]);
+                            ->mapWithKeys(fn ($position, $category_id) => [$category_id => $maxPositions[$category_id] - $position]);
 
                         return Eventy::filter('index.product.data', $data, $product);
                     });

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
@@ -106,6 +107,15 @@ class Product extends Model
             config('rapidez.models.product_option'),
             'product_id',
         );
+    }
+
+    public function categoryProducts(): HasMany
+    {
+        return $this
+            ->hasMany(
+                config('rapidez.models.category_product'),
+                'product_id',
+            );
     }
 
     public function rewrites(): HasMany


### PR DESCRIPTION
Reason i'm using the function_score instead of sorting on the field directly is so relevancy will still be used when no positions are given or positions are the same.