### PR TITLE
Correctly deal with graphql exceptions to excecute errorcallback

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -14,6 +14,9 @@ Vue.prototype.getCheckoutStep = (stepName) => {
 }
 
 Vue.prototype.updateCart = async function (data, response) {
+    if (!response?.data) {
+        return response?.data;
+    }
     cart.value = 'cart' in Object.values(response.data)[0] ? Object.values(response.data)[0].cart : Object.values(response.data)[0]
 
     getAttributeValues().then((response) => {

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -122,15 +122,14 @@ export default {
                     ;[query, variables, options] = await this.beforeRequest(this.query, this.variables, options)
                 }
 
-                let response = await magentoGraphQL(query, variables, options)
-                    .catch(async (error) => {
-                        if(!GraphQLError.prototype.isPrototypeOf(err)) {
-                            throw error
-                        }
-                        const errorResponse = error.response.json();
-                        if (this.errorCallback) {
-                            await this.errorCallback(this.data, errorResponse)
-                        }
+                let response = await magentoGraphQL(query, variables, options).catch(async (error) => {
+                    if (!GraphQLError.prototype.isPrototypeOf(err)) {
+                        throw error
+                    }
+                    const errorResponse = error.response.json()
+                    if (this.errorCallback) {
+                        await this.errorCallback(this.data, errorResponse)
+                    }
 
                     if (this.alert) {
                         error.errors.forEach((error) => {
@@ -138,7 +137,7 @@ export default {
                         })
                     }
 
-                    return errorResponse;
+                    return errorResponse
                 })
 
                 if (response.data.errors) {

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -127,9 +127,9 @@ export default {
                         if(!GraphQLError.prototype.isPrototypeOf(err)) {
                             throw error
                         }
-
+                        const errorResponse = error.response.json();
                         if (this.errorCallback) {
-                            await this.errorCallback(this.data, error.response)
+                            await this.errorCallback(this.data, errorResponse)
                         }
 
                         if (this.alert) {
@@ -138,7 +138,7 @@ export default {
                             });
                         }
 
-                        return error.response;
+                        return errorResponse;
                     })
 
                 if (response.data.errors) {

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -1,6 +1,6 @@
 import { token } from './stores/useUser'
 
-class FetchError extends Error {
+export class FetchError extends Error {
     constructor(message, response) {
         super(message)
         this.response = response
@@ -9,7 +9,15 @@ class FetchError extends Error {
 }
 window.FetchError = FetchError
 
-class SessionExpired extends FetchError {
+export class GraphQLError extends FetchError {
+    constructor(errors, response) {
+        super(errors[0].message, response)
+        this.errors = errors
+    }
+}
+window.GraphQLError = GraphQLError
+
+export class SessionExpired extends FetchError {
     constructor(message, response) {
         super(message, response)
         this.name = this.constructor.name
@@ -17,7 +25,7 @@ class SessionExpired extends FetchError {
 }
 window.SessionExpired = SessionExpired
 
-window.rapidezFetch = ((originalFetch) => {
+export const rapidezFetch = window.rapidezFetch = ((originalFetch) => {
     return (...args) => {
         if (window.app.$data) {
             window.app.$data.loadingCount++
@@ -33,7 +41,7 @@ window.rapidezFetch = ((originalFetch) => {
     }
 })(fetch)
 
-window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
+export const rapidezAPI = window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     let response = await rapidezFetch(window.url('/api/' + endpoint), {
         method: method.toUpperCase(),
         headers: Object.assign(
@@ -54,7 +62,7 @@ window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     return await response.json()
 }
 
-window.magentoGraphQL = async (
+export const magentoGraphQL = window.magentoGraphQL = async (
     query,
     variables = {},
     options = {
@@ -76,19 +84,25 @@ window.magentoGraphQL = async (
             variables: variables,
         }),
     })
-
-    if (!response.ok) {
-        throw new FetchError(window.config.translations.errors.wrong, response)
-    }
+    ;
 
     // You can't call response.json() twice, in case of errors we pass our clone instead which hasn't been read.
     let responseClone = response.clone()
+
+    if (!response.ok && !response.headers?.get('content-type')?.includes('application/json')) {
+        throw new FetchError(window.config.translations.errors.wrong, responseClone)
+    }
+
     let data = await response.json()
 
-    if (data.errors) {
+    if (data?.errors) {
         console.error(data.errors)
 
-        if (data.errors[0]?.extensions?.category === 'graphql-authorization') {
+        data?.errors?.forEach(error => {
+            if (error?.extensions?.category !== 'graphql-authorization') {
+                return;
+            }
+
             if (options?.notifyOnError ?? true) {
                 Notify(window.config.translations.errors.session_expired)
             }
@@ -98,15 +112,19 @@ window.magentoGraphQL = async (
             } else {
                 throw new SessionExpired(window.config.translations.errors.session_expired, responseClone)
             }
-        }
+        });
 
-        throw new FetchError(data.errors[0].message, responseClone)
+        throw new GraphQLError(data.errors, responseClone)
+    }
+
+    if (!response.ok) {
+        throw new FetchError(window.config.translations.errors.wrong, responseClone)
     }
 
     return data
 }
 
-window.magentoAPI = async (
+export const magentoAPI = window.magentoAPI = async (
     method,
     endpoint,
     data = {},


### PR DESCRIPTION
Because an exception would get thrown on failing json the catch would trigger instead of the errorcallback.
Now we throw a separate error if it is caused by GraphQL so we can deal with it differently than we would different FetchErrors