### PR TITLE
Use fallback route middlewares

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
@@ -13,8 +14,21 @@ use Rapidez\Core\Facades\Rapidez;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
-class FallbackController
+class FallbackController extends Controller
 {
+    public function __construct()
+    {
+        foreach (Rapidez::getAllFallbackRoutes() as $route) {
+            $controller = new $route['action']['uses'];
+
+            if (method_exists($controller, 'getMiddleware')) {
+                foreach ($controller->getMiddleware() as $middleware) {
+                    $this->middleware(...$middleware);
+                }
+            }
+        }
+    }
+
     public function __invoke(Request $request)
     {
         $cacheKey = 'fallbackroute-' . md5($request->url());


### PR DESCRIPTION
This controller invokes other controllers, but middlewares registered there in the constructor do not work. Not sure yet how Laravel handles this so with this we're checking middlewares of "child controllers" en register them again.

- Not sure it it's fully compatible with everything; is `uses` always a controller for example? Otherwise this will break
- The middlewares of "child controllers" get registered on all fallback routes, this should be scoped to the specific child