### PR TITLE
Change order of clearing

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -309,6 +309,10 @@ export default {
             this.selectPaymentMethod()
         },
         'checkout.shipping_address.country_id': function () {
+            if (!cart.value?.id) {
+                return
+            }
+
             this.getShippingMethods()
         },
         'checkout.step': function () {

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -33,9 +33,9 @@ export const refresh = async function (force = false) {
 }
 
 export const clear = async function () {
-    await clearAddresses()
     await clearMask()
     await refresh()
+    await clearAddresses()
 }
 
 export const clearAddresses = async function () {


### PR DESCRIPTION
When we do the clearing the old way, the cart get's refreshed to soon, with a country id. This will trigger the estimate-shipping-methods call on the checkout success page, and thus will logout the user.