### PR TITLE
[1.x] Clear all data on token invalidation

### DIFF
--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -8,7 +8,7 @@ let isRefreshing = false
 
 export const refresh = async function () {
     if (!token.value) {
-        userStorage.value = {}
+        clear()
         return false
     }
 
@@ -26,7 +26,7 @@ export const refresh = async function () {
         userStorage.value = !token.value ? {} : response.data
     } catch (error) {
         if (error.response.status == 401) {
-            token.value = ''
+            clear()
             return false
         }
 

--- a/src/Facades/Rapidez.php
+++ b/src/Facades/Rapidez.php
@@ -5,15 +5,15 @@ namespace Rapidez\Core\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static self       addFallbackRoute($action, $position = 9999)
- * @method static self       removeFallbackRoute($action)
+ * @method static self addFallbackRoute($action, $position = 9999)
+ * @method static self removeFallbackRoute($action)
  * @method static Collection getAllFallbackRoutes()
- * @method static ?string    config(string $path, $default = null, bool $sensitive = false)
- * @method static ?string    content($content)
- * @method static object     fancyMagentoSyntaxDecoder(string $encodedString)
- * @method static array      getStores($storeId = null)
- * @method static array      getStore($storeId)
- * @method static void       setStore($store)
+ * @method static ?string config(string $path, $default = null, bool $sensitive = false)
+ * @method static ?string content($content)
+ * @method static object fancyMagentoSyntaxDecoder(string $encodedString)
+ * @method static array getStores($storeId = null)
+ * @method static array getStore($storeId)
+ * @method static void setStore($store)
  *
  * @see \Rapidez\Core\Rapidez
  */


### PR DESCRIPTION
This caused lingering user data like addresses with a `customer_address_id` to persist in localstorage under certain conditions, blocking the guest checkout from being used.