### PR TITLE
Color suggestion change

### DIFF
--- a/resources/css/theme-variables.css
+++ b/resources/css/theme-variables.css
@@ -4,7 +4,8 @@
     --secondary: 249 115 22;
     --secondary-text: 255 255 255;
     --neutral: 51 65 85;
-    --inactive: 100 116 139;
-    --highlight: 241 245 249;
+    --light: 100 116 139;
+    --base-100: 241 245 249;
+    --enhanced: 54 180 34;
     --border: 231 235 239;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,13 +26,19 @@ export default {
                     text: 'rgb(var(--primary-text) / <alpha-value>)', // Text color that goes onto primary color
                 },
                 secondary: {
-                    DEFAULT: 'rgb(var(--secondary) / <alpha-value>)', // Conversion color
+                    DEFAULT: 'rgb(var(--secondary) / <alpha-value>)', // Secondary theme color
                     text: 'rgb(var(--secondary-text) / <alpha-value>)', // Text color that goes onto secondary color
                 },
-                neutral: 'rgb(var(--neutral) / <alpha-value>)', // Default text color
-                inactive: 'rgb(var(--inactive) / <alpha-value>)', // Inactive text color
-                highlight: 'rgb(var(--highlight) / <alpha-value>)', // Background highlight color
+                neutral: {
+                    DETAULT: 'rgb(var(--neutral) / <alpha-value>)', // Default text color
+                    light: 'rgb(var(--light) / <alpha-value>)', // Lighter text color
+                },
+                base: {
+                    100: 'rgb(var(--base-100) / <alpha-value>)' // Background color
+                },
+                enhanced: 'rgb(var(--enhanced) / <alpha-value>)', // Conversion related color
                 border: 'rgb(var(--border) / <alpha-value>)', // Border color
+                disabled: 'rgb(var(--disabled) / <alpha-value>)', // Color that is used for disabled components
             },
             borderColor: {
                 DEFAULT: 'rgb(var(--border) / <alpha-value>)', // Border color default so it gets used when only using border


### PR DESCRIPTION
Related to this [pull request](https://github.com/rapidez/core/pull/580).

Changed:
- Removed the inactive color. We use neutral for the default text color so I added a light variant for neutral. 
`text-neutral-light` 
- Removed highlight and renamed it to base. You can add more colors to the base if needed. 
`bg-base-100`
- Added enhanced (conversion color)
- Added color for disabled elements for example input `disabled:bg-disabled`

![Scherm­afbeelding 2024-10-15 om 11 05 26](https://github.com/user-attachments/assets/a85986a5-0048-4770-aa19-b5b0f3e99534)
