### PR TITLE
Fix cross-sells field

### DIFF
--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -65,7 +65,7 @@
                     </div>
                 </div>
 
-                <x-rapidez::productlist value="cart.cross_sells" title="More choices to go with your product" field="id" />
+                <x-rapidez::productlist value="cart.cross_sells" title="More choices to go with your product" field="entity_id" />
             </div>
             <div v-else>
                 @lang('You don\'t have anything in your cart.')


### PR DESCRIPTION
While we stopped aliasing `entity_id` to `id`, this one seems to have been forgotten about.