### PR TITLE
[2.x] Fix ForCurrentStoreScope

### DIFF
--- a/src/Models/Scopes/ForCurrentStoreScope.php
+++ b/src/Models/Scopes/ForCurrentStoreScope.php
@@ -5,6 +5,7 @@ namespace Rapidez\Core\Models\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\DB;
 
 class ForCurrentStoreScope implements Scope
 {
@@ -19,14 +20,12 @@ class ForCurrentStoreScope implements Scope
     {
         $currentTable = $builder->getQuery()->from;
         $joinTable = $this->joinTable ?: $currentTable . '_store';
-        $primaryKey = $model->getKeyName();
 
-        $builder
-            ->leftJoin($joinTable, function ($join) use ($currentTable, $primaryKey, $joinTable) {
-                $join->on($currentTable . '.' . $primaryKey, '=', $joinTable . '.' . $primaryKey);
-            })
+        $storeQuery = DB::table($joinTable)
             ->whereIn('store_id', [0, config('rapidez.store')])
-            ->orderByDesc('store_id')
+            ->orderBy('store_id')
             ->limit(1);
+
+        $builder->leftJoinLateral($storeQuery, $joinTable);
     }
 }

--- a/src/Models/Scopes/ForCurrentStoreScope.php
+++ b/src/Models/Scopes/ForCurrentStoreScope.php
@@ -23,7 +23,7 @@ class ForCurrentStoreScope implements Scope
 
         $storeQuery = DB::table($joinTable)
             ->whereIn('store_id', [0, config('rapidez.store')])
-            ->orderBy('store_id')
+            ->orderByDesc('store_id')
             ->limit(1);
 
         $builder->leftJoinLateral($storeQuery, $joinTable);


### PR DESCRIPTION
Using a lateral join, which limits the SQL compatibility to [PostgreSQL, MySQL >= 8.0.14, and SQL Server](https://laravel.com/docs/11.x/queries#lateral-joins).

Basically this is fixing the fact that the previous query could only select one thing (caused by the `->limit(1)`). This makes it useful for stuff like grabbing the checkoutagreements.