### PR TITLE
[2.x] Make sure you actually log in in the checkout

### DIFF
--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -12,17 +12,27 @@
                 v-on:input="loginInputChange"
                 required
             />
-            <x-rapidez::input
-                v-if="!emailAvailable"
-                :label="false"
-                class="mt-3"
-                name="password"
-                type="password"
-                placeholder="Password"
-                ref="password"
-                v-on:input="loginInputChange"
-                required
-            />
+            <div class="relative">
+                <x-rapidez::input
+                    v-if="!emailAvailable"
+                    :label="false"
+                    class="mt-3"
+                    name="password"
+                    type="password"
+                    placeholder="Password"
+                    ref="password"
+                    v-on:input="loginInputChange"
+                    required
+                />
+
+                <input
+                    type="checkbox"
+                    v-if="!emailAvailable"
+                    oninvalid="this.setCustomValidity('{{ __('Please log in') }}')"
+                    class="absolute h-full inset-0 opacity-0 pointer-events-none"
+                    required
+                />
+            </div>
 
             <x-rapidez::button type="submit" class="w-full mt-5" dusk="continue">
                 @lang('Continue')


### PR DESCRIPTION
Previously, you could just type in any random password in the password box and it would validate without the need to log in, allowing people to actually try placing an order on an existing account without logging in.

This fixes that bug. I'm not sure if this is also a thing in 3.x as that checkout works quite differently, so I haven't made a PR for that.