### PR TITLE
Watch currentShippingMethod instead of shipping_method

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -331,7 +331,7 @@ export default {
         'checkout.billing_address.customer_address_id': function (customerAddressId) {
             this.setCustomerAddressByAddressId('billing', customerAddressId)
         },
-        'checkout.shipping_method': function () {
+        'currentShippingMethod': function () {
             this.selectShippingMethod()
         },
         'checkout.payment_method': function () {

--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -331,7 +331,7 @@ export default {
         'checkout.billing_address.customer_address_id': function (customerAddressId) {
             this.setCustomerAddressByAddressId('billing', customerAddressId)
         },
-        'currentShippingMethod': function () {
+        currentShippingMethod: function () {
             this.selectShippingMethod()
         },
         'checkout.payment_method': function () {


### PR DESCRIPTION
CurrentShippingMethod will update on changes in `checkout.shipping_methods` and `checkout.shipping_method`
Because `checkout.shipping_method` was being watched while `currentShippingMethod` is being used in `selectShippingMethod()`, a race condition could occur where `checkout.shipping_methods` was empty while `checkout.shipping_method` was filled. 

Resulting in `currentShippingMethod.carrier_code` throwing an error breaking the `shipping-information` API request.

By watching `currentShippingMethod` we are also waiting for the `shipping_methods` to be filled before attempting to update the shipping method