### PR TITLE
Also add global eventy filters to optionswatch model

### DIFF
--- a/src/Models/OptionSwatch.php
+++ b/src/Models/OptionSwatch.php
@@ -2,7 +2,6 @@
 
 namespace Rapidez\Core\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 


### PR DESCRIPTION
The OptionSwatch model wasn't extending the Rapidez base model thus it didn't have the global eventy filter for scopes.
https://github.com/rapidez/core/blob/master/src/Models/Model.php#L11 