### PR TITLE
[2.x] Actually allow null for $dataFilter

### DIFF
--- a/src/Commands/ElasticsearchIndexCommand.php
+++ b/src/Commands/ElasticsearchIndexCommand.php
@@ -21,19 +21,19 @@ abstract class ElasticsearchIndexCommand extends Command
         $this->indexer = $indexer;
     }
 
-    public function indexAllStores(string $indexName, callable|iterable $items, callable|array|null $dataFilter, callable|string $id = 'entity_id'): void
+    public function indexAllStores(string $indexName, callable|iterable $items, callable|array|null $dataFilter = null, callable|string $id = 'entity_id'): void
     {
         $this->indexStores(Rapidez::getStores(), $indexName, $items, $dataFilter, $id);
     }
 
-    public function indexStores(array $stores, string $indexName, callable|iterable $items, callable|array|null $dataFilter, callable|string $id = 'entity_id'): void
+    public function indexStores(array $stores, string $indexName, callable|iterable $items, callable|array|null $dataFilter = null, callable|string $id = 'entity_id'): void
     {
         foreach ($stores as $store) {
             $this->indexStore($store, $indexName, $items, $dataFilter, $id);
         }
     }
 
-    public function indexStore(Store|array $store, string $indexName, callable|iterable $items, callable|array $dataFilter, callable|string $id = 'entity_id'): void
+    public function indexStore(Store|array $store, string $indexName, callable|iterable $items, callable|array|null $dataFilter = null, callable|string $id = 'entity_id'): void
     {
         $storeName = $store['name'] ?? $store['code'] ?? reset($store);
         $this->line('Indexing `' . $indexName . '` for store ' . $storeName);


### PR DESCRIPTION
Because of the missing `|null` in the indexStore function, this could never actually be null. In addition I now add `null` as default so you wouldn't have to specify it in case you want to use it as such.