### PR TITLE
Fixed parent product link for configurable products

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -89,7 +89,7 @@ export default {
                         config.queries.cart +
                         ` } user_errors { code message } } }`,
                     {
-                        sku: this.simpleProduct.sku,
+                        sku: this.product.sku,
                         cartId: mask.value,
                         quantity: this.qty,
                         selected_options: this.selectedOptions,


### PR DESCRIPTION
Without this the product is not linked to it's parent, meaning that product options of the parent aren't considered.
Nor are the selected configurable options shown in the cart as you've added a simple product instead of a configurable product