### PR TITLE
Ensure no current shipping method does not break

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -112,8 +112,8 @@ export default {
                 }
 
                 if (!hasOnlyVirtualItems.value) {
-                    addressInformation.shipping_carrier_code = this.currentShippingMethod.carrier_code
-                    addressInformation.shipping_method_code = this.currentShippingMethod.method_code
+                    addressInformation.shipping_carrier_code = this.currentShippingMethod?.carrier_code
+                    addressInformation.shipping_method_code = this.currentShippingMethod?.method_code
                 }
 
                 if (this.checkout.create_account && this.checkout.password) {
@@ -186,8 +186,8 @@ export default {
                 addressInformation: {
                     shipping_address: this.shippingAddress,
                     billing_address: this.billingAddress,
-                    shipping_carrier_code: this.currentShippingMethod.carrier_code,
-                    shipping_method_code: this.currentShippingMethod.method_code,
+                    shipping_carrier_code: this.currentShippingMethod?.carrier_code,
+                    shipping_method_code: this.currentShippingMethod?.method_code,
                 },
             })
             this.checkout.totals = responseData.totals


### PR DESCRIPTION
currentShippingMethod is never guaranteed to be an object.
as both shipping_methods and shipping_method need to have a value. and have values matching each other.

Otherwise it will be undefined.
If it is we should also assume no shipping method is selected and let the server know.

the shipping-information request seems to succeed with both `undefined` and `null` so we can safely send them.