### PR TITLE
Fix product view report

### DIFF
--- a/config/rapidez/models.php
+++ b/config/rapidez/models.php
@@ -26,6 +26,7 @@ return [
     'quote'                     => Rapidez\Core\Models\Quote::class,
     'quote_item'                => Rapidez\Core\Models\QuoteItem::class,
     'quote_item_option'         => Rapidez\Core\Models\QuoteItemOption::class,
+    'report_event'              => Rapidez\Core\Models\ReportEvent::class,
     'rewrite'                   => Rapidez\Core\Models\Rewrite::class,
     'store'                     => Rapidez\Core\Models\Store::class,
     'widget'                    => Rapidez\Core\Models\Widget::class,

--- a/src/Models/ProductView.php
+++ b/src/Models/ProductView.php
@@ -20,6 +20,18 @@ class ProductView extends Model
             $productView->store_id = config('rapidez.store');
         });
 
+        static::created(function (ProductView $productView) {
+            $reportEventModel = config('rapidez.models.report_event');
+
+            $reportEventModel::create([
+                'store_id' => config('rapidez.store'),
+                'event_type_id' => 1, // Product Viewed
+                'object_id' => $productView->product_id,
+                'subtype' => 0,
+                'subject_id' => 0,
+            ]);
+        });
+
         static::addGlobalScope('store', function (Builder $builder) {
             $builder->where('store_id', config('rapidez.store'));
         });

--- a/src/Models/ReportEvent.php
+++ b/src/Models/ReportEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rapidez\Core\Models;
+
+class ReportEvent extends Model
+{
+    protected $table = 'report_event';
+
+    protected $primaryKey = 'event_id';
+
+    protected $guarded = ['event_id'];
+
+    const CREATED_AT = 'logged_at';
+
+    const UPDATED_AT = null;
+}

--- a/src/Models/ReportEvent.php
+++ b/src/Models/ReportEvent.php
@@ -8,7 +8,7 @@ class ReportEvent extends Model
 
     protected $primaryKey = 'event_id';
 
-    protected $guarded = ['event_id'];
+    protected $guarded = [];
 
     const CREATED_AT = 'logged_at';
 


### PR DESCRIPTION
Magento reads from the `report_event` table to create it's reports. Rapidez currently only inserts the view events into the `report_viewed_product_index` table, hence the reports are not available. 

The data is available so if we want to make this backwards compatible we can run this query in a database;

```sql
insert into report_event (`logged_at`, `event_type_id`, `object_id`, `subject_id`, `subtype`, `store_id`) 
	select `added_at`, 1, `product_id`, 0, 0, store_id from report_viewed_product_index
```