### PR TITLE
Reset styling of the listing component

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -15,7 +15,7 @@
     -webkit-tap-highlight-color: transparant;
 }
 listing {
-/*  Reset browser added styling causing unexpected behavior */
+    /*  Reset browser added styling causing unexpected behavior */
     display: contents;
     font-family: unset;
     unicode-bidi: unset;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -14,3 +14,11 @@
 * {
     -webkit-tap-highlight-color: transparant;
 }
+listing {
+/*  Reset browser added styling causing unexpected behavior */
+    display: contents;
+    font-family: unset;
+    unicode-bidi: unset;
+    margin: unset;
+    white-space: unset;
+}


### PR DESCRIPTION
During render when vue hasn't replaced the components yet some browsers add styling to the listing component.

There is barely any information on it online however it seems that this was an unused, never implemented component that has been long deprecated.
https://html.com/tags/listing/
however some browsers still come with their own styling for it.

Especially the whitespace: pre; and margin: 1em 0px; is problematic.

display: contents; is because we don't really want vue components that get removed anyways to interact with the layout