### PR TITLE
[3.x] Use slot scopes without destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Just run `./vendor/bin/phpunit`
 
 ### Browser tests
 
--   Make sure you've got a Magento install running
--   Prepare Laravel Dusk with `composer run dusk:prepare`
--   Compile the assets with: `composer run dusk:assets` and re-run this when the assets are changed
--   Tests can be started with: `composer run dusk:test`
+- Make sure you've got a Magento install running
+- Prepare Laravel Dusk with `composer run dusk:prepare`
+- Compile the assets with: `composer run dusk:assets` and re-run this when the assets are changed
+- Tests can be started with: `composer run dusk:test`
 
 ## License
 

--- a/resources/views/cart/coupon/add.blade.php
+++ b/resources/views/cart/coupon/add.blade.php
@@ -6,14 +6,14 @@
     :watch="false"
     :callback="updateCart"
     :error-callback="checkResponseForExpiredCart"
-    v-slot="{ mutate, variables }"
+    v-slot="couponQueryScope"
 >
-    <form v-on:submit.prevent="mutate" class="flex gap-3">
+    <form v-on:submit.prevent="couponQueryScope.mutate" class="flex gap-3">
         <x-rapidez::input
             :label="false"
             name="couponCode"
             placeholder="Coupon code"
-            v-model="variables.coupon_code"
+            v-model="couponQueryScope.variables.coupon_code"
             v-bind:disabled="$root.loading"
             required
         />

--- a/resources/views/cart/coupon/list.blade.php
+++ b/resources/views/cart/coupon/list.blade.php
@@ -4,10 +4,10 @@
         :variables="{ cart_id: mask }"
         :callback="updateCart"
         :error-callback="checkResponseForExpiredCart"
-        v-slot="{ mutate }"
+        v-slot="couponListQueryScope"
     >
         <div class="flex">
-            <button v-on:click="mutate" v-bind:dusk="'remove-coupon-' + coupon.code">
+            <button v-on:click="couponListQueryScope.mutate" v-bind:dusk="'remove-coupon-' + coupon.code">
                 <x-heroicon-s-x-mark class="h-4 w-4 text-black-400"/>
             </button>
             @{{ coupon.code }}

--- a/resources/views/cart/item/quantity.blade.php
+++ b/resources/views/cart/item/quantity.blade.php
@@ -3,14 +3,14 @@
     :variables="{ cart_id: mask, cart_item_id: item.id, quantity: item.quantity }"
     :callback="updateCart"
     :error-callback="checkResponseForExpiredCart"
-    v-slot="{ mutate, variables }"
+    v-slot="cartItemQueryScope"
 >
-    <form v-on:submit.prevent="mutate" class="flex items-center gap-1">
+    <form v-on:submit.prevent="cartItemQueryScope.mutate" class="flex items-center gap-1">
         <x-rapidez::input
             name="qty"
             type="number"
             :label="false"
-            v-model="variables.quantity"
+            v-model="cartItemQueryScope.variables.quantity"
             v-bind:dusk="'qty-'+index"
             {{-- TODO: We don't need these importants with Tailwind merge and center isn't really center with type number --}}
             class="!w-14 !px-1 text-center"

--- a/resources/views/cart/item/remove.blade.php
+++ b/resources/views/cart/item/remove.blade.php
@@ -4,9 +4,9 @@
     :notify="{ message: item.product.name+' '+config.translations.cart.remove }"
     :callback="updateCart"
     :error-callback="checkResponseForExpiredCart"
-    v-slot="{ mutate }"
+    v-slot="cartItemRemoveQueryScope"
 >
-    <button :disabled="$root.loading" v-on:click="mutate" title="@lang('Remove')" :dusk="'item-delete-'+index" class="hover:underline">
+    <button :disabled="$root.loading" v-on:click="cartItemRemoveQueryScope.mutate" title="@lang('Remove')" :dusk="'item-delete-'+index" class="hover:underline">
         @lang('Remove')
     </button>
 </graphql-mutation>

--- a/resources/views/checkout/overview.blade.php
+++ b/resources/views/checkout/overview.blade.php
@@ -6,22 +6,22 @@
 
 @section('content')
     <div class="container">
-        <checkout v-cloak v-slot="{ checkout, cart, save, goToStep, forceAccount }">
+        <checkout v-cloak v-slot="checkoutScope">
             <div>
-                <template v-if="checkout.step < getCheckoutStep('success')">
+                <template v-if="checkoutScope.checkout.step < getCheckoutStep('success')">
                     @include('rapidez::checkout.partials.progressbar')
                 </template>
-                <div v-if="checkout.step == 1 && window.app.cart.total_quantity">
+                <div v-if="checkoutScope.checkout.step == 1 && window.app.cart.total_quantity">
                     @include('rapidez::checkout.steps.login')
                 </div>
 
-                <div v-if="[2, 3].includes(checkout.step)" class="-mx-2 lg:flex">
+                <div v-if="[2, 3].includes(checkoutScope.checkout.step)" class="-mx-2 lg:flex">
                     <div class="mb-5 w-full px-2 lg:w-3/4">
-                        <div v-if="checkout.step == 2">
+                        <div v-if="checkoutScope.checkout.step == 2">
                             @include('rapidez::checkout.steps.credentials')
                         </div>
 
-                        <div v-if="checkout.step == 3">
+                        <div v-if="checkoutScope.checkout.step == 3">
                             @include('rapidez::checkout.steps.payment')
                         </div>
                     </div>
@@ -30,7 +30,7 @@
                     </div>
                 </div>
 
-                <div v-if="checkout.step == getCheckoutStep('success')">
+                <div v-if="checkoutScope.checkout.step == getCheckoutStep('success')">
                     @include('rapidez::checkout.steps.success')
                 </div>
             </div>

--- a/resources/views/checkout/partials/address.blade.php
+++ b/resources/views/checkout/partials/address.blade.php
@@ -1,8 +1,8 @@
 <div class="col-span-12" v-if="$root.loggedIn">
     <graphql query="{ customer { addresses { id firstname lastname street city postcode country_code } } }">
-        <div v-if="data" slot-scope="{ data }">
-            <x-rapidez::select v-model="checkout.{{ $type }}_address.customer_address_id" label="">
-                <option v-for="address in data.customer.addresses" :value="address.id">
+        <div v-if="addressQueryScope.data" slot-scope="addressQueryScope">
+            <x-rapidez::select v-model="checkoutScope.checkout.{{ $type }}_address.customer_address_id" label="">
+                <option v-for="address in addressQueryScope.data.customer.addresses" :value="address.id">
                     @{{ address.firstname }} @{{ address.lastname }}
                     - @{{ address.street[0] }} @{{ address.street[1] }} @{{ address.street[2] }}
                     - @{{ address.postcode }}
@@ -15,13 +15,13 @@
     </graphql>
 </div>
 
-<div class="contents" v-if="!$root.loggedIn || !checkout.{{ $type }}_address.customer_address_id">
+<div class="contents" v-if="!$root.loggedIn || !checkoutScope.checkout.{{ $type }}_address.customer_address_id">
     @if (Rapidez::config('customer/address/prefix_show', '') && strlen(Rapidez::config('customer/address/prefix_options', '')))
         <div class="col-span-12">
             <x-rapidez::select
                 name="{{ $type }}_prefix"
                 label="Prefix"
-                v-model="checkout.{{ $type }}_address.prefix"
+                v-model="checkoutScope.checkout.{{ $type }}_address.prefix"
                 :required="Rapidez::config('customer/address/prefix_show', 'opt') == 'req'"
             >
                 @if (Rapidez::config('customer/address/prefix_show', '') === 'opt')
@@ -39,7 +39,7 @@
         <x-rapidez::input
             label="Firstname"
             name="{{ $type }}_firstname"
-            v-model.lazy="checkout.{{ $type }}_address.firstname"
+            v-model.lazy="checkoutScope.checkout.{{ $type }}_address.firstname"
             required
         />
     </div>
@@ -48,7 +48,7 @@
             <x-rapidez::input
                 name="{{ $type }}_middlename"
                 label="Middlename"
-                v-model.lazy="checkout.{{ $type }}_address.middlename"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.middlename"
             />
         </div>
     @endif
@@ -56,7 +56,7 @@
         <x-rapidez::input
             name="{{ $type }}_lastname"
             label="Lastname"
-            v-model.lazy="checkout.{{ $type }}_address.lastname"
+            v-model.lazy="checkoutScope.checkout.{{ $type }}_address.lastname"
             required
         />
     </div>
@@ -65,7 +65,7 @@
             <x-rapidez::select
                 name="{{ $type }}_suffix"
                 label="Suffix"
-                v-model="checkout.{{ $type }}_address.suffix"
+                v-model="checkoutScope.checkout.{{ $type }}_address.suffix"
                 :required="Rapidez::config('customer/address/suffix_show', 'opt') == 'req'"
             >
                 @if (Rapidez::config('customer/address/suffix_show', '') === 'opt')
@@ -83,8 +83,8 @@
         <x-rapidez::input
             name="{{ $type }}_postcode"
             label="Postcode"
-            v-model.lazy="checkout.{{ $type }}_address.postcode"
-            v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkout.{{ $type }}_address))"
+            v-model.lazy="checkoutScope.checkout.{{ $type }}_address.postcode"
+            v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkoutScope.checkout.{{ $type }}_address))"
             required
         />
     </div>
@@ -93,8 +93,8 @@
             <x-rapidez::input
                 name="{{ $type }}_housenumber"
                 label="Housenumber"
-                v-model.lazy="checkout.{{ $type }}_address.street[1]"
-                v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkout.{{ $type }}_address))"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.street[1]"
+                v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkoutScope.checkout.{{ $type }}_address))"
                 required
             />
         </div>
@@ -104,7 +104,7 @@
             <x-rapidez::input
                 name="{{ $type }}_addition"
                 label="Addition"
-                v-model.lazy="checkout.{{ $type }}_address.street[2]"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.street[2]"
             />
         </div>
     @endif
@@ -112,7 +112,7 @@
         <x-rapidez::input
             name="{{ $type }}_street"
             label="Street"
-            v-model.lazy="checkout.{{ $type }}_address.street[0]"
+            v-model.lazy="checkoutScope.checkout.{{ $type }}_address.street[0]"
             required
         />
     </div>
@@ -120,7 +120,7 @@
         <x-rapidez::input
             name="{{ $type }}_city"
             label="City"
-            v-model.lazy="checkout.{{ $type }}_address.city"
+            v-model.lazy="checkoutScope.checkout.{{ $type }}_address.city"
             required
         />
     </div>
@@ -129,8 +129,8 @@
             name="{{ $type }}_country"
             dusk="{{ $type }}_country"
             label="Country"
-            v-model="checkout.{{ $type }}_address.country_id"
-            v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkout.{{ $type }}_address))"
+            v-model="checkoutScope.checkout.{{ $type }}_address.country_id"
+            v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', checkoutScope.checkout.{{ $type }}_address))"
             required
         />
     </div>
@@ -139,7 +139,7 @@
             <x-rapidez::input
                 name="{{ $type }}_telephone"
                 label="Telephone"
-                v-model.lazy="checkout.{{ $type }}_address.telephone"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.telephone"
                 :required="Rapidez::config('customer/address/telephone_show', 'req') == 'req'"
             />
         </div>
@@ -149,7 +149,7 @@
             <x-rapidez::input
                 name="{{ $type }}_fax"
                 label="Fax"
-                v-model.lazy="checkout.{{ $type }}_address.fax"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.fax"
                 :required="Rapidez::config('customer/address/fax_show', false) === 'req'"
             />
         </div>
@@ -160,7 +160,7 @@
                 name="{{ $type }}_company"
                 label="Company"
                 placeholder=""
-                v-model.lazy="checkout.{{ $type }}_address.company"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.company"
                 :required="Rapidez::config('customer/address/company_show', 'opt') == 'req'"
             />
         </div>
@@ -171,7 +171,7 @@
                 name="{{ $type }}_vat_id"
                 label="Tax ID"
                 placeholder=""
-                v-model.lazy="checkout.{{ $type }}_address.vat_id"
+                v-model.lazy="checkoutScope.checkout.{{ $type }}_address.vat_id"
                 :required="Rapidez::config('customer/address/taxvat_show', 'opt') == 'req'"
             />
         </div>

--- a/resources/views/checkout/partials/create-account.blade.php
+++ b/resources/views/checkout/partials/create-account.blade.php
@@ -1,15 +1,15 @@
 <div v-if="!loggedIn" id="create-account-wrapper">
     <div class="grid grid-cols-12 gap-4 mb-3">
-        <div class="col-span-12" v-if="!forceAccount">
-            <x-rapidez::checkbox v-model="checkout.create_account" dusk="create_account">
+        <div class="col-span-12" v-if="!checkoutScope.forceAccount">
+            <x-rapidez::checkbox v-model="checkoutScope.checkout.create_account" dusk="create_account">
                 @lang('Create an account')
             </x-rapidez::checkbox>
         </div>
-        <div class="col-span-12 sm:col-span-6" v-if="checkout.create_account || forceAccount">
-            <x-rapidez::input name="password" type="password" v-model="checkout.password" required />
+        <div class="col-span-12 sm:col-span-6" v-if="checkoutScope.checkout.create_account || checkoutScope.forceAccount">
+            <x-rapidez::input name="password" type="password" v-model="checkoutScope.checkout.password" required />
         </div>
-        <div class="col-span-12 sm:col-span-6" v-if="checkout.create_account || forceAccount">
-            <x-rapidez::input label="Repeat password" name="password_repeat" type="password" v-model="checkout.password_repeat" required />
+        <div class="col-span-12 sm:col-span-6" v-if="checkoutScope.checkout.create_account || checkoutScope.forceAccount">
+            <x-rapidez::input label="Repeat password" name="password_repeat" type="password" v-model="checkoutScope.checkout.password_repeat" required />
         </div>
     </div>
 </div>

--- a/resources/views/checkout/partials/progressbar.blade.php
+++ b/resources/views/checkout/partials/progressbar.blade.php
@@ -1,11 +1,11 @@
 <nav class="grid grid-cols-12 my-5">
     @foreach (array_slice((config('rapidez.frontend.checkout_steps.'.config('rapidez.store_code')) ?: config('rapidez.frontend.checkout_steps.default')), 0, -1) as $stepTitle)
-        <button class="col-span-3 relative focus:outline-none" :disabled="checkout.step < {{ $loop->index }}" :class="checkout.step < {{ $loop->index }} ? 'cursor-default' : ''" v-on:click="if (checkout.step >= {{ $loop->index }}) goToStep({{ $loop->index }})">
+        <button class="col-span-3 relative focus:outline-none" :disabled="checkoutScope.checkout.step < {{ $loop->index }}" :class="checkoutScope.checkout.step < {{ $loop->index }} ? 'cursor-default' : ''" v-on:click="if (checkoutScope.checkout.step >= {{ $loop->index }}) checkoutScope.goToStep({{ $loop->index }})">
             @if (!$loop->last)
-                <div :class="checkout.step > {{ $loop->index }} ? 'bg-neutral' : 'bg-inactive'" class="absolute flex w-full h-0.5 top-5 left-1/2"></div>
+                <div :class="checkoutScope.checkout.step > {{ $loop->index }} ? 'bg-neutral' : 'bg-inactive'" class="absolute flex w-full h-0.5 top-5 left-1/2"></div>
             @endif
             <div
-                :class="{'bg-neutral text-white': {{ $loop->index }} <= checkout.step, 'bg-white': {{ $loop->index }} > checkout.step, 'bg-neutral text-white shadow-md shadow-neutral': {{ $loop->index }} === checkout.step}"
+                :class="{'bg-neutral text-white': {{ $loop->index }} <= checkoutScope.checkout.step, 'bg-white': {{ $loop->index }} > checkoutScope.checkout.step, 'bg-neutral text-white shadow-md shadow-neutral': {{ $loop->index }} === checkoutScope.checkout.step}"
                 class="relative flex w-10 h-10 mx-auto justify-center rounded-full font-bold items-center border border-neutral"
             >
                 {{ $loop->index + 1 }}

--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -5,7 +5,7 @@
             <div class="w-2/12 px-4 text-right">@{{ item.quantity }}</div>
             <div class="w-3/12 text-right">@{{ item.prices.row_total.value | price }}</div>
         </div>
-        <div v-for="total_segment in checkout.totals.total_segments" v-if="total_segment.value" class="flex gap-x-1 border-b py-3 last:border-b-0 last:font-bold">
+        <div v-for="total_segment in checkoutScope.checkout.totals.total_segments" v-if="total_segment.value" class="flex gap-x-1 border-b py-3 last:border-b-0 last:font-bold">
             <div class="w-7/12">@{{ total_segment.title }}</div>
             <div class="w-2/12 px-4"></div>
             <div class="w-3/12 text-right">@{{ total_segment.value | price }}</div>

--- a/resources/views/checkout/steps/credentials.blade.php
+++ b/resources/views/checkout/steps/credentials.blade.php
@@ -1,6 +1,6 @@
 <h1 class="mb-5 text-4xl font-bold">@lang('Credentials')</h1>
 
-<form v-on:submit.prevent="save(['credentials'], 3)" class="flex flex-col gap-5 rounded bg-highlight p-4 md:p-8">
+<form v-on:submit.prevent="checkoutScope.save(['credentials'], 3)" class="flex flex-col gap-5 rounded bg-highlight p-4 md:p-8">
     <div class="flex flex-col gap-2">
         <div class="grid grid-cols-12 gap-4">
             <p class="col-span-12 text-2xl font-bold">
@@ -9,11 +9,11 @@
             @include('rapidez::checkout.partials.address', ['type' => 'shipping'])
         </div>
         <div class="col-span-12 my-5">
-            <x-rapidez::checkbox v-model="checkout.hide_billing">
+            <x-rapidez::checkbox v-model="checkoutScope.checkout.hide_billing">
                 @lang('My billing and shipping address are the same')
             </x-rapidez::checkbox>
         </div>
-        <div v-if="!checkout.hide_billing" class="grid grid-cols-12 gap-4">
+        <div v-if="!checkoutScope.checkout.hide_billing" class="grid grid-cols-12 gap-4">
             <p class="col-span-12 text-2xl font-bold">
                 @lang('Billing address')
             </p>
@@ -25,8 +25,8 @@
         <p class="text-2xl font-bold">
             @lang('Shipping method')
         </p>
-        <template v-for="(method, index) in checkout.shipping_methods">
-            <x-rapidez::radio v-model="checkout.shipping_method" v-bind:value="method.carrier_code+'_'+method.method_code" v-bind:dusk="'method-'+index">
+        <template v-for="(method, index) in checkoutScope.checkout.shipping_methods">
+            <x-rapidez::radio v-model="checkoutScope.checkout.shipping_method" v-bind:value="method.carrier_code+'_'+method.method_code" v-bind:dusk="'method-'+index">
                 @{{ method.method_title }}
             </x-rapidez::radio>
         </template>

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -1,6 +1,6 @@
-<login v-slot="{ email, password, go, loginInputChange, emailAvailable }">
+<login v-slot="checkoutLoginScope">
     <div class="flex justify-center">
-        <form class="p-8 w-[400px]" v-on:submit.prevent="go()">
+        <form class="p-8 w-[400px]" v-on:submit.prevent="checkoutLoginScope.go">
             <h1 class="font-bold text-4xl text-center mb-5">@lang('Checkout')</h1>
 
             <x-rapidez::input
@@ -8,19 +8,19 @@
                 name="email"
                 type="email"
                 placeholder="Email"
-                v-bind:value="email"
-                v-on:input="loginInputChange"
+                v-bind:value="checkoutLoginScope.email"
+                v-on:input="checkoutLoginScope.loginInputChange"
                 required
             />
             <x-rapidez::input
-                v-if="!emailAvailable"
+                v-if="!checkoutLoginScope.emailAvailable"
                 :label="false"
                 class="mt-3"
                 name="password"
                 type="password"
                 placeholder="Password"
                 ref="password"
-                v-on:input="loginInputChange"
+                v-on:input="checkoutLoginScope.loginInputChange"
                 required
             />
 
@@ -29,7 +29,7 @@
             </x-rapidez::button>
 
             @if (App::providerIsLoaded('Rapidez\Account\AccountServiceProvider'))
-                <a href="{{ route('account.forgotpassword') }}" class="inline-block text-sm hover:underline mt-5" v-if="!emailAvailable">
+                <a href="{{ route('account.forgotpassword') }}" class="inline-block text-sm hover:underline mt-5" v-if="!checkoutLoginScope.emailAvailable">
                     @lang('Forgot your password?')
                 </a>
             @endif

--- a/resources/views/checkout/steps/payment.blade.php
+++ b/resources/views/checkout/steps/payment.blade.php
@@ -1,12 +1,12 @@
 @php($checkoutAgreements = \Rapidez\Core\Models\CheckoutAgreement::all())
 
 <h1 class="font-bold text-4xl mb-5">@lang('Payment method')</h1>
-<form class="bg-highlight p-8 rounded mt-6" v-on:submit.prevent="save(['payment_method'], 4)">
-    <div class="my-2 border bg-white p-4 rounded" v-for="(method, index) in checkout.payment_methods">
+<form class="bg-highlight p-8 rounded mt-6" v-on:submit.prevent="checkoutScope.save(['payment_method'], 4)">
+    <div class="my-2 border bg-white p-4 rounded" v-for="(method, index) in checkoutScope.checkout.payment_methods">
         <x-rapidez::radio
             v-bind:value="method.code"
             v-bind:dusk="'method-'+index"
-            v-model="checkout.payment_method"
+            v-model="checkoutScope.checkout.payment_method"
             class="[&+div]:flex-1"
         >
             <div class="flex items-center">
@@ -48,7 +48,7 @@
                         <x-rapidez::checkbox
                             name="agreement_ids[]"
                             :value="$agreement->agreement_id"
-                            v-model="checkout.agreement_ids"
+                            v-model="checkoutScope.checkout.agreement_ids"
                             dusk="agreements"
                             required
                         >

--- a/resources/views/checkout/steps/success.blade.php
+++ b/resources/views/checkout/steps/success.blade.php
@@ -1,15 +1,15 @@
 <checkout-success>
-    <template slot-scope="{ order, hideBilling, shipping, billing, items }">
-        <div dusk="checkout-success" v-cloak v-if="order">
+    <template slot-scope="checkoutSuccessScope">
+        <div dusk="checkout-success" v-cloak v-if="checkoutSuccessScope.order">
             <h1 class="font-bold text-4xl mb-5">@lang('Order placed succesfully')</h1>
             <div class="bg-highlight rounded p-8">
                 <p>@lang('We will get to work for you right away')</p>
-                <p>@lang('We will send a confirmation of your order to') <span class="font-bold">@{{ order.customer_email }}</span></p>
+                <p>@lang('We will send a confirmation of your order to') <span class="font-bold">@{{ checkoutSuccessScope.order.customer_email }}</span></p>
             </div>
             <div class="mt-4">
                 <div
                     class="flex flex-wrap items-center mb-4 border-b pb-2"
-                    v-for="(item, productId, index) in items"
+                    v-for="(item, productId, index) in checkoutSuccessScope.items"
                 >
                     <div class="w-1/6 sm:w-1/12 pr-3">
                         <a :href="item.url" class="block">
@@ -41,22 +41,22 @@
                 </div>
             </div>
             <div class="flex flex-col mt-4 gap-x-4 md:flex-row">
-                <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral md:w-1/2" v-if="billing">
+                <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral md:w-1/2" v-if="checkoutSuccessScope.billing">
                     <p class="text-neutral font-lg font-bold mb-2">@lang('Billing address')</p>
                     <ul>
-                        <li>@{{ billing.firstname }} @{{ billing.lastname }}</li>
-                        <li>@{{ billing.street }}</li>
-                        <li>@{{ billing.postcode }} - @{{ billing.city }} - @{{ billing.country_id }}</li>
-                        <li>@{{ billing.telephone }}</li>
+                        <li>@{{ checkoutSuccessScope.billing.firstname }} @{{ checkoutSuccessScope.billing.lastname }}</li>
+                        <li>@{{ checkoutSuccessScope.billing.street }}</li>
+                        <li>@{{ checkoutSuccessScope.billing.postcode }} - @{{ checkoutSuccessScope.billing.city }} - @{{ checkoutSuccessScope.billing.country_id }}</li>
+                        <li>@{{ checkoutSuccessScope.billing.telephone }}</li>
                     </ul>
                 </div>
-                <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral mt-4 md:mt-0 md:w-1/2" v-if="shipping">
+                <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral mt-4 md:mt-0 md:w-1/2" v-if="checkoutSuccessScope.shipping">
                     <p class="text-neutral font-lg font-bold mb-2">@lang('Shipping address')</p>
                     <ul>
-                        <li>@{{ shipping.firstname }} @{{ shipping.lastname }}</li>
-                        <li>@{{ shipping.street }}</li>
-                        <li>@{{ shipping.postcode }} - @{{ shipping.city }} - @{{ shipping.country_id }}</li>
-                        <li>@{{ shipping.telephone }}</li>
+                        <li>@{{ checkoutSuccessScope.shipping.firstname }} @{{ checkoutSuccessScope.shipping.lastname }}</li>
+                        <li>@{{ checkoutSuccessScope.shipping.street }}</li>
+                        <li>@{{ checkoutSuccessScope.shipping.postcode }} - @{{ checkoutSuccessScope.shipping.city }} - @{{ checkoutSuccessScope.shipping.country_id }}</li>
+                        <li>@{{ checkoutSuccessScope.shipping.telephone }}</li>
                     </ul>
                 </div>
             </div>
@@ -64,11 +64,11 @@
             <div class="flex flex-col mt-4 gap-x-4 md:flex-row">
                 <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral md:w-1/2">
                     <p class="text-neutral font-lg font-bold mb-2">@lang('Shipping method')</p>
-                    <p>@{{ order.shipping_description }}</p>
+                    <p>@{{ checkoutSuccessScope.order.shipping_description }}</p>
                 </div>
                 <div class="w-full p-8 bg-highlight rounded border-l-2 border-neutral mt-4 md:mt-0 md:w-1/2">
                     <p class="text-neutral font-lg font-bold mb-2">@lang('Payment method')</p>
-                    <p v-for="method in order.sales_order_payments">@{{ method.additional_information.method_title || method.additional_information.raw_details_info.method_title }}</p>
+                    <p v-for="method in checkoutSuccessScope.order.sales_order_payments">@{{ method.additional_information.method_title || method.additional_information.raw_details_info.method_title }}</p>
                 </div>
             </div>
         </div>

--- a/resources/views/components/cookie-notice.blade.php
+++ b/resources/views/components/cookie-notice.blade.php
@@ -8,14 +8,14 @@
         show-until-close
         v-cloak
     >
-        <dialog slot-scope="{ close }" class="container rounded bg-white p-6 shadow fixed inset-x-0 bottom-4 z-30">
+        <dialog slot-scope="popupScope" class="container rounded bg-white p-6 shadow fixed inset-x-0 bottom-4 z-30">
             <div class="flex flex-wrap items-center justify-between">
                 <div class="flex-1 items-center">
                     <div class="text-sm text-black">
                         {{ $slot }}
                     </div>
                 </div>
-                <x-rapidez::button.outline @click="close" class="mt-3 w-full shrink-0 md:ml-6 md:w-auto">
+                <x-rapidez::button.outline @click="popupScope.close" class="mt-3 w-full shrink-0 md:ml-6 md:w-auto">
                     {{ $button ?? __('Accept cookies') }}
                 </x-rapidez::button.outline>
             </div>

--- a/resources/views/components/country-select.blade.php
+++ b/resources/views/components/country-select.blade.php
@@ -1,7 +1,7 @@
 <graphql query="{ countries { two_letter_abbreviation full_name_locale } }" cache="countries">
-    <div v-if="data" slot-scope="{ data }">
+    <div v-if="countryQueryScope.data" slot-scope="countryQueryScope">
         <x-rapidez::select {{ $attributes }}>
-            <option v-for="country in data.countries" :value="country.two_letter_abbreviation.toUpperCase()">
+            <option v-for="country in countryQueryScope.data.countries" :value="country.two_letter_abbreviation.toUpperCase()">
                 @{{ country.full_name_locale }}
             </option>
         </x-rapidez::select>

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -18,8 +18,8 @@
         }]"
         v-cloak
     >
-        <div slot-scope="{ loaded, filters, sortOptions, reactiveFilters, getQuery, _renderProxy: listingSlotProps }">
-            <x-rapidez::reactive-base v-if="loaded">
+        <div slot-scope="listingScope">
+            <x-rapidez::reactive-base v-if="listingScope.loaded">
                 @isset($query)
                     <reactive-component
                         component-id="query-filter"
@@ -29,7 +29,7 @@
                 @endisset
                 <reactive-component
                     component-id="score-position"
-                    :custom-query="getQuery"
+                    :custom-query="listingScope.getQuery"
                     :show-filter="false"
                 ></reactive-component>
 

--- a/resources/views/components/notifications.blade.php
+++ b/resources/views/components/notifications.blade.php
@@ -1,6 +1,6 @@
 <notifications v-cloak>
-    <div class="fixed sm:max-w-sm sm:w-full top-6 right-6 left-6 sm:left-auto flex flex-col {{ config('rapidez.frontend.z-indexes.notification') }}" slot-scope="{ notifications }">
-        <notification v-if="notifications.length" v-for="(notification, index) in notifications" :notification="notification" :key="index +1">
+    <div class="fixed sm:max-w-sm sm:w-full top-6 right-6 left-6 sm:left-auto flex flex-col {{ config('rapidez.frontend.z-indexes.notification') }}" slot-scope="notificationsScope">
+        <notification v-if="notificationsScope.notifications.length" v-for="(notification, index) in notificationsScope.notifications" :notification="notification" :key="index + 1">
             <transition
                 enter-active-class="ease-in-out duration-500"
                 enter-class="opacity-0"
@@ -8,25 +8,25 @@
                 leave-active-class="ease-in-out duration-500"
                 leave-class="opacity-100"
                 leave-to-class="opacity-0"
-                slot-scope="{ message, type, show, close, classes, link }"
+                slot-scope="notificationScope"
             >
-                <component :is="link ? 'a' : 'div'" v-if="show" class="relative flex items-end justify-center pointer-events-none mb-3 sm:items-start sm:justify-end {{ config('rapidez.frontend.z-indexes.notification') }}" :class="{ 'pointer-events-none': !link }">
-                    <div class="max-w-sm w-full shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden border" :class="classes">
+                <component :is="notificationScope.link ? 'a' : 'div'" v-if="notificationScope.show" class="relative flex items-end justify-center pointer-events-none mb-3 sm:items-start sm:justify-end {{ config('rapidez.frontend.z-indexes.notification') }}" :class="{ 'pointer-events-none': !notificationScope.link }">
+                    <div class="max-w-sm w-full shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden border" :class="notificationScope.classes">
                         <div class="p-4">
                             <div class="flex items-start">
                                 <div class="flex-shrink-0">
-                                    <x-heroicon-o-check-circle class="h-6 w-6" v-if="type == 'success'"/>
-                                    <x-heroicon-o-exclamation-circle class="h-6 w-6" v-if="type == 'error'"/>
-                                    <x-heroicon-o-information-circle class="h-6 w-6" v-if="type == 'info'"/>
-                                    <x-heroicon-o-exclamation-triangle class="h-6 w-6" v-if="type == 'warning'"/>
+                                    <x-heroicon-o-check-circle class="h-6 w-6" v-if="notificationScope.type == 'success'"/>
+                                    <x-heroicon-o-exclamation-circle class="h-6 w-6" v-else-if="notificationScope.type == 'error'"/>
+                                    <x-heroicon-o-information-circle class="h-6 w-6" v-else-if="notificationScope.type == 'info'"/>
+                                    <x-heroicon-o-exclamation-triangle class="h-6 w-6" v-else-if="notificationScope.type == 'warning'"/>
                                 </div>
                                 <div class="ml-3 w-0 flex-1 pt-0.5">
                                     <p class="text-sm font-medium">
-                                        @{{ message }}
+                                        @{{ notificationScope.message }}
                                     </p>
                                 </div>
                                 <div class="ml-4 flex-shrink-0 flex self-start">
-                                    <button @click.prevent="close()" class="rounded-md inline-flex focus:outline-none focus:ring-none focus:ring-offset-none">
+                                    <button @click.prevent="notificationScope.close" class="rounded-md inline-flex focus:outline-none focus:ring-none focus:ring-offset-none">
                                         <span class="sr-only">@lang('Close')</span>
                                         <x-heroicon-s-x-mark class="h-5 w-5"/>
                                     </button>

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -1,8 +1,8 @@
 @props(['value', 'title' => false, 'field' => 'sku.keyword'])
 
 @if ($value)
-    <lazy v-slot="{ intersected }">
-        <listing v-if="intersected">
+    <lazy v-slot="lazyScope">
+        <listing v-if="lazyScope.intersected">
             <x-rapidez::reactive-base>
                 <reactive-list
                     component-id="{{ md5(serialize($value)) }}"
@@ -24,36 +24,36 @@
 
                     <div slot="renderNoResults"></div>
 
-                    <div class="relative" slot="render" slot-scope="{ data, loading }" v-if="!loading">
+                    <div class="relative" slot="render" slot-scope="listRenderScope" v-if="!listRenderScope.loading">
                         <slider>
-                            <div slot-scope="{ navigate, showLeft, showRight, currentSlide, slidesTotal }">
+                            <div slot-scope="listSliderScope">
                                 <div class="-mx-2 flex mt-5 overflow-x-auto snap-x scrollbar-hide scroll-smooth snap-mandatory" ref="slider">
-                                    <template v-for="item in data">
+                                    <template v-for="item in listRenderScope.data">
                                         @include('rapidez::listing.partials.item', ['slider' => true])
                                     </template>
                                 </div>
                                 <x-rapidez::button.slider
                                     class="absolute left-0 top-1/2 sm:-translate-x-1/2 -translate-y-1/2"
-                                    v-if="showLeft"
-                                    v-on:click="navigate(currentSlide - 1)"
+                                    v-if="listSliderScope.showLeft"
+                                    v-on:click="listSliderScope.navigate(listSliderScope.currentSlide - 1)"
                                     :aria-label="__('Prev')"
                                 >
                                     <x-heroicon-o-chevron-left class="w-6 h-6 shrink-0"/>
                                 </x-rapidez::button.slider>
                                 <x-rapidez::button.slider
                                     class="absolute right-0 top-1/2 sm:translate-x-1/2 -translate-y-1/2"
-                                    v-if="showRight"
-                                    v-on:click="navigate(currentSlide + 1)"
+                                    v-if="listSliderScope.showRight"
+                                    v-on:click="listSliderScope.navigate(listSliderScope.currentSlide + 1)"
                                     :aria-label="__('Next')"
                                 >
                                     <x-heroicon-o-chevron-right class="w-6 h-6 shrink-0"/>
                                 </x-rapidez::button.slider>
-                                <div v-show="slidesTotal > 1" class="flex flex-row justify-center w-full mt-[35px]">
+                                <div v-show="listSliderScope.slidesTotal > 1" class="flex flex-row justify-center w-full mt-[35px]">
                                     <div
-                                        v-for="slide, index in slidesTotal"
-                                        v-on:click="navigate(index)"
+                                        v-for="slide, index in listSliderScope.slidesTotal"
+                                        v-on:click="listSliderScope.navigate(index)"
                                         class="relative bg-white rounded-full border w-[15px] h-[15px] mx-1 cursor-pointer"
-                                        :class="{ 'bg-neutral border-0': index === currentSlide }">
+                                        :class="{ 'bg-neutral border-0': index === listSliderScope.currentSlide }">
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/layouts/partials/footer/newsletter.blade.php
+++ b/resources/views/layouts/partials/footer/newsletter.blade.php
@@ -4,17 +4,17 @@
     <div class="sm:w-full sm:max-w-md xl:mt-0" dusk="newsletter">
         <lazy>
             <graphql-mutation query="mutation visitor ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }" :alert="false" :clear="true">
-                <div slot-scope="{ mutate, variables, mutated, error }">
-                    <p v-if="mutated" class="text-neutral text-xl font-bold" v-cloak>
+                <div slot-scope="newsletterQueryScope">
+                    <p v-if="newsletterQueryScope.mutated" class="text-neutral text-xl font-bold" v-cloak>
                         @lang('Thank you for subscribing!')
                     </p>
                     <div v-else>
-                        <form class="mt-4 sm:flex sm:max-w-md items-center" v-on:submit.prevent="mutate">
+                        <form class="mt-4 sm:flex sm:max-w-md items-center" v-on:submit.prevent="newsletterQueryScope.mutate">
                             <x-rapidez::input
                                 :label="false"
                                 name="email"
                                 type="email"
-                                v-model="variables.email"
+                                v-model="newsletterQueryScope.variables.email"
                                 class="w-full min-w-0 appearance-none rounded-md border h-10 border-text-inactive bg-white py-2 px-4 text-base text-gray-900 placeholder-text-neutral shadow-sm focus:border-indigo-500 focus:placeholder-gray-400 focus:outline-none focus:ring-indigo-500"
                                 wrapperClass="flex-grow"
                                 dusk="newsletter-email"
@@ -32,8 +32,8 @@
                                 </x-rapidez::button>
                             </div>
                         </form>
-                        <p v-if="error" class="mt-3 text-sm text-red-700" v-cloak>
-                            @{{ error }}
+                        <p v-if="newsletterQueryScope.error" class="mt-3 text-sm text-red-700" v-cloak>
+                            @{{ newsletterQueryScope.error }}
                         </p>
                         <p class="mt-3 text-sm">
                             @lang('We care about the protection of your data. Read our')

--- a/resources/views/layouts/partials/header/account.blade.php
+++ b/resources/views/layouts/partials/header/account.blade.php
@@ -1,11 +1,11 @@
 <div class="mr-3">
     <toggler v-if="$root.loggedIn" v-cloak>
-        <div slot-scope="{ toggle, close, isOpen }" v-on-click-away="close">
-            <button dusk="account_menu" class="flex my-1" v-on:click="toggle">
+        <div slot-scope="accountTogglerScope" v-on-click-away="accountTogglerScope.close">
+            <button dusk="account_menu" class="flex my-1" v-on:click="accountTogglerScope.toggle">
                 <x-heroicon-o-user class="h-6 w-6"/>
                 @{{ $root.user.firstname }}
             </button>
-            <div v-if="isOpen" class="absolute bg-white border shadow rounded mr-1 {{ config('rapidez.frontend.z-indexes.header-dropdowns') }} {{ Route::currentRouteName() == 'checkout' ? 'right-0' : '' }}">
+            <div v-if="accountTogglerScope.isOpen" class="absolute bg-white border shadow rounded mr-1 {{ config('rapidez.frontend.z-indexes.header-dropdowns') }} {{ Route::currentRouteName() == 'checkout' ? 'right-0' : '' }}">
                 @if (App::providerIsLoaded('Rapidez\Account\AccountServiceProvider'))
                     <a class="block hover:bg-inactive px-3 py-2" href="{{ route('account.overview') }}">@lang('Account')</a>
                     <a class="block hover:bg-inactive px-3 py-2" href="{{ route('account.orders') }}">@lang('Orders')</a>
@@ -17,8 +17,8 @@
                     <button
                         class="block hover:bg-inactive px-3 py-2 cursor-pointer"
                         dusk="logout"
-                        slot-scope="{ logout }"
-                        @click="logout('/')"
+                        slot-scope="userLogoutScope"
+                        @click="userLogoutScope.logout('/')"
                     >
                         @lang('Logout')
                     </button>

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -42,7 +42,7 @@
             >
                 <div
                     class="{{ config('rapidez.frontend.z-indexes.header-dropdowns') }} absolute -inset-x-10 top-full max-h-[600px] overflow-auto rounded-b-xl border bg-white p-2 md:p-5 shadow-xl md:inset-x-0 md:w-full md:-translate-y-px"
-                    v-if="dataSearchScope.downshiftProps.isOpen && (dataSearchScope.suggestions.length || autocompleteScope.resultsCount)"
+                    v-if="dataSearchScope.downshiftProps.isOpen && (dataSearchScope.data.length || autocompleteScope.resultsCount)"
                 >
                     <template v-for="(resultsData, resultsType) in autocompleteScope.results ?? {}" v-if="resultsData?.hits?.length">
                         @foreach (config('rapidez.frontend.autocomplete.additionals') as $key => $fields)

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -18,7 +18,7 @@
     class="w-full"
     v-cloak
 >
-    <x-rapidez::reactive-base slot-scope="{ results, resultsCount, searchAdditionals, debounce, size, highlight }">
+    <x-rapidez::reactive-base slot-scope="autocompleteScope">
         <data-search
             placeholder="@lang('Search')"
             v-on:value-selected="search"
@@ -31,20 +31,20 @@
             :field-weights="Object.values(config.searchable)"
             :show-icon="false"
             fuzziness="AUTO"
-            :debounce="debounce"
-            :size="size"
+            :debounce="autocompleteScope.debounce"
+            :size="autocompleteScope.size"
             :highlight="true"
-            v-on:value-change="searchAdditionals($event)"
+            v-on:value-change="autocompleteScope.searchAdditionals($event)"
         >
             <div
                 slot="render"
-                slot-scope="{ downshiftProps: { isOpen }, data: suggestions }"
+                slot-scope="dataSearchScope"
             >
                 <div
                     class="{{ config('rapidez.frontend.z-indexes.header-dropdowns') }} absolute -inset-x-10 top-full max-h-[600px] overflow-auto rounded-b-xl border bg-white p-2 md:p-5 shadow-xl md:inset-x-0 md:w-full md:-translate-y-px"
-                    v-if="isOpen && (suggestions.length || resultsCount)"
+                    v-if="dataSearchScope.downshiftProps.isOpen && (dataSearchScope.suggestions.length || autocompleteScope.resultsCount)"
                 >
-                    <template v-for="(resultsData, resultsType) in results ?? {}" v-if="resultsData?.hits?.length">
+                    <template v-for="(resultsData, resultsType) in autocompleteScope.results ?? {}" v-if="resultsData?.hits?.length">
                         @foreach (config('rapidez.frontend.autocomplete.additionals') as $key => $fields)
                             @includeIf('rapidez::layouts.partials.header.autocomplete.' . $key)
                         @endforeach

--- a/resources/views/layouts/partials/header/autocomplete/categories.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/categories.blade.php
@@ -5,7 +5,7 @@
     <ul class="flex flex-col gap-1">
         <li v-for="hit in resultsData.hits" class="w-full">
             <a :href="hit._source.url" class="w-full hover:text-primary flex gap-1">
-                <span class="ml-2" v-html="highlight(hit, 'name')"></span>
+                <span class="ml-2" v-html="autocompleteScope.highlight(hit, 'name')"></span>
             </a>
         </li>
     </ul>

--- a/resources/views/layouts/partials/header/autocomplete/products.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/products.blade.php
@@ -1,9 +1,9 @@
 <ul class="gap-5 grid md:grid-cols-2">
-    <li v-for="suggestion in suggestions" :key="suggestion.source._id">
+    <li v-for="suggestion in dataSearchScope.suggestions" :key="suggestion.source._id">
         <a :href="suggestion.source.url | url" class="flex flex-wrap flex-1">
             <img :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento/catalog/product' + suggestion.source.thumbnail + '.webp'" class="self-center object-contain w-14 aspect-square" />
             <div class="flex flex-1 flex-wrap px-2">
-                <strong class="hyphens block w-full" v-html="highlight(suggestion, 'name')"></strong>
+                <strong class="hyphens block w-full" v-html="autocompleteScope.highlight(suggestion, 'name')"></strong>
                 <div class="self-end">@{{ suggestion.source.price | price }}</div>
             </div>
         </a>

--- a/resources/views/layouts/partials/header/minicart.blade.php
+++ b/resources/views/layouts/partials/header/minicart.blade.php
@@ -1,10 +1,10 @@
 <toggler>
-    <div class="relative" v-if="hasCart" v-on-click-away="close" slot-scope="{ toggle, close, isOpen }" v-cloak>
-        <button class="flex my-1 focus:outline-none" v-on:click="toggle">
+    <div class="relative" v-if="hasCart" v-on-click-away="minicartTogglerScope.close" slot-scope="minicartTogglerScope" v-cloak>
+        <button class="flex my-1 focus:outline-none" v-on:click="minicartTogglerScope.toggle">
             <x-heroicon-o-shopping-cart class="h-6 w-6"/>
             <span class="bg-neutral rounded-full w-6 h-6 text-white text-center" dusk="minicart-count">@{{ Math.round(cart.total_quantity) }}</span>
         </button>
-        <div v-if="isOpen" class="absolute right-0 bg-white border shadow rounded-xl p-5 {{ config('rapidez.frontend.z-indexes.header-dropdowns') }}">
+        <div v-if="minicartTogglerScope.isOpen" class="absolute right-0 bg-white border shadow rounded-xl p-5 {{ config('rapidez.frontend.z-indexes.header-dropdowns') }}">
             <table class="w-full mb-3">
                 <tr v-for="item in cart.items" class="[&>*]:pb-3">
                     <td class="block w-48 truncate overflow-hidden">@{{ item.product.name }}</td>

--- a/resources/views/listing/filters.blade.php
+++ b/resources/views/listing/filters.blade.php
@@ -5,7 +5,7 @@
         <lazy>
             @include('rapidez::listing.partials.filter.selected')
             @include('rapidez::listing.partials.filter.category')
-            <template v-for="filter in filters">
+            <template v-for="filter in listingScope.filters">
                 @include('rapidez::listing.partials.filter.price')
                 @include('rapidez::listing.partials.filter.swatch')
                 @include('rapidez::listing.partials.filter.boolean')

--- a/resources/views/listing/partials/filter/boolean.blade.php
+++ b/resources/views/listing/partials/filter/boolean.blade.php
@@ -2,24 +2,24 @@
     v-else-if="filter.input == 'boolean'"
     :component-id="filter.code"
     :data-field="filter.code+(filter.type != 'int' ? '.keyword' : '')"
-    :react="{and: reactiveFilters}"
+    :react="{and: listingScope.reactiveFilters}"
     :show-search="false"
     u-r-l-params
 >
     <div
         slot="render"
         class="relative pb-4"
-        slot-scope="{ data, handleChange, value }"
-        v-if="data.length > 0"
+        slot-scope="booleanFilterScope"
+        v-if="booleanFilterScope.data.length > 0"
     >
         <x-rapidez::filter.heading>
             <ul class="flex flex-col gap-1">
-                <li class="flex" v-for="item in data">
+                <li class="flex" v-for="item in booleanFilterScope.data">
                     <x-rapidez::checkbox
-                        v-bind:checked="value[item.key]"
-                        v-on:change="handleChange(item.key)"
+                        v-bind:checked="booleanFilterScope.value[item.key]"
+                        v-on:change="booleanFilterScope.handleChange(item.key)"
                     >
-                        <div class="font-sans font-medium text-sm items-center flex text-inactive" :class="{'text-neutral': value[item.key] == true}">
+                        <div class="font-sans font-medium text-sm items-center flex text-inactive" :class="{'text-neutral': booleanFilterScope.value[item.key] == true}">
                             <template v-if="item.key">@lang('Yes')</template>
                             <template v-if="!item.key">@lang('No')</template>
                             <span class="block ml-0.5 text-xs">(@{{ item.doc_count }})</span>

--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -4,24 +4,24 @@
         categories: { terms: { field: 'categories.keyword' } },
         category_paths: { terms: { field: 'category_paths.keyword' } }
     }})"
-    :react="{and: reactiveFilters.filter(item => item != 'category') }"
+    :react="{and: listingScope.reactiveFilters.filter(item => item != 'category') }"
     u-r-l-params
 >
-    <div slot-scope="{ aggregations, setQuery, value }">
-        <category-filter :aggregations="aggregations" :value="value" :set-query="setQuery">
-            <div slot-scope="{ hasResults, results }" class="pb-4">
+    <div slot-scope="categoryFilterComponentSlot">
+        <category-filter :aggregations="categoryFilterComponentSlot.aggregations" :value="categoryFilterComponentSlot.value" :set-query="categoryFilterComponentSlot.setQuery">
+            <div slot-scope="categoryFilterSlot" class="pb-4">
                 <x-rapidez::filter.heading>
                     <x-slot:title>
                         @lang('Category')
                     </x-slot:title>
-                    <input class="hidden" type="radio" name="category" value="" :checked="!value" v-on:change="setQuery({})"/>
+                    <input class="hidden" type="radio" name="category" value="" :checked="!categoryFilterComponentSlot.value" v-on:change="categoryFilterComponentSlot.setQuery({})"/>
                     <ul>
                         <category-filter-category
-                            v-for="category in results"
+                            v-for="category in categoryFilterSlot.results"
                             v-bind:key="category.key"
                             :category="category"
-                            :value="(value || config.category?.entity_id) + ''"
-                            :set-query="setQuery"
+                            :value="(categoryFilterComponentSlot.value || config.category?.entity_id) + ''"
+                            :set-query="categoryFilterComponentSlot.setQuery"
                         />
                     </ul>
                 </x-rapidez::filter.heading>

--- a/resources/views/listing/partials/filter/select.blade.php
+++ b/resources/views/listing/partials/filter/select.blade.php
@@ -7,36 +7,36 @@
         list: '!max-h-full [&>li]:!h-auto',
         label: 'text-inactive before:shrink-0'
     }"
-    :react="{and: filter.input == 'multiselect' ? reactiveFilters : reactiveFilters.filter(item => item != filter.code) }"
+    :react="{and: filter.input == 'multiselect' ? listingScope.reactiveFilters : listingScope.reactiveFilters.filter(item => item != filter.code) }"
     :query-format="filter.input == 'multiselect' ? 'and' : 'or'"
     :show-search="false"
     u-r-l-params
 >
-    <div slot="render" class="relative pb-4" slot-scope="{ data, handleChange, value }" v-if="data.length > 1">
+    <div slot="render" class="relative pb-4" slot-scope="selectFilterScope" v-if="selectFilterScope.data.length > 1">
         <x-rapidez::filter.heading>
             <toggler>
-                <ul class="flex flex-col gap-1" slot-scope="{ toggle, isOpen }">
+                <ul class="flex flex-col gap-1" slot-scope="selectFilterTogglerScope">
                     <li
-                        v-for="item, index in data"
-                        v-if="index < 6 || isOpen"
+                        v-for="item, index in selectFilterScope.data"
+                        v-if="index < 6 || selectFilterTogglerScope.isOpen"
                         :key="item._id"
                         class="flex justify-between text-base text-inactive"
                     >
                         <div class="flex">
                             <x-rapidez::checkbox
-                                v-bind:checked="value[item.key]"
-                                v-on:change="handleChange(item.key)"
+                                v-bind:checked="selectFilterScope.value[item.key]"
+                                v-on:change="selectFilterScope.handleChange(item.key)"
                             >
-                                <div class="font-sans font-medium text-inactive items-center text-sm flex" :class="{'text-neutral': value[item.key] == true}">
+                                <div class="font-sans font-medium text-inactive items-center text-sm flex" :class="{'text-neutral': selectFilterScope.value[item.key] == true}">
                                     @{{ item.key }}
                                     <span class="block ml-0.5 text-xs">(@{{ item.doc_count }})</span>
                                 </div>
                             </x-rapidez::checkbox>
                         </div>
                     </li>
-                    <li v-if="data.length > 6">
-                        <button class="text-sm text-primary" @click="toggle">
-                            <span v-if="isOpen" class="flex gap-x-4">
+                    <li v-if="selectFilterScope.data.length > 6">
+                        <button class="text-sm text-primary" @click="selectFilterTogglerScope.toggle">
+                            <span v-if="selectFilterTogglerScope.isOpen" class="flex gap-x-4">
                                 @lang('Less options')
                             </span>
                             <span v-else class="flex gap-x-4">

--- a/resources/views/listing/partials/filter/selected.blade.php
+++ b/resources/views/listing/partials/filter/selected.blade.php
@@ -1,14 +1,14 @@
 <selected-filters :inner-class="{ button: '!hidden last:!inline-flex' }">
     <x-rapidez::button
         class="w-full mb-3 text-sm"
-        slot-scope="{ clearValues, selectedValues, components }"
-        v-on:click="clearValues"
-        v-if="Object.keys(selectedValues).filter(function (id) {
-            let value = selectedValues[id].value
+        slot-scope="selectedFiltersScope"
+        v-on:click="selectedFiltersScope.clearValues"
+        v-if="Object.keys(selectedFiltersScope.selectedValues).filter(function (id) {
+            let value = selectedFiltersScope.selectedValues[id].value
             let isArray = Array.isArray(value)
 
-            return components.includes(id)
-                && selectedValues[id].showFilter
+            return selectedFiltersScope.components.includes(id)
+                && selectedFiltersScope.selectedValues[id].showFilter
                 && (
                     (isArray && value.length)
                     || (!isArray && value)

--- a/resources/views/listing/partials/filter/swatch.blade.php
+++ b/resources/views/listing/partials/filter/swatch.blade.php
@@ -5,31 +5,31 @@
     :inner-class="{
         title: 'capitalize text-sm font-medium text-gray-900',
     }"
-    :react="{and: filter.input == 'multiselect' ? reactiveFilters : reactiveFilters.filter(item => item != filter.code) }"
+    :react="{and: filter.input == 'multiselect' ? listingScope.reactiveFilters : listingScope.reactiveFilters.filter(item => item != filter.code) }"
     :query-format="filter.input == 'multiselect' ? 'and' : 'or'"
     :show-search="false"
     :show-checkbox="false"
     u-r-l-params
 >
-    <div slot="render" class="pb-4" slot-scope="{ data, value, handleChange }">
+    <div slot="render" class="pb-4" slot-scope="swatchFilterScope">
         <x-rapidez::filter.heading>
             <div class="flex flex-wrap gap-2 items-center my-1">
-                <template v-for="swatch in data">
+                <template v-for="swatch in swatchFilterScope.data">
                     <label
                         v-if="filter.visual_swatch"
                         class="size-6 ring-black/5 ring-1 ring-inset cursor-pointer flex items-center justify-center hover:opacity-75 rounded-full transition"
-                        v-bind:class="{'outline-2 outline outline-black outline-offset-1' : value[swatch.key]}"
+                        v-bind:class="{'outline-2 outline outline-black outline-offset-1' : swatchFilterScope.value[swatch.key]}"
                         v-bind:style="{ background: $root.swatches[filter.code]?.options[swatch.key].swatch }"
                     >
-                        <input type="checkbox" v-on:change="handleChange(swatch.key)" class="hidden" v-bind:checked="value[swatch.key]"/>
+                        <input type="checkbox" v-on:change="swatchFilterScope.handleChange(swatch.key)" class="hidden" v-bind:checked="swatchFilterScope.value[swatch.key]"/>
                     </label>
                     <label
                         v-else
                         class="border px-3 transition-all rounded cursor-pointer text-sm text-inactive font-medium"
-                        v-bind:class="{'border-neutral text-neutral' : value[swatch.key]}"
+                        v-bind:class="{'border-neutral text-neutral' : swatchFilterScope.value[swatch.key]}"
                     >
                         @{{ $root.swatches[filter.code]?.options[swatch.key].swatch }}
-                        <input type="checkbox" v-on:change="handleChange(swatch.key)" class="hidden" v-bind:checked="value[swatch.key]"/>
+                        <input type="checkbox" v-on:change="swatchFilterScope.handleChange(swatch.key)" class="hidden" v-bind:checked="swatchFilterScope.value[swatch.key]"/>
                     </label>
                 </template>
             </div>

--- a/resources/views/listing/partials/item/addtocart.blade.php
+++ b/resources/views/listing/partials/item/addtocart.blade.php
@@ -1,11 +1,11 @@
-<add-to-cart v-bind:product="item" v-slot="addToCart" v-cloak>
-    <form class="px-2 pb-2" v-on:submit.prevent="addToCart.add">
+<add-to-cart v-bind:product="item" v-slot="addToCartScope" v-cloak>
+    <form class="px-2 pb-2" v-on:submit.prevent="addToCartScope.add">
         <div class="flex items-center space-x-2 mb-2">
             <div class="font-semibold">
-                @{{ (addToCart.simpleProduct.special_price || addToCart.simpleProduct.price) | price }}
+                @{{ (addToCartScope.simpleProduct.special_price || addToCartScope.simpleProduct.price) | price }}
             </div>
-            <div class="line-through text-sm" v-if="addToCart.simpleProduct.special_price">
-                @{{ addToCart.simpleProduct.price | price }}
+            <div class="line-through text-sm" v-if="addToCartScope.simpleProduct.special_price">
+                @{{ addToCartScope.simpleProduct.price | price }}
             </div>
         </div>
 

--- a/resources/views/listing/partials/item/super_attributes.blade.php
+++ b/resources/views/listing/partials/item/super_attributes.blade.php
@@ -6,7 +6,7 @@
         label=""
         v-bind:id="item.entity_id+'_super_attribute_'+superAttributeId"
         v-bind:name="superAttributeId"
-        v-model="addToCart.options[superAttributeId]"
+        v-model="addToCartScope.options[superAttributeId]"
         class="block mb-3"
         required
     >
@@ -14,10 +14,10 @@
             @lang('Select') @{{ superAttribute.label.toLowerCase() }}
         </option>
         <option
-            v-for="(option, optionId) in addToCart.getOptions(superAttribute.code)"
+            v-for="(option, optionId) in addToCartScope.getOptions(superAttribute.code)"
             v-text="option.label"
             :value="optionId"
-            :disabled="addToCart.disabledOptions['super_'+superAttribute.code].includes(optionId)"
+            :disabled="addToCartScope.disabledOptions['super_'+superAttribute.code].includes(optionId)"
         />
     </x-rapidez::select>
 </div>

--- a/resources/views/listing/partials/stats.blade.php
+++ b/resources/views/listing/partials/stats.blade.php
@@ -1,13 +1,13 @@
-<div class="flex-wrap flex-1 gap-1 text-base flex justify-between" slot="renderResultStats" slot-scope="{ numberOfResults, numberOfPages, currentPage, time }">
-    @{{ numberOfResults }} @lang('products')
-    <template v-if="numberOfPages > 1">
-        (@lang('page'): @{{ currentPage + 1 }}/@{{ numberOfPages }})
+<div class="flex-wrap flex-1 gap-1 text-base flex justify-between" slot="renderResultStats" slot-scope="renderResultStatsScope">
+    @{{ renderResultStatsScope.numberOfResults }} @lang('products')
+    <template v-if="renderResultStatsScope.numberOfPages > 1">
+        (@lang('page'): @{{ renderResultStatsScope.currentPage + 1 }}/@{{ renderResultStatsScope.numberOfPages }})
     </template>
 
     <div class="justify-self-end mr-5">
         <div class="flex items-center gap-1 flex-wrap">
             <span class="text-sm text-inactive">@lang('Items per page'):</span>
-            <select class="{{ $dropdownClasses }}" v-model="listingSlotProps.pageSize">
+            <select class="{{ $dropdownClasses }}" v-model="listingScope.pageSize">
                 <option
                     v-for="size in $root.config.grid_per_page_values.concat($root.config.translations.all)"
                     v-bind:value="size"

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -6,9 +6,9 @@
     list-class="flex flex-wrap mt-5 -mx-4 sm:-mx-1 overflow-hidden"
     :pagination="true"
     v-on:page-click="scrollToElement('#products')"
-    :size="isNaN(parseInt(listingSlotProps.pageSize)) ? 10000 : parseInt(listingSlotProps.pageSize)"
-    :react="{and: reactiveFilters}"
-    :sort-options="sortOptions"
+    :size="isNaN(parseInt(listingScope.pageSize)) ? 10000 : parseInt(listingScope.pageSize)"
+    :react="{and: listingScope.reactiveFilters}"
+    :sort-options="listingScope.sortOptions"
     :inner-class="{
         button: 'pagination-button',
         current: 'current-button',

--- a/resources/views/product/partials/images.blade.php
+++ b/resources/views/product/partials/images.blade.php
@@ -17,17 +17,17 @@
     @endif
 
     <images v-cloak>
-        <div slot-scope="{ images, active, zoomed, toggleZoom, change }">
-            <div class="relative" v-if="images.length">
+        <div slot-scope="imagesScope">
+            <div class="relative" v-if="imagesScope.images.length">
                 <a
-                    :href="config.media_url + '/catalog/product' + images[active]"
+                    :href="config.media_url + '/catalog/product' + imagesScope.images[imagesScope.active]"
                     class="flex items-center justify-center"
-                    :class="zoomed ? 'fixed inset-0 bg-white !h-full {{ config('rapidez.frontend.z-indexes.lightbox') }} cursor-[zoom-out]' : 'border rounded p-5 h-[440px]'"
-                    v-on:click.prevent="toggleZoom"
+                    :class="imagesScope.zoomed ? 'fixed inset-0 bg-white !h-full {{ config('rapidez.frontend.z-indexes.lightbox') }} cursor-[zoom-out]' : 'border rounded p-5 h-[440px]'"
+                    v-on:click.prevent="imagesScope.toggleZoom"
                 >
                     <img
-                        v-if="!zoomed"
-                        :src="'/storage/{{ config('rapidez.store') }}/resizes/400/magento/catalog/product' + images[active] + '.webp'"
+                        v-if="!imagesScope.zoomed"
+                        :src="'/storage/{{ config('rapidez.store') }}/resizes/400/magento/catalog/product' + imagesScope.images[imagesScope.active] + '.webp'"
                         alt="{{ $product->name }}"
                         class="object-contain w-full m-auto max-h-[400px]"
                         width="400"
@@ -35,27 +35,27 @@
                     />
                     <img
                         v-else
-                        :src="config.media_url + '/catalog/product' + images[active]"
+                        :src="config.media_url + '/catalog/product' + imagesScope.images[imagesScope.active]"
                         alt="{{ $product->name }}"
                         class="max-h-full max-w-full"
                         loading="lazy"
                     />
                 </a>
-                <button class="{{ config('rapidez.frontend.z-indexes.lightbox') }} top-1/2 left-3 -translate-y-1/2" :class="zoomed ? 'fixed' : 'absolute'" v-if="active" v-on:click="change(active-1)" aria-label="@lang('Prev')">
+                <button class="{{ config('rapidez.frontend.z-indexes.lightbox') }} top-1/2 left-3 -translate-y-1/2" :class="imagesScope.zoomed ? 'fixed' : 'absolute'" v-if="imagesScope.active" v-on:click="imagesScope.change(imagesScope.active-1)" aria-label="@lang('Prev')">
                     <x-heroicon-o-chevron-left class="h-8 w-8 text-gray-900" />
                 </button>
-                <button class="{{ config('rapidez.frontend.z-indexes.lightbox') }} top-1/2 right-3 -translate-y-1/2" :class="zoomed ? 'fixed' : 'absolute'" v-if="active != images.length-1" v-on:click="change(active+1)" aria-label="@lang('Next')">
+                <button class="{{ config('rapidez.frontend.z-indexes.lightbox') }} top-1/2 right-3 -translate-y-1/2" :class="imagesScope.zoomed ? 'fixed' : 'absolute'" v-if="imagesScope.active != imagesScope.images.length-1" v-on:click="imagesScope.change(imagesScope.active+1)" aria-label="@lang('Next')">
                     <x-heroicon-o-chevron-right class="h-8 w-8 text-gray-900" />
                 </button>
             </div>
             <x-rapidez::no-image v-else class="h-96 rounded" />
 
-            <div v-if="images.length > 1" class="flex" :class="zoomed ? 'fixed bottom-0 left-3 {{ config('rapidez.z-indexes.lightbox') }}' : ' flex-wrap mt-3'">
+            <div v-if="imagesScope.images.length > 1" class="flex" :class="imagesScope.zoomed ? 'fixed bottom-0 left-3 {{ config('rapidez.z-indexes.lightbox') }}' : ' flex-wrap mt-3'">
                 <button
-                    v-for="(image, imageId) in images"
+                    v-for="(image, imageId) in imagesScope.images"
                     class="flex items-center justify-center bg-white border rounded p-2 mr-3 mb-3 h-[100px] w-[100px]"
-                    :class="active == imageId ? 'border-neutral' : ''"
-                    @click="change(imageId)"
+                    :class="imagesScope.active == imageId ? 'border-neutral' : ''"
+                    @click="imagesScope.change(imageId)"
                 >
                     <img
                         :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento/catalog/product' + image + '.webp'"
@@ -67,7 +67,7 @@
                     />
                 </button>
             </div>
-            <div v-if="zoomed" class="{{ config('rapidez.frontend.z-indexes.lightbox') }} pointer-events-none fixed top-3 right-3">
+            <div v-if="imagesScope.zoomed" class="{{ config('rapidez.frontend.z-indexes.lightbox') }} pointer-events-none fixed top-3 right-3">
                 <x-heroicon-o-x-mark class="h-6 w-6" />
             </div>
         </div>


### PR DESCRIPTION
The destructuring made it harder to add functionality to vue components, as it meant you also had to overwrite the view containing the `slot-scope` just because we defined every individual thing unnecessarily.

This is of course an extremely breaking change, and should also be done in other packages. Just making sure we actually want this before I do that though 😉