### PR TITLE
[2.x] Slideover header button fix

### DIFF
--- a/resources/views/components/slideover/partials/header.blade.php
+++ b/resources/views/components/slideover/partials/header.blade.php
@@ -2,10 +2,7 @@
     <div class="px-5">
         <div class="relative flex items-center justify-center">
             @if ($hasParent)
-                <label
-                    {{ $attributes->merge(['id' => $id]) }}
-                    class="absolute left-0 top-1/2 -translate-y-1/2 cursor-pointer text-white"
-                >
+                <label for="{{ $id }}" class="absolute left-0 top-1/2 -translate-y-1/2 cursor-pointer text-white">
                     <x-heroicon-o-arrow-left class="size-6" />
                 </label>
             @elseif ($headerbutton->isNotEmpty())
@@ -16,10 +13,7 @@
                     {{ $title }}
                 </span>
             @endif
-            <label
-                v-bind:for="{{ $attributes->get('v-bind:id') ?? '\'' . $closeId . '\'' }}"
-                class="absolute right-0 top-1/2 -translate-y-1/2 cursor-pointer text-white"
-            >
+            <label v-bind:for="{{ $attributes->get('v-bind:id') ?? '\'' . $closeId . '\'' }}" class="absolute right-0 top-1/2 -translate-y-1/2 cursor-pointer text-white">
                 <x-heroicon-o-x-mark class="size-6" />
             </label>
         </div>


### PR DESCRIPTION
The back arrow button used `id` instead of `for` and used a weird attributes merge (that didn't include the class in the merge, which broke it). There may have been a use case for it while developing this slideover, but it sure as heck isn't used now.