### PR TITLE
Add config change event

### DIFF
--- a/src/Events/ConfigChangeEvent.php
+++ b/src/Events/ConfigChangeEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\Core\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class ConfigChangeEvent
+{
+    use Dispatchable;
+
+    public $config;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+}

--- a/src/Jobs/CheckConfigJob.php
+++ b/src/Jobs/CheckConfigJob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rapidez\Core\Jobs;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Event;
+use Rapidez\Core\Events\ConfigChangeEvent;
+
+class CheckConfigJob
+{
+    use Dispatchable;
+
+    public function handle(): void
+    {
+        config('rapidez.models.config')::withoutGlobalScopes()
+            ->where('updated_at', '>', Carbon::now()->subHour())
+            ->get()
+            ->each(fn ($change) => Event::dispatch(ConfigChangeEvent::class, $change));
+    }
+}


### PR DESCRIPTION
There are a few rare cases where, for example, you want to clear some Rapidez cache when some config is changed in Magento. If we run a job hourly, we can look at the `updated_at` field and see if any configurations have been changed within the past hour. (This would obviously also be put into the docs if this is the solution we go for)

Another option would be to keep track of the last time this job was run in the cache, and then using that to compare. However if you ever clear cache (especially in response to some config change), you would run into problems.

There's already an event that gets sent out within Magento whenever you change a config setting, but I don't think there's any feasible way for us to hook into that specific event?