### PR TITLE
Set recaptcha token to right header in graphql mutation

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -108,7 +108,7 @@ export default {
                 let options = { headers: {} }
 
                 if (this.recaptcha) {
-                    options['headers']['X-Recaptcha'] = await this.getReCaptchaToken()
+                    options['headers']['X-ReCaptcha'] = await this.getReCaptchaToken()
                 }
 
                 if (this.store) {

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -108,7 +108,7 @@ export default {
                 let options = { headers: {} }
 
                 if (this.recaptcha) {
-                    options['headers']['Authorization'] = await this.getReCaptchaToken()
+                    options['headers']['X-Recaptcha'] = await this.getReCaptchaToken()
                 }
 
                 if (this.store) {


### PR DESCRIPTION
The recaptcha validation fails because it checks the `X-recaptcha` header and not the `Authorization` header.