### PR TITLE
Add event for when setStore had been executed

### DIFF
--- a/src/Http/Middleware/DetermineAndSetShop.php
+++ b/src/Http/Middleware/DetermineAndSetShop.php
@@ -18,7 +18,6 @@ class DetermineAndSetShop
         $store = Rapidez::getStore($storeCode ?: config('rapidez.store'));
 
         Rapidez::setStore($store);
-        config()->set('frontend.base_url', url('/'));
 
         return $next($request);
     }

--- a/src/Rapidez.php
+++ b/src/Rapidez.php
@@ -5,6 +5,7 @@ namespace Rapidez\Core;
 use Illuminate\Routing\RouteAction;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
 use Rapidez\Core\Models\Store;
 
 class Rapidez
@@ -106,6 +107,9 @@ class Rapidez
         config()->set('rapidez.website_code', $store['website_code']);
         config()->set('rapidez.group', $store['group_id']);
         config()->set('rapidez.root_category_id', $store['root_category_id']);
+        config()->set('frontend.base_url', url('/'));
+
+        Event::dispatch('rapidez:store-set', [$store]);
     }
 
     public function withStore(Store|array|callable|int|string $store, callable $callback, ...$args)


### PR DESCRIPTION
At the moment if any other functions need to be excecuted once we know the current store we use a middleware and assume or force the middlewares to run in the correct order.
This is prone to errors when the execution order is different, or the setStore function has been executed somewhere other than the DetermineAndSetShop middleware

This event allows us to hook and update config during **any** calls to the setStore function, be that in a middleware or in a command

Example usage, forcing a custom root url:
```php
        Event::listen('rapidez:store-set', function ($store) {
            $baseUrl = config('rapidez.url.' . $store['code']);
            if ($baseUrl) {
                URL::forceRootUrl($baseUrl);
                config()->set('frontend.base_url', url('/'));
            }
        });
```