### PR TITLE
Send full address to check shipping methods

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -41,11 +41,7 @@ export default {
         },
 
         async getShippingMethods() {
-            let responseData = await this.magentoCart('post', 'estimate-shipping-methods', {
-                address: {
-                    country_id: this.checkout.shipping_address.country_id,
-                },
-            })
+            let responseData = await this.magentoCart('post', 'estimate-shipping-methods', { address: this.checkout.shipping_address })
             this.checkout.shipping_methods = responseData
 
             if (responseData.length === 1) {


### PR DESCRIPTION
This allows for shipping restrictions to work on, for example, the postcode.