### PR TITLE
Remove unnecessary toArray calls in product indexer

### DIFF
--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -49,8 +49,8 @@ class ElasticsearchIndexer
 
         $currentValues = match (true) {
             is_callable($dataFilter) => $dataFilter($item),
-            is_null($dataFilter)     => $this->makeArray($item),
-            default                  => Arr::only($this->makeArray($item), $dataFilter),
+            is_null($dataFilter)     => $item,
+            default                  => Arr::only($item instanceof Arrayable ? $item->toArray() : (array) $item, $dataFilter),
         };
 
         if (is_null($currentValues)) {
@@ -66,11 +66,6 @@ class ElasticsearchIndexer
         }
 
         IndexJob::dispatch($this->index, $currentId, $currentValues);
-    }
-
-    public function makeArray(object $item): array
-    {
-        return $item instanceof Arrayable ? $item->toArray() : (array) $item;
     }
 
     public function prepare(string $indexName, array $mapping = [], array $settings = [], array $synonymsFor = []): void

--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -47,11 +47,10 @@ class ElasticsearchIndexer
             return;
         }
 
-        $arrItem = $item instanceof Arrayable ? $item->toArray() : (array) $item;
         $currentValues = match (true) {
             is_callable($dataFilter) => $dataFilter($item),
-            is_null($dataFilter)     => $arrItem,
-            default                  => Arr::only($arrItem, $dataFilter),
+            is_null($dataFilter)     => $this->makeArray($item),
+            default                  => Arr::only($this->makeArray($item), $dataFilter),
         };
 
         if (is_null($currentValues)) {
@@ -67,6 +66,11 @@ class ElasticsearchIndexer
         }
 
         IndexJob::dispatch($this->index, $currentId, $currentValues);
+    }
+
+    public function makeArray(object $item): array
+    {
+        return $item instanceof Arrayable ? $item->toArray() : (array) $item;
     }
 
     public function prepare(string $indexName, array $mapping = [], array $settings = [], array $synonymsFor = []): void


### PR DESCRIPTION
If you're using a callable dataFilter, this toArray call was being done unnecessarily.

The specific reason I'm doing this now is because Statamic has a bug creating an infinite loop calling `toArray()` on entries under certain specific conditions. This is really just a workaround for that, but I can imagine other situations where the extraneous `toArray()` call is also annoying.