### PR TITLE
Change product url attribute

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -198,6 +198,11 @@ class Product extends Model
     {
         $configModel = config('rapidez.models.config');
 
+        return '/' . $this->rewrites()
+                ->where('store_id', config('rapidez.store'))
+                ->firstWhere('redirect_type', '=', 0)?->request_path ??
+                'catalog/product/view/id/' . $this->entity_id;
+
         return '/' . ($this->url_key ? $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
     }
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -196,14 +196,10 @@ class Product extends Model
 
     public function getUrlAttribute(): string
     {
-        $configModel = config('rapidez.models.config');
-
         return '/' . $this->rewrites()
                 ->where('store_id', config('rapidez.store'))
                 ->firstWhere('redirect_type', '=', 0)?->request_path ??
                 'catalog/product/view/id/' . $this->entity_id;
-
-        return '/' . ($this->url_key ? $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
     }
 
     public function getImagesAttribute(): array

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -199,7 +199,7 @@ class Product extends Model
         return '/' . $this->rewrites()
             ->where('store_id', config('rapidez.store'))
             ->firstWhere('redirect_type', '=', 0)?->request_path ??
-                'catalog/product/view/id/' . $this->entity_id;
+            'catalog/product/view/id/' . $this->entity_id;
     }
 
     public function getImagesAttribute(): array


### PR DESCRIPTION
This way, the url is always right. We're using `.env` files in our Magento installations to for example set the `catalog/seo/product_url_suffix` value. Rapidez only looks for this in the database and thus can't find it. Then it will default to `.html` even if you don't want that. In the url_rewrites table, the url will always be right when having redirect type of `0`. With or without the suffix set.