### PR TITLE
[2.x] Don't always assume api call returns json

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -62,8 +62,7 @@ export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {
     let responseData = await response.text()
 
     try {
-        let json = JSON.parse(responseData)
-        return json
+        return JSON.parse(responseData)
     } catch (e) {
         return responseData
     }

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -59,7 +59,14 @@ export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {
         throw new FetchError(window.config.translations.errors.wrong, response)
     }
 
-    return await response.json()
+    let responseData = await response.text()
+
+    try {
+        let json = JSON.parse(responseData)
+        return json
+    } catch (e) {
+        return responseData
+    }
 })
 
 export const magentoGraphQL = (window.magentoGraphQL = async (


### PR DESCRIPTION
For some API calls, like the `DELETE` call on a wishlist in the multiple-wishlists package, no data is returned. Of course we could also add some return data to the package there, but we might as well fix this to not be an issue.

The code for this isn't great---it's a little frustrating that there doesn't seem to be a cleaner reliable way to test for json-ness of a response (we could check for the response header but that's not bulletproof).