### PR TITLE
Also apply middlewares when running fallback routes

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Pipeline;
@@ -55,7 +56,7 @@ class FallbackController extends Controller
         abort(404);
     }
 
-    protected function tryRoute(Route $route, $request)
+    protected function tryRoute(Route $route, $request): ?Response
     {
         try {
             $middleware = $this->router->gatherRouteMiddleware($route->setContainer($this->container));


### PR DESCRIPTION
This PR supersedes: https://github.com/rapidez/core/pull/616

Instead of simply calling the given functions we send them through the routing pipeline as is done in Laravel itself
https://github.com/laravel/framework/blob/5527e72efe5d86cf83afe21944a47fe9a0bdc406/src/Illuminate/Routing/Router.php#L797

Which applies the middlewares, but only for the given router.
However this expects a route instead of a route action. Thus we turn it into a route.
and to maintain backwards compatibility, and exact compatibility with regular routing arguments we pass it through the createRoute function
https://github.com/laravel/framework/blob/5527e72efe5d86cf83afe21944a47fe9a0bdc406/src/Illuminate/Routing/Router.php#L554

Otherwise it would only accept `[Class, 'function']` arguments