### PR TITLE
[2.x] Round prices before multiplying by qty

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -137,7 +137,9 @@ export default {
 
         calculatePrices: function () {
             this.price = Math.round((parseFloat(this.simpleProduct.price) + this.priceAddition(this.simpleProduct.price)) * 100) / 100
-            this.specialPrice = Math.round((parseFloat(this.simpleProduct.special_price) + this.priceAddition(this.simpleProduct.special_price)) * 100) / 100
+            this.specialPrice =
+                Math.round((parseFloat(this.simpleProduct.special_price) + this.priceAddition(this.simpleProduct.special_price)) * 100) /
+                100
         },
 
         getOptions: function (superAttributeCode) {

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -136,8 +136,8 @@ export default {
         },
 
         calculatePrices: function () {
-            this.price = parseFloat(this.simpleProduct.price) + this.priceAddition(this.simpleProduct.price)
-            this.specialPrice = parseFloat(this.simpleProduct.special_price) + this.priceAddition(this.simpleProduct.special_price)
+            this.price = Math.round((parseFloat(this.simpleProduct.price) + this.priceAddition(this.simpleProduct.price)) * 100) / 100
+            this.specialPrice = Math.round((parseFloat(this.simpleProduct.special_price) + this.priceAddition(this.simpleProduct.special_price)) * 100) / 100
         },
 
         getOptions: function (superAttributeCode) {


### PR DESCRIPTION
Magento rounds prices to 2 decimals before they get multiplied by qty. Not doing this can cause some slightly incorrect prices to be shown on the PDP, especially in combination with tier price discounts.

(More specifically, it converts to the given currency before multiplying by qty by calling `currencyByStore`. This isn't always 2 decimals, see [the ISO 4217 specification](https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes)---9 currencies have more than 2 decimals, and 17 currencies have no decimals at all)