### PR TITLE
[3.x] Use default meta description from magento

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,7 +16,7 @@
         @endif
     </title>
 
-    <meta name="description" content="@yield('description', '')"/>
+    <meta name="description" content="@yield('description', Rapidez::config('design/head/default_description', ''))"/>
     <meta name="robots" content="@yield('robots', Rapidez::config('design/search_engine_robots/default_robots', 'INDEX,FOLLOW'))"/>
     <link rel="canonical" href="@yield('canonical', url()->current())" />
 


### PR DESCRIPTION
Magento provides a config for this that we can listen to in case it's not set on the page.