### PR TITLE
Support catalog urls

### DIFF
--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -2,6 +2,7 @@
 
 @section('title', $category->meta_title ?: $category->name)
 @section('description', $category->meta_description)
+@section('canonical', url($category->url))
 @include('rapidez::layouts.partials.head.hreflang', ['alternates' => $category->alternates])
 
 @section('content')

--- a/resources/views/product/overview.blade.php
+++ b/resources/views/product/overview.blade.php
@@ -2,6 +2,7 @@
 
 @section('title', $product->meta_title ?: $product->name)
 @section('description', $product->meta_description)
+@section('canonical', url($product->url))
 @include('rapidez::layouts.partials.head.hreflang', ['alternates' => $product->alternates])
 
 @section('content')

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ Route::get('robots.txt', fn () => response(Rapidez::config('design/search_engine
 Route::middleware('web')->group(function () {
     Route::get('catalog/product/view/id/{productId}', [config('rapidez.routing.controllers.product'), 'show']);
     Route::get('catalog/category/view/id/{categoryId}', [config('rapidez.routing.controllers.category'), 'show']);
-    
+
     Route::view('cart', 'rapidez::cart.overview')->name('cart');
     Route::view('checkout', 'rapidez::checkout.overview')->name('checkout');
     Route::get('search', SearchController::class)->name('search');

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,9 @@ Route::get('robots.txt', fn () => response(Rapidez::config('design/search_engine
     ->header('Content-Type', 'text/plain; charset=UTF-8'));
 
 Route::middleware('web')->group(function () {
+    Route::get('catalog/product/view/id/{productId}', [config('rapidez.routing.controllers.product'), 'show']);
+    Route::get('catalog/category/view/id/{categoryId}', [config('rapidez.routing.controllers.category'), 'show']);
+    
     Route::view('cart', 'rapidez::cart.overview')->name('cart');
     Route::view('checkout', 'rapidez::checkout.overview')->name('checkout');
     Route::get('search', SearchController::class)->name('search');

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -58,7 +58,7 @@ class Category extends Model
 
     public function getUrlAttribute(): string
     {
-        return '/' . $this->url_path;
+        return '/' . ($this->url_path ? $this->url_path : 'catalog/category/view/id/' . $this->entity_id);
     }
 
     public function subcategories()

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -198,7 +198,7 @@ class Product extends Model
     {
         $configModel = config('rapidez.models.config');
 
-        return '/' . $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html');
+        return '/' . ($this->url_key ? $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
     }
 
     public function getImagesAttribute(): array


### PR DESCRIPTION
Magento has these urls built in by default, and these are always available in Magento.
When no url rewrite has been made for the specified product or category Magento will automatically publish the `catalog/<x>/view/id/<id>` url to the sitemap. Causing 404s to be found on the sitemap prevously