### PR TITLE
Automatic font preload links in the head

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     "require": {
         "php": "^8.1|^8.2|^8.3",
         "blade-ui-kit/blade-heroicons": "^2.4",
-        "mailerlite/laravel-elasticsearch": "^11.1",
         "illuminate/database": "^10.0|^11.0",
         "illuminate/events": "^10.0|^11.0",
         "illuminate/queue": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.0|^5.3",
+        "log1x/laravel-webfonts": "^1.0",
+        "mailerlite/laravel-elasticsearch": "^11.1",
         "rapidez/blade-directives": "^0.6",
         "tormjens/eventy": "^0.8"
     },

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,7 @@
     <link rel="canonical" href="@yield('canonical', url()->current())" />
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @preloadFonts
 
     @stack('head')
     @config('design/head/includes')


### PR DESCRIPTION
The package just grabs all the woff2 fonts discovered by Vite and generates preload links for them:
```html
<link rel='preload' href='https://website.com/build/assets/font.woff2' as='font' type='font/woff2' crossorigin>
```