### PR TITLE
Fall back to other default address if only one is set

### DIFF
--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -76,8 +76,8 @@ export default {
 
         setCheckoutCredentialsFromDefaultUserAddresses() {
             if (this.$root && this.$root.loggedIn) {
-                this.setCustomerAddressByAddressId('shipping', this.$root.user.default_shipping)
-                this.setCustomerAddressByAddressId('billing', this.$root.user.default_billing)
+                this.setCustomerAddressByAddressId('shipping', this.$root.user.default_shipping ?? this.$root.user.default_billing)
+                this.setCustomerAddressByAddressId('billing', this.$root.user.default_billing ?? this.$root.user.default_shipping)
             }
         },
 


### PR DESCRIPTION
This caused issues in the checkout when only default billing or only default shipping were set.