### PR TITLE
Also add category scopes eventy filter when indexing products

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -61,7 +61,7 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
                 $bar = $this->output->createProgressBar($productQuery->getQuery()->getCountForPagination());
                 $bar->start();
 
-                $categories = Category::query()
+                $categories = Category::withEventyGlobalScopes('index.category.scopes')
                     ->where('catalog_category_flat_store_' . config('rapidez.store') . '.entity_id', '<>', Rapidez::config('catalog/category/root_id', 2))
                     ->pluck('name', 'entity_id');
 


### PR DESCRIPTION
Sometimes you would want to exclude categories to get indexed, or add something to the query. This is why we need to use the eventy scope here too.