### PR TITLE
Always add store & authorization header to rapidez API calls

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -36,12 +36,11 @@ window.rapidezFetch = ((originalFetch) => {
 window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     let response = await rapidezFetch(window.url('/api/' + endpoint), {
         method: method.toUpperCase(),
-        headers: {
+        headers: Object.assign({
             Store: window.config.store_code,
             Authorization: token.value ? `Bearer ${token.value}` : null,
             'Content-Type': 'application/json',
-            ...(options?.headers || {}),
-        },
+        }, options?.headers || {}),
         body: Object.keys(data).length ? JSON.stringify(data) : null,
     })
 

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -36,11 +36,14 @@ window.rapidezFetch = ((originalFetch) => {
 window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     let response = await rapidezFetch(window.url('/api/' + endpoint), {
         method: method.toUpperCase(),
-        headers: Object.assign({
-            Store: window.config.store_code,
-            Authorization: token.value ? `Bearer ${token.value}` : null,
-            'Content-Type': 'application/json',
-        }, options?.headers || {}),
+        headers: Object.assign(
+            {
+                Store: window.config.store_code,
+                Authorization: token.value ? `Bearer ${token.value}` : null,
+                'Content-Type': 'application/json',
+            },
+            options?.headers || {},
+        ),
         body: Object.keys(data).length ? JSON.stringify(data) : null,
     })
 

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -37,6 +37,8 @@ window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     let response = await rapidezFetch(window.url('/api/' + endpoint), {
         method: method.toUpperCase(),
         headers: {
+            Store: window.config.store_code,
+            Authorization: token.value ? `Bearer ${token.value}` : null,
             'Content-Type': 'application/json',
             ...(options?.headers || {}),
         },


### PR DESCRIPTION
This is useful for, for example, the multiple wishlists package which needs both.