### PR TITLE
Make Graphql and GraphqlMutation errorCallback the same

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -13,7 +13,7 @@ Vue.prototype.getCheckoutStep = (stepName) => {
     return (config.checkout_steps[config.store_code] ?? config.checkout_steps['default'])?.indexOf(stepName)
 }
 
-Vue.prototype.updateCart = async function (data, response) {
+Vue.prototype.updateCart = async function (variables, response) {
     if (!response?.data) {
         return response?.data
     }
@@ -22,11 +22,9 @@ Vue.prototype.updateCart = async function (data, response) {
     return response.data
 }
 
-Vue.prototype.checkResponseForExpiredCart = async function (error) {
-    let responseData = await error.response?.json()
-
+Vue.prototype.checkResponseForExpiredCart = async function (variables, response) {
     if (
-        responseData?.errors?.some(
+        response?.errors?.some(
             (error) =>
                 error.extensions.category === 'graphql-no-such-entity' &&
                 error.path.some((path) =>

--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -28,7 +28,7 @@ export default {
         },
         errorCallback: {
             type: Function,
-            default: (error) => Notify(window.config.translations.errors.wrong, 'warning'),
+            default: (variables, error) => Notify(window.config.translations.errors.wrong, 'warning'),
         },
         store: {
             type: String,
@@ -82,14 +82,14 @@ export default {
                     }
                 }
 
-                this.data = this.callback ? await this.callback(this.data, response) : response.data
+                this.data = this.callback ? await this.callback(this.variables, response) : response.data
 
                 if (this.cache) {
                     useLocalStorage(this.cachePrefix + this.cache, null, { serializer: StorageSerializers.object }).value = this.data
                 }
             } catch (error) {
                 console.error(error)
-                this.errorCallback(error)
+                this.errorCallback(this.variables, await error?.response?.json())
             }
         },
     },

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -127,7 +127,7 @@ export default {
                         throw error
                     }
 
-                    const errorResponse = error.response.json()
+                    const errorResponse = await error.response.json()
                     if (this.errorCallback) {
                         await this.errorCallback(this.data, errorResponse)
                     }

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -137,7 +137,7 @@ export default {
                 }
 
                 if (error?.response) {
-                    const responseData = await error.response.json();
+                    const responseData = await error.response.json()
                     if (GraphQLError.prototype.isPrototypeOf(error) && !(await this.checkResponseForExpiredCart({}, responseData))) {
                         // If there are errors we may still get a newly updated cart back.
                         await this.updateCart({}, responseData)

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -137,9 +137,10 @@ export default {
                 }
 
                 if (error?.response) {
-                    if (!(await this.checkResponseForExpiredCart(error.response)) && GraphQLError.prototype.isPrototypeOf(error)) {
+                    const responseData = await error.response.json();
+                    if (GraphQLError.prototype.isPrototypeOf(error) && !(await this.checkResponseForExpiredCart({}, responseData))) {
                         // If there are errors we may still get a newly updated cart back.
-                        await this.updateCart({}, await error.response.json())
+                        await this.updateCart({}, responseData)
                     }
                 }
             }

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -1,5 +1,6 @@
 import { StorageSerializers, asyncComputed, useLocalStorage, useMemoize } from '@vueuse/core'
 import { computed, watch } from 'vue'
+import { GraphQLError } from '../fetch'
 import { mask, clearMask } from './useMask'
 
 const cartStorage = useLocalStorage('cart', {}, { serializer: StorageSerializers.object })
@@ -27,7 +28,7 @@ export const refresh = async function (force = false) {
         cart.value = Object.values(response.data)[0]
     } catch (error) {
         console.error(error)
-        Vue.prototype.checkResponseForExpiredCart(error)
+        GraphQLError.prototype.isPrototypeOf(error) && Vue.prototype.checkResponseForExpiredCart({}, await error?.response?.json())
     }
 }
 


### PR DESCRIPTION
In all different contexts. checkResponseForExpiredCart would be sent different types of data.
I've pulled the arguments of both callback functions of the graphql and graphqlMutation component inline.
Also caught an error where the graphql component's callback component should return variables instead of data to be in-line with graphqlMutation