### PR TITLE
Reduce the usage of hardcoded step numbers

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -5,3 +5,7 @@ Vue.prototype.scrollToElement = (selector) => {
         behavior: 'smooth',
     })
 }
+
+Vue.prototype.getCheckoutStep = (stepName) => {
+    return config.checkout_steps[config.store_code]?.indexOf(stepName)
+}

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -28,7 +28,7 @@ export default {
     },
 
     created() {
-        let successStep = this.$root.config.checkout_steps[this.$root.config.store_code]?.indexOf('success')
+        let successStep = this.$root.getCheckoutStep('success')
         if (successStep > 0) {
             this.$root.checkout.step = successStep
         }

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -67,7 +67,7 @@ export default {
                 .then((response) => {
                     if ((this.emailAvailable = response.data)) {
                         this.$root.guestEmail = this.email
-                        this.$root.checkout.step = 2
+                        this.$root.checkout.step = this.nextStep
                     } else {
                         this.$nextTick(function () {
                             this.$scopedSlots.default()[0].context.$refs.password.focus()
@@ -86,11 +86,19 @@ export default {
 
         successfulLogin() {
             if (this.checkoutLogin) {
-                this.$root.checkout.step = 2
+                this.$root.checkout.step = this.nextStep
             } else if (this.redirect) {
                 Turbo.visit(window.url(this.redirect))
             }
         },
     },
+    computed: {
+        loginStep: function () {
+            return config.checkout_steps[config.store_code]?.indexOf('login')
+        },
+        nextStep: function () {
+            return this.loginStep + 1
+        }
+    }
 }
 </script>

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -98,7 +98,7 @@ export default {
         },
         nextStep: function () {
             return this.loginStep + 1
-        }
-    }
+        },
+    },
 }
 </script>

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -94,7 +94,7 @@ export default {
     },
     computed: {
         loginStep: function () {
-            return config.checkout_steps[config.store_code]?.indexOf('login')
+            return this.$root.getCheckoutStep('login')
         },
         nextStep: function () {
             return this.loginStep + 1

--- a/resources/views/checkout/overview.blade.php
+++ b/resources/views/checkout/overview.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         <checkout v-cloak v-slot="{ checkout, cart, hasItems, save, goToStep }">
             <div>
-                <template v-if="checkout.step !== 4">
+                <template v-if="checkout.step < config.checkout_steps[config.store_code]?.indexOf('success')">
                     @include('rapidez::checkout.partials.progressbar')
                 </template>
                 <div v-if="checkout.step == 1 && hasItems">
@@ -30,7 +30,7 @@
                     </div>
                 </div>
 
-                <div v-if="checkout.step == 4">
+                <div v-if="checkout.step == config.checkout_steps[config.store_code]?.indexOf('success')">
                     @include('rapidez::checkout.steps.success')
                 </div>
             </div>

--- a/resources/views/checkout/overview.blade.php
+++ b/resources/views/checkout/overview.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         <checkout v-cloak v-slot="{ checkout, cart, hasItems, save, goToStep }">
             <div>
-                <template v-if="checkout.step < config.checkout_steps[config.store_code]?.indexOf('success')">
+                <template v-if="checkout.step < getCheckoutStep('success')">
                     @include('rapidez::checkout.partials.progressbar')
                 </template>
                 <div v-if="checkout.step == 1 && hasItems">
@@ -30,7 +30,7 @@
                     </div>
                 </div>
 
-                <div v-if="checkout.step == config.checkout_steps[config.store_code]?.indexOf('success')">
+                <div v-if="checkout.step == getCheckoutStep('success')">
                     @include('rapidez::checkout.steps.success')
                 </div>
             </div>


### PR DESCRIPTION
This new way of getting the next step number allows us to place the login step on the same step as another simply by extending the Login.vue and overriding the computed nextStep function