### PR TITLE
Clear cart storage

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -31,6 +31,7 @@ export const refresh = async function () {
     } catch (error) {
         if (error.response.status == 404) {
             mask.value = null
+            cartStorage.value = {}
             return false
         }
 
@@ -45,6 +46,7 @@ export const clear = async function () {
     await clearAddresses()
     await clearMask()
     await refresh()
+    cartStorage.value = {}
 }
 
 export const clearAddresses = async function () {

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -46,7 +46,6 @@ export const clear = async function () {
     await clearAddresses()
     await clearMask()
     await refresh()
-    cartStorage.value = {}
 }
 
 export const clearAddresses = async function () {


### PR DESCRIPTION
When an order is placed as a logged-in user, the shopping cart is not emptied. This fix ensures that it does get emptied after placing the order.