### PR TITLE
Move resizeobserver to nextTick function

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -53,12 +53,12 @@ export default {
     },
     mounted() {
         this.initSlider()
-        useResizeObserver(this.slider, useThrottleFn(this.updateSpan, 150, true, true))
         useEventListener(this.slider, 'scroll', useThrottleFn(this.scroll, 150, true, true), { passive: true })
         if (this.loop) {
             useEventListener(this.slider, 'scrollend', this.scrollend, { passive: true })
         }
         this.$nextTick(() => {
+            useResizeObserver(this.slider, useThrottleFn(this.updateSpan, 150, true, true))
             if (this.loop) {
                 this.initLoop()
             }


### PR DESCRIPTION
In later versions of VueUse the old situation causes:
> TypeError: Cannot read properties of undefined (reading 'mounted')

or

> [Vue warn]: onMounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup().

Executing this in the nexttick ensures VueUse can resolve the current Vue instance