### PR TITLE
Prevent any leftover customer_address_id

### DIFF
--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -72,9 +72,16 @@ export default {
         },
 
         setCheckoutCredentialsFromDefaultUserAddresses() {
-            if (this.$root && this.$root.loggedIn) {
+            if (!this.$root) {
+                return;
+            }
+
+            if (this.$root.loggedIn) {
                 this.setCustomerAddressByAddressId('shipping', this.$root.user.default_shipping)
                 this.setCustomerAddressByAddressId('billing', this.$root.user.default_billing)
+            } else {
+                this.setCustomerAddressByAddressId('shipping')
+                this.setCustomerAddressByAddressId('billing')
             }
         },
 
@@ -84,13 +91,13 @@ export default {
                 return
             }
 
-            let address = this.$root.user.addresses.find((address) => address.id == id)
+            let address = this.$root.user?.addresses?.find((address) => address.id == id) || window.address_defaults
 
             this.$root.checkout[type + '_address'] = Object.assign(
                 this.$root.checkout[type + '_address'],
                 Object.assign(
                     {
-                        customer_address_id: address.id,
+                        customer_address_id: address?.id,
                     },
                     address,
                 ),

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -73,7 +73,7 @@ export default {
 
         setCheckoutCredentialsFromDefaultUserAddresses() {
             if (!this.$root) {
-                return;
+                return
             }
 
             if (this.$root.loggedIn) {


### PR DESCRIPTION
While a leftover customer_address_id shouldn't occur it does seem to happen sometimes, causing a request to guest-carts with a customer_address_id.

This prevents it by automatically setting it to null when loading the checkout if the customer is not logged in