### PR TITLE
Check correct customer id when jwt is used

### DIFF
--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -38,7 +38,7 @@ class Customer extends Model implements AuthenticatableContract
             DecodeJwt::isJwt($token),
             fn (Builder $query) => $query
                 ->where(
-                    $this->qualifyColumn('customer_id'),
+                    $this->getQualifiedKeyName(),
                     DecodeJwt::decode($token)
                         ->claims()
                         ->get('uid')


### PR DESCRIPTION
customer_id existed because before it was joined on.
The right value to use is entity_id which is the keyname of the Customer instance