### PR TITLE
[2.x] Add fixed product taxes in cart

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -97,6 +97,7 @@ export const cart = computed({
 
         cartStorage.value.virtualItems = virtualItems
         cartStorage.value.hasOnlyVirtualItems = hasOnlyVirtualItems
+        cartStorage.value.fixedProductTaxes = fixedProductTaxes
 
         return cartStorage.value
     },
@@ -117,6 +118,16 @@ export const virtualItems = computed(() => {
 
 export const hasOnlyVirtualItems = computed(() => {
     return cart.value.total_quantity === virtualItems.value.length
+})
+
+export const fixedProductTaxes = computed(() => {
+    let taxes = {}
+    cart.value?.items?.forEach(item =>
+        item.prices?.fixed_product_taxes?.forEach(tax =>
+            taxes[tax.label] = (taxes[tax.label] ?? 0) + tax.amount.value
+        )
+    )
+    return taxes
 })
 
 export default () => cart

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -122,10 +122,8 @@ export const hasOnlyVirtualItems = computed(() => {
 
 export const fixedProductTaxes = computed(() => {
     let taxes = {}
-    cart.value?.items?.forEach(item =>
-        item.prices?.fixed_product_taxes?.forEach(tax =>
-            taxes[tax.label] = (taxes[tax.label] ?? 0) + tax.amount.value
-        )
+    cart.value?.items?.forEach((item) =>
+        item.prices?.fixed_product_taxes?.forEach((tax) => (taxes[tax.label] = (taxes[tax.label] ?? 0) + tax.amount.value)),
     )
     return taxes
 })

--- a/resources/views/cart/queries/cart.graphql
+++ b/resources/views/cart/queries/cart.graphql
@@ -44,6 +44,12 @@ items {
         row_total_including_tax {
             value
         }
+        fixed_product_taxes {
+            amount {
+                value
+            }
+            label
+        }
     }
     ... on SimpleCartItem {
         @include('rapidez::cart.queries.partials.customizable_options')

--- a/resources/views/cart/sidebar.blade.php
+++ b/resources/views/cart/sidebar.blade.php
@@ -7,6 +7,10 @@
         <dt>@lang('Tax')</dt>
         <dd>@{{ cart.prices.applied_taxes[0].amount.value | price }}</dd>
     </div>
+    <div v-for="value, name in cart.fixedProductTaxes.value">
+        <dt>@{{ name }}</dt>
+        <dd>@{{ value | price }}</dd>
+    </div>
     <div v-if="cart.shipping_addresses.length && cart.shipping_addresses[0].selected_shipping_method">
         <dt>
             @lang('Shipping')<br>


### PR DESCRIPTION
As the fixed product tax [can not be fetched on the total prices](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/WeeeGraphQl/etc/schema.graphqls), we have to individually sum all products together :)