### PR TITLE
Add health check for usage of Rapidez model

### DIFF
--- a/src/Listeners/Healthcheck/Base.php
+++ b/src/Listeners/Healthcheck/Base.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rapidez\Core\Listeners\Healthcheck;
+
+use Illuminate\Support\Facades\Event;
+
+class Base
+{
+    public function handle()
+    {
+        return [
+            'healthy'  => true,
+            'messages' => [
+                // [
+                //     'type'  => 'error',
+                //     'value' => ''.
+                // ],
+                // [
+                //     'type'  => 'warn',
+                //     'value' => ''.
+                // ],
+                // [
+                //     'type'  => 'info',
+                //     'value' => ''.
+                // ],
+            ],
+        ];
+    }
+
+    public static function register()
+    {
+        Event::listen('rapidez:health-check', static::class);
+    }
+}

--- a/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Rapidez\Core\Listeners;
+namespace Rapidez\Core\Listeners\Healthcheck;
 
 use Illuminate\Support\Facades\Event;
 
-class ElasticsearchHealthcheck
+class ElasticsearchHealthcheck extends Base
 {
     protected $esVersion = '7.6';
 
@@ -37,10 +37,5 @@ class ElasticsearchHealthcheck
         }
 
         return $response;
-    }
-
-    public static function register()
-    {
-        Event::listen('rapidez:health-check', static::class);
     }
 }

--- a/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
@@ -2,8 +2,6 @@
 
 namespace Rapidez\Core\Listeners\Healthcheck;
 
-use Illuminate\Support\Facades\Event;
-
 class ElasticsearchHealthcheck extends Base
 {
     protected $esVersion = '7.6';

--- a/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
+++ b/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Rapidez\Core\Listeners;
+namespace Rapidez\Core\Listeners\Healthcheck;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
 use PDOException;
 
-class MagentoSettingsHealthcheck
+class MagentoSettingsHealthcheck extends Base
 {
     public function handle()
     {
@@ -77,10 +76,5 @@ class MagentoSettingsHealthcheck
         }
 
         return $response;
-    }
-
-    public static function register()
-    {
-        Event::listen('rapidez:health-check', static::class);
     }
 }

--- a/src/Listeners/Healthcheck/ModelsHealthcheck.php
+++ b/src/Listeners/Healthcheck/ModelsHealthcheck.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rapidez\Core\Listeners\Healthcheck;
+
+use Rapidez\Core\Models\Model;
+
+class ModelsHealthcheck extends Base
+{
+    public function handle()
+    {
+        $response =  [
+            'healthy'  => true,
+            'messages' => [],
+        ];
+        $classesWithIncorrectParent = collect(config('rapidez.models'))->filter(fn ($model) => !is_subclass_of($model, Model::class));
+
+        if (!$classesWithIncorrectParent->count()) {
+            return $response;
+        }
+
+        $response['messages'][] = [
+            'type'  => 'warn',
+            'value' => __('Models should extend :rapidezModel, the following dont: :models', ['rapidezModel' => Model::class, 'models' => PHP_EOL . '- ' .$classesWithIncorrectParent->implode(PHP_EOL . '- ')])
+        ];
+
+        return $response;
+    }
+}

--- a/src/Listeners/Healthcheck/ModelsHealthcheck.php
+++ b/src/Listeners/Healthcheck/ModelsHealthcheck.php
@@ -8,19 +8,19 @@ class ModelsHealthcheck extends Base
 {
     public function handle()
     {
-        $response =  [
+        $response = [
             'healthy'  => true,
             'messages' => [],
         ];
-        $classesWithIncorrectParent = collect(config('rapidez.models'))->filter(fn ($model) => !is_subclass_of($model, Model::class));
+        $classesWithIncorrectParent = collect(config('rapidez.models'))->filter(fn ($model) => ! is_subclass_of($model, Model::class));
 
-        if (!$classesWithIncorrectParent->count()) {
+        if (! $classesWithIncorrectParent->count()) {
             return $response;
         }
 
         $response['messages'][] = [
             'type'  => 'warn',
-            'value' => __('Models should extend :rapidezModel, the following dont: :models', ['rapidezModel' => Model::class, 'models' => PHP_EOL . '- ' .$classesWithIncorrectParent->implode(PHP_EOL . '- ')])
+            'value' => __('Models should extend :rapidezModel, the following dont: :models', ['rapidezModel' => Model::class, 'models' => PHP_EOL . '- ' . $classesWithIncorrectParent->implode(PHP_EOL . '- ')]),
         ];
 
         return $response;

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -30,8 +30,9 @@ use Rapidez\Core\Http\Controllers\Fallback\UrlRewriteController;
 use Rapidez\Core\Http\Middleware\CheckStoreCode;
 use Rapidez\Core\Http\Middleware\DetermineAndSetShop;
 use Rapidez\Core\Http\ViewComposers\ConfigComposer;
-use Rapidez\Core\Listeners\ElasticsearchHealthcheck;
-use Rapidez\Core\Listeners\MagentoSettingsHealthcheck;
+use Rapidez\Core\Listeners\Healthcheck\ElasticsearchHealthcheck;
+use Rapidez\Core\Listeners\Healthcheck\MagentoSettingsHealthcheck;
+use Rapidez\Core\Listeners\Healthcheck\ModelsHealthcheck;
 use Rapidez\Core\Listeners\ReportProductView;
 use Rapidez\Core\ViewComponents\PlaceholderComponent;
 use Rapidez\Core\ViewDirectives\WidgetDirective;
@@ -249,6 +250,7 @@ class RapidezServiceProvider extends ServiceProvider
     protected function bootListeners(): self
     {
         Event::listen(ProductViewEvent::class, ReportProductView::class);
+        ModelsHealthcheck::register();
         MagentoSettingsHealthcheck::register();
         ElasticsearchHealthcheck::register();
 


### PR DESCRIPTION
This checks if any of the models written (or overwritten) in `config/rapidez/models.php` are not extending Rapidez' Model.
And warns if it has found any models.

As this is not breaking to the application the healthcheck will not fail.

Sample output:
![image](https://github.com/rapidez/core/assets/15870933/590e9f8b-268d-487d-9108-76f0bf83fdb1)