### PR TITLE
Styling quantity select / enhanced quantity select

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,3 +24,9 @@ listing {
     margin: unset;
     white-space: unset;
 }
+
+/* Remove default browser arrows for input type="number" */
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+    @apply appearance-none m-0;
+}

--- a/resources/views/components/quantity/enhanced.blade.php
+++ b/resources/views/components/quantity/enhanced.blade.php
@@ -6,10 +6,14 @@
 ])
 
 <quantity-select :input-ref="'qty-select-' + {{ $index }}" :model="parseInt({{ $model }})" :min-qty="{{ $minSaleQty }}" :increment="{{ $qtyIncrements }}" v-slot="qtySelect">
-    <div class="flex">
-        <x-rapidez::button.outline @click.prevent="qtySelect.decrease">
-            <div class="bg-neutral h-0.5 w-3 hover:bg-white"></div>
-        </x-rapidez::button.outline>
+    <div class="flex items-center justify-center border rounded bg-white h-14 self-start">
+        <button
+            @click.prevent="qtySelect.decrease"
+            v-bind:disabled="qtySelect.model <= qtySelect.defaultQty"
+            class="shrink-0 pl-2.5 text-neutral disabled:cursor-not-allowed disabled:text-neutral/50"
+        >
+            <x-heroicon-o-minus-small class="mt-0.5 size-5" stroke-width="2" />
+        </button>
         <x-rapidez::input
             name="qty"
             type="number"
@@ -17,16 +21,16 @@
             v-model="{{ $model }}"
             dusk="qty-select"
             v-bind:ref="'qty-select-' + {{ $index }}"
-            class="!w-14 !px-1 text-center"
+            class="border-none !w-12 bg-transparent font-medium text-center !px-0 sm:text-base"
             @change="(e) => qtySelect.updateQty(e.target.value)"
             :min="$minSaleQty"
             :step="$qtyIncrements"
         />
-        <x-rapidez::button.outline @click.prevent="qtySelect.increase">
-            <div class="relative">
-                <div class="bg-neutral absolute h-0.5 w-3 rotate-90"></div>
-                <div class="bg-neutral h-0.5 w-3"></div>
-            </div>
-        </x-rapidez::button.outline>
+        <button
+            @click.prevent="qtySelect.increase"
+            class="shrink-0 pr-2.5 text-neutral"
+        >
+            <x-heroicon-o-plus class="mt-0.5 size-5" stroke-width="2" />
+        </button>
     </div>
 </quantity-select>

--- a/resources/views/components/quantity/index.blade.php
+++ b/resources/views/components/quantity/index.blade.php
@@ -11,7 +11,8 @@
     label="Quantity"
     v-model="{{ $model }}"
     labelClass="flex items-center sr-only mr-3"
-    wrapperClass="flex"
+    wrapperClass="flex self-start h-full"
+    class="min-h-14 min-w-20"
 >
     <option v-for="i in ({{ $qtyIncrements }} * {{ $multiplier }})" v-if="i % {{ $qtyIncrements }} === 0" v-bind:value="i">
         @{{ i }}

--- a/resources/views/product/partials/addtocart.blade.php
+++ b/resources/views/product/partials/addtocart.blade.php
@@ -14,23 +14,23 @@
                 </div>
             @endif
 
-            <div class="flex flex-wrap items-center gap-3">
-                <div>
-                    <div class="text-2xl font-bold text-neutral" v-text="$options.filters.price(addToCart.specialPrice || addToCart.price)">
-                        {{ price($product->special_price ?: $product->price) }}
-                    </div>
-                    <div class="text-lg text-neutral line-through" v-if="addToCart.specialPrice" v-text="$options.filters.price(addToCart.price)">
-                        {{ $product->special_price ? price($product->price) : '' }}
-                    </div>
+            <div>
+                <div class="text-2xl font-bold text-neutral" v-text="$options.filters.price(addToCart.specialPrice || addToCart.price)">
+                    {{ price($product->special_price ?: $product->price) }}
                 </div>
+                <div class="text-lg text-neutral line-through" v-if="addToCart.specialPrice" v-text="$options.filters.price(addToCart.price)">
+                    {{ $product->special_price ? price($product->price) : '' }}
+                </div>
+            </div>
 
+            <div class="flex gap-3 max-sm:flex-col">
                 <x-rapidez::quantity
                     model="addToCart.qty"
                     :minSaleQty="$product->min_sale_qty"
                     :qtyIncrements="$product->qty_increments"
                 />
 
-                <x-rapidez::button.cart/>
+                <x-rapidez::button.cart class="w-full max-sm:min-h-14"/>
             </div>
         @endif
     </form>


### PR DESCRIPTION
Visual fixes for quantity select(s)

_Quantity select enhanced:_
<img width="844" alt="Scherm­afbeelding 2024-10-21 om 11 39 50" src="https://github.com/user-attachments/assets/3ac4eed8-6f87-4340-a3b9-90a5b5b9845e">
<img width="375" alt="Scherm­afbeelding 2024-10-21 om 11 49 37" src="https://github.com/user-attachments/assets/d26467b9-9f27-4cc5-89bb-393943be2393">

Quantity select:
<img width="774" alt="Scherm­afbeelding 2024-10-21 om 12 03 09" src="https://github.com/user-attachments/assets/cb7bab3a-64bb-457f-9789-049864b132d4">
<img width="374" alt="Scherm­afbeelding 2024-10-21 om 11 49 20" src="https://github.com/user-attachments/assets/5f4e812d-1c11-4916-abd3-e8f9a946806b">
