### PR TITLE
When child has no images, push empty array.

### DIFF
--- a/src/Casts/Children.php
+++ b/src/Casts/Children.php
@@ -25,7 +25,7 @@ class Children implements CastsAttributes
                 }
             }
 
-            $child->images = collect($child->images)->sortBy('position')->pluck('value')->toArray();
+            $child->images = isset($child->images) ? collect($child?->images)->sortBy('position')->pluck('value')->toArray() : [];
 
             unset($child->special_from_date, $child->special_to_date);
         }


### PR DESCRIPTION
Without this check an error was thrown when a child that has nog image, is indexed bij the index products command.

<img width="842" alt="Scherm­afbeelding 2024-09-23 om 11 17 40" src="https://github.com/user-attachments/assets/28f43ff0-faaa-40ef-b607-ee3a278e8365">
