### PR TITLE
[2.x] Add resizedpath helper function

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -110,7 +110,11 @@ function init() {
                     this.scrollLock = bool
                 }
             },
-            resizedPath(imagePath, size, store) {
+            resizedPath(imagePath, size, store = null) {
+                if(!store) {
+                    store = window.config.store
+                }
+
                 let mediaPosition = imagePath.indexOf('/media/')
                 if (mediaPosition > 0) {
                     return `/storage/${store}/resizes/${size}/magento` + imagePath.substr(mediaPosition + 6)
@@ -121,7 +125,7 @@ function init() {
                     return `/storage/${store}/resizes/${size}/magento/catalog` + imagePath.substr(productPosition)
                 }
 
-                return `/storage/${store}/resizes/${size}/magento` + imagePath
+                return `/storage/${store}/resizes/${size}/magento/catalog/product` + imagePath
             },
         },
         computed: {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -110,6 +110,19 @@ function init() {
                     this.scrollLock = bool
                 }
             },
+            resizedPath(imagePath, size, store) {
+                let mediaPosition = imagePath.indexOf('/media/')
+                if (mediaPosition > 0) {
+                    return `/storage/${store}/resizes/${size}/magento` + imagePath.substr(mediaPosition + 6)
+                }
+
+                let productPosition = imagePath.indexOf('/product/')
+                if (productPosition > 0) {
+                    return `/storage/${store}/resizes/${size}/magento/catalog` + imagePath.substr(productPosition)
+                }
+
+                return `/storage/${store}/resizes/${size}/magento` + imagePath
+            },
         },
         computed: {
             // Wrap the local storage in getter and setter functions so you do not have to interact using .value

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -111,7 +111,7 @@ function init() {
                 }
             },
             resizedPath(imagePath, size, store = null) {
-                if(!store) {
+                if (!store) {
                     store = window.config.store
                 }
 

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -6,7 +6,7 @@
                     <img
                         class="mx-auto"
                         :alt="item.product.name"
-                        :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento' + item.product.image.url.replace(config.media_url, '') + '.webp'"
+                        :src="resizedPath(item.product.image.url + '.webp', '80x80', {{ config('rapidez.store') }})"
                         height="80"
                     />
                 </a>

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -6,7 +6,7 @@
                     <img
                         class="mx-auto"
                         :alt="item.product.name"
-                        :src="resizedPath(item.product.image.url + '.webp', '80x80', {{ config('rapidez.store') }})"
+                        :src="resizedPath(item.product.image.url + '.webp', '80x80')"
                         height="80"
                     />
                 </a>

--- a/resources/views/layouts/partials/header/autocomplete/products.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/products.blade.php
@@ -1,7 +1,7 @@
 <ul class="gap-5 grid md:grid-cols-2">
     <li v-for="suggestion in suggestions" :key="suggestion.source._id">
         <a :href="suggestion.source.url | url" class="flex flex-wrap flex-1">
-            <img :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" class="self-center object-contain w-14 aspect-square" />
+            <img :src="resizedPath(suggestion.source.thumbnail + '.webp', '80x80')" class="self-center object-contain w-14 aspect-square" />
             <div class="flex flex-1 flex-wrap px-2">
                 <strong class="hyphens block w-full" v-html="highlight(suggestion, 'name')"></strong>
                 <div class="self-end">@{{ suggestion.source.price | price }}</div>

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -9,7 +9,7 @@
             <a :href="item.url | url" class="block">
                 <img
                     v-if="item.thumbnail"
-                    :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + item.thumbnail + '.webp'"
+                    :src="resizedPath(item.thumbnail + '.webp', '200')"
                     class="mb-3 h-48 w-full rounded-t object-contain" :alt="item.name" :loading="config.category && count <= 4 ? 'eager' : 'lazy'"
                     width="200"
                     height="200"

--- a/resources/views/product/partials/images.blade.php
+++ b/resources/views/product/partials/images.blade.php
@@ -27,7 +27,7 @@
                 >
                     <img
                         v-if="!zoomed"
-                        :src="'/storage/{{ config('rapidez.store') }}/resizes/400/magento/catalog/product' + images[active] + '.webp'"
+                        :src="resizedPath(images[active] + '.webp', '400')"
                         alt="{{ $product->name }}"
                         class="object-contain w-full m-auto max-h-[400px]"
                         width="400"
@@ -58,7 +58,7 @@
                     @click="change(imageId)"
                 >
                     <img
-                        :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento/catalog/product' + image + '.webp'"
+                        :src="resizedPath(image + '.webp', '80x80')"
                         alt="{{ $product->name }}"
                         class="object-contain w-full m-auto max-h-[80px]"
                         loading="lazy"


### PR DESCRIPTION
We currently use a replace with the media url, however that does not work on multisite at all, or in cases where the media url isn't exactly the same as what magento returns from graphql.

This solution catches every use case I know of so far. Placeholder image, product images, custom media, and a fallback to the product url.