### PR TITLE
Frontend - Pagination styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,6 @@
 @import 'components/vue-slider';
 @import './theme-variables.css';
+@import './components/pagination.css';
 
 @tailwind base;
 @tailwind components;

--- a/resources/css/components/pagination.css
+++ b/resources/css/components/pagination.css
@@ -1,0 +1,37 @@
+.pagination .pagination-button:first-child:nth-last-child(3),
+.pagination .pagination-button:first-child:nth-last-child(3) ~ .pagination-button {
+    @apply hidden;
+}
+
+.pagination {
+    @apply flex flex-wrap justify-center gap-x-2 !m-0 !mb-6 max-md:gap-y-4;
+}
+
+.pagination-button {
+    @apply !font-semibold !font-sans !border !border-border !rounded !bg-white !text-neutral !shadow;
+}
+
+.pagination-button.active {
+    @apply !border !border-none !bg-primary !text-white !shadow-none;
+}
+
+.pagination-button:first-child {
+    @apply !mr-auto max-md:hidden;
+}
+
+.pagination-button:last-child {
+    @apply !ml-auto max-md:w-full max-md:-order-1;
+}
+
+.pagination-button:not(:first-child):not(:last-child) {
+    @apply !m-0 !size-14 max-md:flex-1 max-md:w-auto;
+}
+
+.pagination-button:first-child,
+.pagination-button:last-child {
+    @apply h-14 px-6 max-md:!m-0;
+}
+
+.pagination-button[disabled] {
+    @apply opacity-60;
+}

--- a/resources/css/components/pagination.css
+++ b/resources/css/components/pagination.css
@@ -4,7 +4,7 @@
 }
 
 .pagination {
-    @apply flex flex-wrap justify-center gap-x-2 !m-0 !mb-6 max-md:gap-y-4;
+    @apply flex flex-wrap justify-center gap-x-2 !m-0 !my-6 max-md:gap-y-4;
 }
 
 .pagination-button {
@@ -16,7 +16,7 @@
 }
 
 .pagination-button:first-child {
-    @apply !mr-auto max-md:hidden;
+    @apply !mr-auto max-md:w-full max-md:order-last;
 }
 
 .pagination-button:last-child {

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -10,8 +10,10 @@
     :react="{and: reactiveFilters}"
     :sort-options="sortOptions"
     :inner-class="{
-        button: '!bg-inactive disabled:!bg-opacity-60 !text-white [&.active]:!bg-neutral',
-        sortOptions: '{{ $dropdownClasses }}'
+        button: 'pagination-button',
+        current: 'current-button',
+        sortOptions: '{{ $dropdownClasses }}',
+        pagination: 'pagination'
     }"
     prev-label="@lang('Prev')"
     next-label="@lang('Next')"


### PR DESCRIPTION
**Old:**
<img width="1200" alt="Scherm­afbeelding 2024-09-05 om 11 57 10" src="https://github.com/user-attachments/assets/9f1f1c52-d7e6-4683-a4fd-59112b289ec5">
<img width="391" alt="Scherm­afbeelding 2024-09-05 om 11 57 26" src="https://github.com/user-attachments/assets/a340d83b-6077-4b5a-b82f-9c871b70c712">

**New:**
<img width="1214" alt="Scherm­afbeelding 2024-09-05 om 11 49 26" src="https://github.com/user-attachments/assets/c8b38ebb-dea4-49e8-9e77-443f8c680105">
<img width="379" alt="Scherm­afbeelding 2024-09-05 om 12 01 11" src="https://github.com/user-attachments/assets/17d70950-341b-4f75-922a-41e6686be60b">

Other changes:
- Don't show pagination when there is only 1 page. 

