### PR TITLE
[2.x] Move default selects to always select

### DIFF
--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -17,7 +17,7 @@ class WithProductAttributesScope implements Scope
             $model->qualifyColumn('type_id'),
             $model->getQualifiedCreatedAtColumn(),
         ]);
-        
+
         if (empty($model->attributesToSelect)) {
             return;
         }

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -10,6 +10,14 @@ class WithProductAttributesScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
+        $builder->addSelect([
+            $model->getQualifiedKeyName(),
+            $model->qualifyColumn('sku'),
+            $model->qualifyColumn('visibility'),
+            $model->qualifyColumn('type_id'),
+            $model->getQualifiedCreatedAtColumn(),
+        ]);
+        
         if (empty($model->attributesToSelect)) {
             return;
         }
@@ -20,14 +28,6 @@ class WithProductAttributesScope implements Scope
         });
 
         $attributes = array_filter($attributes, fn ($a) => $a['type'] !== 'static');
-
-        $builder->addSelect([
-            $model->getQualifiedKeyName(),
-            $model->qualifyColumn('sku'),
-            $model->qualifyColumn('visibility'),
-            $model->qualifyColumn('type_id'),
-            $model->getQualifiedCreatedAtColumn(),
-        ]);
 
         $grammar = $builder->getQuery()->getGrammar();
         foreach ($attributes as $attribute) {


### PR DESCRIPTION
When not using `selectAttributes` this scope would return too early and not actually select basic stuff like `entity_id`, causing some relations to break.