### PR TITLE
Only add super attributes if they're also in the flat table

### DIFF
--- a/src/Casts/QuoteItems.php
+++ b/src/Casts/QuoteItems.php
@@ -14,7 +14,7 @@ class QuoteItems implements CastsAttributes
         // which joins the catalog_product_super_attribute_label table.
         $attributeModel = config('rapidez.models.attribute');
         $superAttributes = Arr::pluck($attributeModel::getCachedWhere(function ($attribute) {
-            return $attribute['super'];
+            return $attribute['super'] && $attribute['flat'];
         }), 'name', 'id');
 
         $items = json_decode($value);

--- a/src/Listeners/MagentoSettingsHealthcheck.php
+++ b/src/Listeners/MagentoSettingsHealthcheck.php
@@ -54,7 +54,7 @@ class MagentoSettingsHealthcheck
             ];
         }
 
-        $superAttributesCount = count($attributeModel::getCachedWhere(fn ($attribute) => $attribute['super']));
+        $superAttributesCount = count($attributeModel::getCachedWhere(fn ($attribute) => $attribute['super'] && $attribute['flat']));
         $joinCount = ($superAttributesCount * 2) + (count($nonFlatAttributes) * 3) + 4;
 
         if ($joinCount > 58) {

--- a/src/Models/Scopes/Product/WithProductChildrenScope.php
+++ b/src/Models/Scopes/Product/WithProductChildrenScope.php
@@ -16,7 +16,7 @@ class WithProductChildrenScope implements Scope
         $attributeModel = config('rapidez.models.attribute');
 
         $superAttributes = Arr::pluck($attributeModel::getCachedWhere(function ($attribute) {
-            return $attribute['super'];
+            return $attribute['super'] && $attribute['flat'];
         }), 'code');
 
         $grammar = $builder->getQuery()->getGrammar();

--- a/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
@@ -14,7 +14,7 @@ class WithProductSuperAttributesScope implements Scope
     {
         $attributeModel = config('rapidez.models.attribute');
         $superAttributes = Arr::pluck($attributeModel::getCachedWhere(function ($attribute) {
-            return $attribute['super'];
+            return $attribute['super'] && $attribute['flat'];
         }), 'code', 'id');
 
         $grammar = $builder->getQuery()->getGrammar();

--- a/src/Models/Traits/Product/CastSuperAttributes.php
+++ b/src/Models/Traits/Product/CastSuperAttributes.php
@@ -10,7 +10,7 @@ trait CastSuperAttributes
     {
         $attributeModel = config('rapidez.models.attribute');
         $superAttributes = Arr::pluck($attributeModel::getCachedWhere(function ($attribute) {
-            return $attribute['super'];
+            return $attribute['super'] && $attribute['flat'];
         }), 'code');
 
         foreach ($superAttributes as $superAttribute) {


### PR DESCRIPTION
It's possible to turn an attribute into a super attribute without having it added to the flat table. This causes the query to break, as the super attributes assume that it's in the flat table.

This should only happen if something is configured wrong, so maybe it's still an idea to check and throw a nice descriptive warning or error when this happens?