### PR TITLE
Improve slider performance by influencing scroll position for infinite scroll

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -44,7 +44,6 @@ export default {
             mounted: false,
             hover: false,
             direction: 1,
-            chunk: '',
             pause: () => {},
             resume: () => {},
         }
@@ -52,9 +51,12 @@ export default {
     mounted() {
         this.initSlider()
         useEventListener(this.slider, 'scroll', useThrottleFn(this.scroll, 150, true, true), { passive: true })
+        if (this.loop) {
+            useEventListener(this.slider, 'scrollend', this.scrollend, { passive: true })
+        }
         this.$nextTick(() => {
             if (this.loop) {
-                this.chunk = this.slider.cloneNode(true)
+                this.initLoop()
             }
             this.slider.dispatchEvent(new CustomEvent('scroll'))
             this.mounted = true
@@ -65,6 +67,29 @@ export default {
     methods: {
         initSlider() {
             this.slider = this.$scopedSlots.default()[0].context.$refs[this.reference]
+        },
+        initLoop() {
+            if(!this.loop) {
+                return;
+            }
+
+            const slides = Array.from(this.slides)
+            if (!slides.length) {
+                return;
+            }
+            let firstChild = this.slider.firstChild;
+
+            for (let slide of slides) {
+                let startClone = this.slider.insertBefore(slide.cloneNode(true), firstChild)
+                startClone.dataset.clone = true
+                startClone.dataset.position = 'start'
+
+                let endClone = this.slider.appendChild(slide.cloneNode(true))
+                endClone.dataset.clone = true
+                endClone.dataset.position = 'end'
+            }
+
+            this.slider.dispatchEvent(new CustomEvent('scrollend'))
         },
         initAutoPlay() {
             if (!this.autoplay) {
@@ -85,12 +110,20 @@ export default {
             this.showLeft = this.loop || this.position
             this.showRight = this.loop || this.slider.offsetWidth + this.position < this.slider.scrollWidth - 1
         },
+        scrollend(event) {
+            let scrollPosition = this.vertical ? event.target.scrollTop : event.target.scrollLeft;
+            if (scrollPosition < this.sliderStart) {
+                this.slider.scrollTo({[this.vertical ? 'top' : 'left']: scrollPosition + this.sliderStart, behavior: 'instant'})
+            } else if (scrollPosition > this.sliderEnd) {
+                this.slider.scrollTo({[this.vertical ? 'top' : 'left']: scrollPosition - this.sliderStart, behavior: 'instant'})
+            }
+        },
         autoScroll() {
             if (this.slidesTotal == 1) {
                 return
             }
             let next = this.currentSlide + this.direction
-            if (next >= this.slidesTotal || next < 0) {
+            if ((next >= this.slidesTotal && !this.loop) || next < 0) {
                 if (this.bounce) {
                     this.direction = -this.direction
                     next = this.currentSlide + this.direction
@@ -101,21 +134,11 @@ export default {
             this.navigate(next)
         },
         navigate(index) {
+            index = this.loop ? index + this.slides.length : index;
+
             this.vertical
                 ? this.slider.scrollTo(0, this.slider.children[index]?.offsetTop)
-                : this.slider.scrollTo(this.slider.children[0]?.offsetWidth * index, 0)
-        },
-        handleLoop() {
-            if (this.currentSlide + 1 === this.slidesTotal - 1) {
-                Array.from(this.chunk.children).forEach((child) => {
-                    this.slider.appendChild(child.cloneNode(true))
-                })
-            }
-            if (this.currentSlide < 1) {
-                Array.from(this.chunk.children).forEach((child) => {
-                    this.slider.insertBefore(child.cloneNode(true), this.slider.firstChild)
-                })
-            }
+                : this.slider.scrollTo(this.slider.children[index]?.offsetLeft, 0)
         },
     },
     watch: {
@@ -128,9 +151,6 @@ export default {
         },
         currentSlide() {
             this.initSlider()
-            if (this.loop) {
-                this.handleLoop()
-            }
         },
     },
     computed: {
@@ -138,8 +158,7 @@ export default {
             if (!this.mounted) {
                 return 0
             }
-
-            return Math.round(this.position / this.childSpan)
+            return Math.round(this.position / this.childSpan) % this.slides.length;
         },
         slidesVisible() {
             if (!this.mounted) {
@@ -169,8 +188,26 @@ export default {
                 return 0
             }
 
-            return (this.slider.children?.length ?? 1) - this.slidesVisible + 1
+            return (this.slides?.length ?? 1) - (this.loop ? 0 : this.slidesVisible - 1)
         },
+        slides()
+        {
+            return this.slider.querySelectorAll(':scope > :not([data-clone=true])')
+        },
+        sliderStart()
+        {
+            return this.vertical ? this.slides[0].offsetTop : this.slides[0].offsetLeft
+        },
+        sliderEnd()
+        {
+            let lastChild = this.slides[this.slides.length - 1];
+
+            if (this.vertical) {
+                return lastChild.offsetTop + lastChild.offsetHeight;
+            }
+
+            return lastChild.offsetLeft + lastChild.offsetWidth;
+        }
     },
 }
 </script>

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -69,15 +69,15 @@ export default {
             this.slider = this.$scopedSlots.default()[0].context.$refs[this.reference]
         },
         initLoop() {
-            if(!this.loop) {
-                return;
+            if (!this.loop) {
+                return
             }
 
             const slides = Array.from(this.slides)
             if (!slides.length) {
-                return;
+                return
             }
-            let firstChild = this.slider.firstChild;
+            let firstChild = this.slider.firstChild
 
             for (let slide of slides) {
                 let startClone = this.slider.insertBefore(slide.cloneNode(true), firstChild)
@@ -111,11 +111,11 @@ export default {
             this.showRight = this.loop || this.slider.offsetWidth + this.position < this.slider.scrollWidth - 1
         },
         scrollend(event) {
-            let scrollPosition = this.vertical ? event.target.scrollTop : event.target.scrollLeft;
+            let scrollPosition = this.vertical ? event.target.scrollTop : event.target.scrollLeft
             if (scrollPosition < this.sliderStart) {
-                this.slider.scrollTo({[this.vertical ? 'top' : 'left']: scrollPosition + this.sliderStart, behavior: 'instant'})
+                this.slider.scrollTo({ [this.vertical ? 'top' : 'left']: scrollPosition + this.sliderStart, behavior: 'instant' })
             } else if (scrollPosition > this.sliderEnd) {
-                this.slider.scrollTo({[this.vertical ? 'top' : 'left']: scrollPosition - this.sliderStart, behavior: 'instant'})
+                this.slider.scrollTo({ [this.vertical ? 'top' : 'left']: scrollPosition - this.sliderStart, behavior: 'instant' })
             }
         },
         autoScroll() {
@@ -134,7 +134,7 @@ export default {
             this.navigate(next)
         },
         navigate(index) {
-            index = this.loop ? index + this.slides.length : index;
+            index = this.loop ? index + this.slides.length : index
 
             this.vertical
                 ? this.slider.scrollTo(0, this.slider.children[index]?.offsetTop)
@@ -158,7 +158,7 @@ export default {
             if (!this.mounted) {
                 return 0
             }
-            return Math.round(this.position / this.childSpan) % this.slides.length;
+            return Math.round(this.position / this.childSpan) % this.slides.length
         },
         slidesVisible() {
             if (!this.mounted) {
@@ -190,24 +190,21 @@ export default {
 
             return (this.slides?.length ?? 1) - (this.loop ? 0 : this.slidesVisible - 1)
         },
-        slides()
-        {
+        slides() {
             return this.slider.querySelectorAll(':scope > :not([data-clone=true])')
         },
-        sliderStart()
-        {
+        sliderStart() {
             return this.vertical ? this.slides[0].offsetTop : this.slides[0].offsetLeft
         },
-        sliderEnd()
-        {
-            let lastChild = this.slides[this.slides.length - 1];
+        sliderEnd() {
+            let lastChild = this.slides[this.slides.length - 1]
 
             if (this.vertical) {
-                return lastChild.offsetTop + lastChild.offsetHeight;
+                return lastChild.offsetTop + lastChild.offsetHeight
             }
 
-            return lastChild.offsetLeft + lastChild.offsetWidth;
-        }
+            return lastChild.offsetLeft + lastChild.offsetWidth
+        },
     },
 }
 </script>


### PR DESCRIPTION
Because cloneNode was used every time a scroll occurred a ton of DOM elements would be created every second.

DOM operations are quite heavy on the browser, thus we only create the copies we need and create the illusion of infinite scroll by resetting the scroll position.

As a bonus the navigation buttons and positions work as intended