### PR TITLE
[2.x] Fix casts in quote model

### DIFF
--- a/src/Models/Quote.php
+++ b/src/Models/Quote.php
@@ -4,6 +4,7 @@ namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Rapidez\Core\Actions\DecodeJwt;
+use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
 
 class Quote extends Model
@@ -15,7 +16,6 @@ class Quote extends Model
     protected $guarded = [];
 
     protected $casts = [
-        'items'       => QuoteItems::class,
         'cross_sells' => CommaSeparatedToIntegerArray::class,
     ];
 


### PR DESCRIPTION
Not sure what happened here but these were undefined classes, and you'd get an error when trying to grab the child items or crosssells. Not that we really use this model anymore, so I guess nobody noticed...