### PR TITLE
Add config option for category positions

### DIFF
--- a/config/rapidez/indexer.php
+++ b/config/rapidez/indexer.php
@@ -19,4 +19,9 @@ return [
     'additional_filters' => [
         // eav_attribute attribute_code. e.g. brand
     ],
+
+    // Index the positions per category
+    // This option enables the magento functionality where products are sortable per category.
+    // You might want to disable this if you have a lot of categories, as each category results in a new mapping being created.
+    'category_positions' => true,
 ];

--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -85,10 +85,12 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
 
                         $data = $this->withCategories($data, $categories);
 
-                        $data['positions'] = $product->categoryProducts
-                            ->pluck('position', 'category_id')
-                            // Turn all positions positive
-                            ->mapWithKeys(fn ($position, $category_id) => [$category_id => $maxPositions[$category_id] - $position]);
+                        if (config('rapidez.indexer.category_positions')) {
+                            $data['positions'] = $product->categoryProducts
+                                ->pluck('position', 'category_id')
+                                // Turn all positions positive
+                                ->mapWithKeys(fn ($position, $category_id) => [$category_id => $maxPositions[$category_id] - $position]);
+                        }
 
                         return Eventy::filter('index.product.data', $data, $product);
                     });


### PR DESCRIPTION
Ran into an issue with a certain project where we ended up having more than 1000 individual mappings in elasticsearch, because this creates an individual mapping for each category---almost two thirds of the mapping table was just category positions.