### PR TITLE
Unmake positions flattened

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -41,9 +41,6 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
                     'grouped' => [
                         'type' => 'flattened',
                     ],
-                    'positions' => [
-                        'type' => 'flattened',
-                    ],
                 ],
             ]), Eventy::filter('index.product.settings', []), ['name']);
             try {


### PR DESCRIPTION
This breaks the default magento store for some reason, maybe it has an attribute named `positions`? It doesn't seem to be a problem elsewhere.

If that's the issue, we could also possibly just rename `positions` to something else instead, like `category_positions`.