### PR TITLE
[2.x] Allow for separate slider & child containers

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -10,6 +10,10 @@ export default {
             type: String,
             default: 'slider',
         },
+        containerReference: {
+            type: String,
+            default: null,
+        },
         vertical: {
             type: Boolean,
             default: false,
@@ -38,6 +42,7 @@ export default {
     data: () => {
         return {
             slider: '',
+            container: '',
             position: 0,
             showLeft: false,
             showRight: false,
@@ -73,6 +78,9 @@ export default {
     methods: {
         initSlider() {
             this.slider = this.$scopedSlots.default()[0].context.$refs[this.reference]
+            this.container = this.containerReference
+                ? this.$scopedSlots.default()[0].context.$refs[this.containerReference]
+                : this.slider
         },
         initLoop() {
             if (!this.loop) {
@@ -83,14 +91,14 @@ export default {
             if (!slides.length) {
                 return
             }
-            let firstChild = this.slider.firstChild
+            let firstChild = this.container.firstChild
 
             for (let slide of slides) {
-                let startClone = this.slider.insertBefore(slide.cloneNode(true), firstChild)
+                let startClone = this.container.insertBefore(slide.cloneNode(true), firstChild)
                 startClone.dataset.clone = true
                 startClone.dataset.position = 'start'
 
-                let endClone = this.slider.appendChild(slide.cloneNode(true))
+                let endClone = this.container.appendChild(slide.cloneNode(true))
                 endClone.dataset.clone = true
                 endClone.dataset.position = 'end'
             }
@@ -114,7 +122,7 @@ export default {
         scroll(event) {
             this.position = this.vertical ? event.target.scrollTop : event.target.scrollLeft
             this.showLeft = this.loop || this.position
-            this.showRight = this.loop || this.slider.offsetWidth + this.position < this.slider.scrollWidth - 1
+            this.showRight = this.loop || this.container.offsetWidth + this.position < this.container.scrollWidth - 1
         },
         scrollend(event) {
             let scrollPosition = this.vertical ? event.target.scrollTop : event.target.scrollLeft
@@ -143,18 +151,18 @@ export default {
             index = this.loop ? index + this.slides.length : index
 
             this.vertical
-                ? this.slider.scrollTo({ top: this.slider.children[index]?.offsetTop, behavior: behavior })
-                : this.slider.scrollTo({ left: this.slider.children[index]?.offsetLeft, behavior: behavior })
+                ? this.slider.scrollTo({ top: this.container.children[index]?.offsetTop, behavior: behavior })
+                : this.slider.scrollTo({ left: this.container.children[index]?.offsetLeft, behavior: behavior })
         },
         handleLoop() {
             if (this.currentSlide + 1 === this.slidesTotal - 1) {
                 Array.from(this.chunk.children).forEach((child) => {
-                    this.slider.appendChild(child.cloneNode(true))
+                    this.container.appendChild(child.cloneNode(true))
                 })
             }
             if (this.currentSlide < 1) {
                 Array.from(this.chunk.children).forEach((child) => {
-                    this.slider.insertBefore(child.cloneNode(true), this.slider.firstChild)
+                    this.container.insertBefore(child.cloneNode(true), this.container.firstChild)
                 })
             }
         },
@@ -162,12 +170,12 @@ export default {
             let slide = this.childSpan == 0 ? 0 : this.currentSlide
 
             this.childSpan = this.vertical
-                ? this.slider.children[0]?.offsetHeight ?? this.slider.offsetHeight
-                : this.slider.children[0]?.offsetWidth ?? this.slider.offsetWidth
+                ? this.container.children[0]?.offsetHeight ?? this.container.offsetHeight
+                : this.container.children[0]?.offsetWidth ?? this.container.offsetWidth
 
             this.navigate(slide, 'instant')
 
-            this.sliderSpan = this.vertical ? this.slider.offsetHeight : this.slider.offsetWidth
+            this.sliderSpan = this.vertical ? this.container.offsetHeight : this.container.offsetWidth
         },
     },
     watch: {
@@ -204,7 +212,7 @@ export default {
             return (this.slides?.length ?? 1) - (this.loop ? 0 : this.slidesVisible - 1)
         },
         slides() {
-            return this.slider.querySelectorAll(':scope > :not([data-clone=true])')
+            return this.container.querySelectorAll(':scope > :not([data-clone=true])')
         },
         sliderStart() {
             return this.vertical ? this.slides[0].offsetTop : this.slides[0].offsetLeft

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -78,9 +78,7 @@ export default {
     methods: {
         initSlider() {
             this.slider = this.$scopedSlots.default()[0].context.$refs[this.reference]
-            this.container = this.containerReference
-                ? this.$scopedSlots.default()[0].context.$refs[this.containerReference]
-                : this.slider
+            this.container = this.containerReference ? this.$scopedSlots.default()[0].context.$refs[this.containerReference] : this.slider
         },
         initLoop() {
             if (!this.loop) {


### PR DESCRIPTION
Sometimes, the parent `slider` element is not the element directly containing the children. You might have some funky table styling that requires a different approach to the way the slider is built.

For example, this is useful for https://github.com/rapidez/compare because of the way the table is structured.