### PR TITLE
Use script to get the positions from the flattened type

### DIFF
--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -39,7 +39,7 @@
                                 function_score: {
                                     script_score: {
                                         script: {
-                                            source: 'Integer.parseInt(doc[\'positions.'+(window.config.category.entity_id)+'\'].value)',
+                                            source: 'Integer.parseInt(doc[\'positions.'+(window.config.category.entity_id)+'\'].empty ? \'0\' : doc[\'positions.'+(window.config.category.entity_id)+'\'].value)',
                                         },
                                     }
                                 }

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -37,9 +37,10 @@
                         return {
                             query: {
                                 function_score: {
-                                    field_value_factor: {
-                                        field: 'positions.'+window.config.category.entity_id,
-                                        missing: 0
+                                    script_score: {
+                                        script: {
+                                            source: 'Integer.parseInt(doc[\'positions.'+(window.config.category.entity_id)+'\'].value)',
+                                        },
                                     }
                                 }
                             }


### PR DESCRIPTION
Supersedes #427.

We use a script here because the position from the flattened type, for some reason, cannot be implicitly cast to a number type *even though that's literally what it contains if you retrieve it directly from the index*.

By using a script, we can directly parse (not explicitly cast, that also doesn't work) it into a number. ES scripts get cached so this doesn't cause any sort of noticeable performance hit.