### PR TITLE
[2.x] Add CSRF token to Rapidez API requests

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -49,6 +49,7 @@ export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {
                 Store: window.config.store_code,
                 Authorization: token.value ? `Bearer ${token.value}` : null,
                 'Content-Type': 'application/json',
+                'X-CSRF-Token': window.app.csrfToken,
             },
             options?.headers || {},
         ),

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -59,6 +59,7 @@ function init() {
             loadingCount: 0,
             loading: false,
             loadAutocomplete: false,
+            csrfToken: document.querySelector('[name=csrf-token]').content,
             cart: useCart(),
             user: useUser(),
             mask: useMask(),


### PR DESCRIPTION
This token was already added to the base layout template, so here's using it :)