### PR TITLE
Use lowercase & asciifolding filters in default analyzer & in synonym analyzer

### DIFF
--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -91,6 +91,12 @@ class ElasticsearchIndexer
             foreach ($synonymsFor as $property) {
                 data_set($mapping, 'properties.' . $property . '.type', 'text');
                 data_set($mapping, 'properties.' . $property . '.analyzer', 'synonym');
+                data_set($mapping, 'properties.' . $property . '.fields', [
+                    'keyword' => [
+                        'type' => 'keyword',
+                        'ignore_above' => 256,
+                    ]
+                ]);
             }
         }
 

--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -93,9 +93,9 @@ class ElasticsearchIndexer
                 data_set($mapping, 'properties.' . $property . '.analyzer', 'synonym');
                 data_set($mapping, 'properties.' . $property . '.fields', [
                     'keyword' => [
-                        'type' => 'keyword',
+                        'type'         => 'keyword',
                         'ignore_above' => 256,
-                    ]
+                    ],
                 ]);
             }
         }

--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -71,6 +71,11 @@ class ElasticsearchIndexer
 
     public function prepare(string $indexName, array $mapping = [], array $settings = [], array $synonymsFor = []): void
     {
+        data_set($settings, 'index.analysis.analyzer.default', [
+            'filter' => ['lowercase', 'asciifolding'],
+            'tokenizer' => 'standard',
+        ]);
+
         if (count($synonymsFor)) {
             $synonyms = config('rapidez.models.search_synonym')::whereIn('store_id', [0, config('rapidez.store')])
                 ->get()
@@ -78,7 +83,10 @@ class ElasticsearchIndexer
                 ->toArray();
 
             data_set($settings, 'index.analysis.filter.synonym', ['type' => 'synonym', 'synonyms' => $synonyms]);
-            data_set($settings, 'index.analysis.analyzer.synonym', ['tokenizer' => 'standard', 'filter' => ['synonym']]);
+            data_set($settings, 'index.analysis.analyzer.synonym', [
+                'filter' => ['lowercase', 'asciifolding', 'synonym'],
+                'tokenizer' => 'standard',
+            ]);
 
             foreach ($synonymsFor as $property) {
                 data_set($mapping, 'properties.' . $property . '.type', 'text');


### PR DESCRIPTION
- `lowercase` filter makes the searching case insensitive
- `asciifolding` allows the search to ignore accents on letters and other weird unicode stuff