### PR TITLE
Redirect when the order can not be fetched from the success page

### DIFF
--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -47,7 +47,7 @@ export default {
                 {
                     headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
                 },
-            )
+            ).catch((error) => Turbo.visit(window.url('/')))
         },
 
         serialize(address) {

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -40,8 +40,7 @@ export default {
 
     methods: {
         async refreshOrder() {
-            this.order = await window
-                .rapidezAPI(
+            this.order = await window.rapidezAPI(
                     'get',
                     'order',
                     {},

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -41,14 +41,13 @@ export default {
     methods: {
         async refreshOrder() {
             this.order = await window.rapidezAPI(
-                    'get',
-                    'order',
-                    {},
-                    {
-                        headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
-                    },
-                )
-                .catch((error) => Turbo.visit(window.url('/')))
+                'get',
+                'order',
+                {},
+                {
+                    headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
+                },
+            .catch((error) => Turbo.visit(window.url('/')))
         },
 
         serialize(address) {

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -40,14 +40,16 @@ export default {
 
     methods: {
         async refreshOrder() {
-            this.order = await window.rapidezAPI(
-                'get',
-                'order',
-                {},
-                {
-                    headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
-                },
-            ).catch((error) => Turbo.visit(window.url('/')))
+            this.order = await window
+                .rapidezAPI(
+                    'get',
+                    'order',
+                    {},
+                    {
+                        headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
+                    },
+                )
+                .catch((error) => Turbo.visit(window.url('/')))
         },
 
         serialize(address) {

--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -47,7 +47,7 @@ export default {
                 {
                     headers: { Authorization: 'Bearer ' + (this.token || this.mask) },
                 },
-            .catch((error) => Turbo.visit(window.url('/')))
+            ).catch((error) => Turbo.visit(window.url('/')))
         },
 
         serialize(address) {


### PR DESCRIPTION
So when you're on the success page and the order can not be found there is nothing to show so we can redirect away.

Normally you won't get here as the success page is wrapped by the checkout component, but for example from payment providers the page is rendered standalone, see:

- https://github.com/rapidez/paynl/blob/master/resources/views/success.blade.php
- https://github.com/rapidez/core/blob/master/resources/views/checkout/steps/success.blade.php

cc https://github.com/rapidez/core/pull/503, where there is already taken care of this. Correct @indykoning?

Internal reference: FSM2-1401 and HDB-792