### PR TITLE
Exclude register themes when running from console

### DIFF
--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -150,6 +150,10 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function registerThemes(): self
     {
+        if(app()->runningInConsole()) {
+            return $this;
+        }
+        
         $path = config('rapidez.frontend.themes.' . request()->server('MAGE_RUN_CODE', request()->has('_store') && ! app()->isProduction() ? request()->get('_store') : 'default'), false);
 
         if (! $path) {


### PR DESCRIPTION
Exclude registerThemes from running in console to prevent caching the wrong theme paths for a specific store code.