### PR TITLE
Fix usage of whitespace tokenizer

### DIFF
--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -78,7 +78,7 @@ class ElasticsearchIndexer
                 ->toArray();
 
             data_set($settings, 'index.analysis.filter.synonym', ['type' => 'synonym', 'synonyms' => $synonyms]);
-            data_set($settings, 'index.analysis.analyzer.synonym', ['tokenizer' => 'lowercase', 'filter' => ['synonym']]);
+            data_set($settings, 'index.analysis.analyzer.synonym', ['tokenizer' => 'standard', 'filter' => ['synonym']]);
 
             foreach ($synonymsFor as $property) {
                 data_set($mapping, 'properties.' . $property . '.type', 'text');

--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -78,7 +78,7 @@ class ElasticsearchIndexer
                 ->toArray();
 
             data_set($settings, 'index.analysis.filter.synonym', ['type' => 'synonym', 'synonyms' => $synonyms]);
-            data_set($settings, 'index.analysis.analyzer.synonym', ['tokenizer' => 'whitespace', 'filter' => ['synonym']]);
+            data_set($settings, 'index.analysis.analyzer.synonym', ['tokenizer' => 'lowercase', 'filter' => ['synonym']]);
 
             foreach ($synonymsFor as $property) {
                 data_set($mapping, 'properties.' . $property . '.type', 'text');


### PR DESCRIPTION
Makes it a little more reliable, as the whitespace tokenizer made synonyms case sensitive.

Could also use the standard tokenizer, shouldn't really make a difference here.

[Tokenizer reference](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/analysis-tokenizers.html)