### PR TITLE
[2.x] Filter out double slashes

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -42,7 +42,7 @@ export const rapidezFetch = (window.rapidezFetch = ((originalFetch) => {
 })(fetch))
 
 export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
-    let response = await rapidezFetch(window.url('/api/' + endpoint), {
+    let response = await rapidezFetch(window.url('/api/' + endpoint.replace(/^\/+/, '')), {
         method: method.toUpperCase(),
         headers: Object.assign(
             {
@@ -138,7 +138,7 @@ export const magentoAPI = (window.magentoAPI = async (
         notifyOnError: true,
     },
 ) => {
-    let response = await rapidezFetch(config.magento_url + '/rest/' + window.config.store_code + '/V1/' + endpoint, {
+    let response = await rapidezFetch(config.magento_url + '/rest/' + window.config.store_code + '/V1/' + endpoint.replace(/^\/+/, ''), {
         method: method.toUpperCase(),
         headers: {
             Authorization: token.value ? `Bearer ${token.value}` : null,

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -16,7 +16,7 @@ Vue.filter('price', function (value) {
 window.url = function (path = '') {
     // Replace any double slashes not preceded by a : with a single slash
     path = path.replaceAll(/([^:])\/\//g, '$1/')
-    
+
     // Transform urls starting with / into url with domain
     if (!path.startsWith('/')) {
         return path

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -14,6 +14,9 @@ Vue.filter('price', function (value) {
 })
 
 window.url = function (path = '') {
+    // Replace any double slashes not preceded by a : with a single slash
+    path = path.replaceAll(/([^:])\/\//g, '$1/')
+    
     // Transform urls starting with / into url with domain
     if (!path.startsWith('/')) {
         return path

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -14,13 +14,7 @@ Vue.filter('price', function (value) {
 })
 
 window.url = function (path = '') {
-    // Transform urls starting with / into url with domain
-    if (path.startsWith('/')) {
-        path = (window.config.base_url || window.origin) + path
-    }
-
-    // Replace any double slashes not preceded by a : with a single slash
-    return path.replaceAll(/([^:])\/\//g, '$1/')
+    return (window.config.base_url || window.origin) + path
 }
 
 Vue.filter('url', window.url)

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -14,6 +14,11 @@ Vue.filter('price', function (value) {
 })
 
 window.url = function (path = '') {
+    // Transform urls starting with / into url with domain
+    if (!path.startsWith('/')) {
+        return path
+    }
+
     return (window.config.base_url || window.origin) + path
 }
 

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -14,15 +14,13 @@ Vue.filter('price', function (value) {
 })
 
 window.url = function (path = '') {
-    // Replace any double slashes not preceded by a : with a single slash
-    path = path.replaceAll(/([^:])\/\//g, '$1/')
-
     // Transform urls starting with / into url with domain
-    if (!path.startsWith('/')) {
-        return path
+    if (path.startsWith('/')) {
+        path = (window.config.base_url || window.origin) + path
     }
 
-    return (window.config.base_url || window.origin) + path
+    // Replace any double slashes not preceded by a : with a single slash
+    return path.replaceAll(/([^:])\/\//g, '$1/')
 }
 
 Vue.filter('url', window.url)


### PR DESCRIPTION
Sometimes, when using the new fetch.js functionality, a doubled `/` will slip through and break some requests. We can filter these out before it happens, just gotta make sure we don't filter out the `://` at the start of a url 😉 