### PR TITLE
[2.x] Enable highlighting in autocomplete products

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -33,6 +33,7 @@
             fuzziness="AUTO"
             :debounce="debounce"
             :size="size"
+            :highlight="true"
             v-on:value-change="searchAdditionals($event)"
         >
             <div


### PR DESCRIPTION
This PR enables highlighting from elasticsearch in the product listing, which puts the `<mark></mark>` tags around matched text on every product title. This was already enabled by default on categories and any other extra indices, so this is for consistency.