### PR TITLE
Multiply fixed product tax by item quantity

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -163,8 +163,9 @@ export const hasOnlyVirtualItems = computed(() => {
 
 export const fixedProductTaxes = computed(() => {
     let taxes = {}
+    // Note: Magento does internal rounding before multiplying by the quantity, so we actually don't lose any precision here by using the rounded tax amount.
     cart.value?.items?.forEach((item) =>
-        item.prices?.fixed_product_taxes?.forEach((tax) => (taxes[tax.label] = (taxes[tax.label] ?? 0) + tax.amount.value)),
+        item.prices?.fixed_product_taxes?.forEach((tax) => (taxes[tax.label] = (taxes[tax.label] ?? 0) + tax.amount.value * item.quantity)),
     )
     return taxes
 })


### PR DESCRIPTION
The graphql endpoint only returns the fixed product tax amount for a single quantity regardless of the actual cart quantity.

Also note that---while you're able to set fixed product taxes with up to 4 decimals of precision---Magento will automatically round that to whatever currency you use before doing any calculations with it. As a result we actually do not lose any precision by doing it this way.