### PR TITLE
Always set step in checkout success to success step

### DIFF
--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -29,6 +29,11 @@ export default {
         this.token ??= localStorage.token
         this.mask ??= localStorage.mask
 
+        let successStep = this.$root.config.checkout_steps[config.store_code]?.indexOf('success')
+        if (successStep > 0) {
+            this.$root.checkout.step = successStep
+        }
+
         this.refreshOrder()
         this.clearCart()
     },

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -29,7 +29,7 @@ export default {
         this.token ??= localStorage.token
         this.mask ??= localStorage.mask
 
-        let successStep = this.$root.config.checkout_steps[config.store_code]?.indexOf('success')
+        let successStep = this.$root.config.checkout_steps[this.$root.config.store_code]?.indexOf('success')
         if (successStep > 0) {
             this.$root.checkout.step = successStep
         }


### PR DESCRIPTION
This is relevant for when external payment providers are used---the checkout step value is lost, causing it to say "step 1 out of X".

We can reasonably assume the success step is always step 4 as it's forced this way with the rest API stuff, but I've overengineered it anyway to not have it be hardcoded.