### PR TITLE
[2.x] Remove all global scopes from quote relation

### DIFF
--- a/src/Models/SalesOrder.php
+++ b/src/Models/SalesOrder.php
@@ -3,7 +3,6 @@
 namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
-use Rapidez\Core\Models\Scopes\IsActiveScope;
 
 class SalesOrder extends Model
 {

--- a/src/Models/SalesOrder.php
+++ b/src/Models/SalesOrder.php
@@ -43,7 +43,7 @@ class SalesOrder extends Model
         $query->whereHas(
             'quote',
             fn ($query) => $query
-                ->withoutGlobalScope(IsActiveScope::class)
+                ->withoutGlobalScopes()
                 ->whereQuoteIdOrCustomerToken($quoteIdMaskOrCustomerToken)
         );
     }


### PR DESCRIPTION
When combined with https://github.com/rapidez/amasty-automatic-related-products/ it will try to query `quote_item` on a quote without actually having that table joined. 

The solution is either to do this, or to update the package and add a join to always make sure quote_item is joined. Which would be preferable?