### PR TITLE
Implement macroable on all Rapidez Models

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -3,9 +3,32 @@
 namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Model as BaseModel;
+use Illuminate\Support\Traits\Macroable;
 use Rapidez\Core\Models\Traits\HasEventyGlobalScopeFilter;
 
 class Model extends BaseModel
 {
     use HasEventyGlobalScopeFilter;
+    use Macroable {
+        Macroable::__call as macroCall;
+        Macroable::__callStatic as macroCallStatic;
+    }
+
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return static::macroCall($method, $parameters);
+        }
+
+        return parent::__call($method, $parameters);
+    }
+
+    public static function __callStatic($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return static::macroCallStatic($method, $parameters);
+        }
+
+        return parent::__callStatic($method, $parameters);
+    }
 }


### PR DESCRIPTION
This change in combination with the `resolveRelationUsing` function eliminates nearly any need to override models and instead macroing and mixing in functionality

