### PR TITLE
[2.x] Only allow certain types to be searchable in autocomplete

### DIFF
--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -25,7 +25,9 @@ class ConfigComposer
 
         $attributeModel = config('rapidez.models.attribute');
         $searchableAttributes = Arr::pluck(
-            $attributeModel::getCachedWhere(fn ($attribute) => $attribute['search']),
+            $attributeModel::getCachedWhere(fn ($attribute) =>
+                $attribute['search'] && in_array($attribute['type'], ['text', 'varchar', 'static'])
+            ),
             'search_weight',
             'code'
         );

--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -25,8 +25,7 @@ class ConfigComposer
 
         $attributeModel = config('rapidez.models.attribute');
         $searchableAttributes = Arr::pluck(
-            $attributeModel::getCachedWhere(fn ($attribute) =>
-                $attribute['search'] && in_array($attribute['type'], ['text', 'varchar', 'static'])
+            $attributeModel::getCachedWhere(fn ($attribute) => $attribute['search'] && in_array($attribute['type'], ['text', 'varchar', 'static'])
             ),
             'search_weight',
             'code'


### PR DESCRIPTION
Right now, if you want to use a swatch (which gets indexed as a long in ES), ES will throw a big ol' error complaining about trying to fuzzy search on a long.

This isn't perfect because `static` fields aren't necessarily text and you can still get ES to index text fields as numbers. But it's at least better than always breaking when using swatches.