### PR TITLE
Don't throw warning when GraphQL component is used without slot

### DIFF
--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -45,7 +45,7 @@ export default {
         if (!('default' in this.$scopedSlots)) {
             return null
         }
-        
+
         return this.$scopedSlots.default(this)
     },
 

--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -42,6 +42,10 @@ export default {
     }),
 
     render() {
+        if (!('default' in this.$scopedSlots)) {
+            return null
+        }
+        
         return this.$scopedSlots.default(this)
     },
 


### PR DESCRIPTION
This actually happens in the [core cart overview](https://github.com/rapidez/core/blob/master/resources/views/cart/overview.blade.php#L10-L17) (also in checkout theme). This throws a warning in the console any time you open the cart, because the default scoped slot doesn't exist.