### PR TITLE
[2.x] Add wrapper hack for turbo

### DIFF
--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -10,13 +10,13 @@ Turbo.setProgressBarDelay(5)
 // This allows things placed in the body by scripts like GTM to persist
 Object.assign(PageRenderer.prototype, {
     assignNewBody() {
-        const container = document.querySelector("#turbo-wrapper")
-        const newContainer = this.newElement.querySelector("#turbo-wrapper")
+        const container = document.querySelector('#turbo-wrapper')
+        const newContainer = this.newElement.querySelector('#turbo-wrapper')
 
         if (container && newContainer) {
             container.replaceWith(newContainer)
         } else {
             document.body.replaceWith(this.newElement)
         }
-    }
+    },
 })

--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -1,6 +1,22 @@
 import * as Turbo from '@hotwired/turbo'
+import { PageRenderer } from '@hotwired/turbo'
 
 import TurbolinksAdapter from 'vue-turbolinks'
 Vue.use(TurbolinksAdapter)
 
 Turbo.setProgressBarDelay(5)
+
+// Patch the internal Turbo renderer to use #turbo-wrapper as the root node instead of the body
+// This allows things placed in the body by scripts like GTM to persist
+Object.assign(PageRenderer.prototype, {
+    assignNewBody() {
+        const container = document.querySelector("#turbo-wrapper")
+        const newContainer = this.newElement.querySelector("#turbo-wrapper")
+
+        if (container && newContainer) {
+            container.replaceWith(newContainer)
+        } else {
+            document.body.replaceWith(this.newElement)
+        }
+    }
+})

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,30 +26,32 @@
     @config('design/head/includes')
 </head>
 <body class="text-neutral antialiased">
-    <div id="app" class="flex flex-col min-h-dvh">
-        @includeWhen(!request()->is('checkout'), 'rapidez::layouts.partials.header')
-        @includeWhen(request()->is('checkout'), 'rapidez::layouts.checkout.header')
-        <main>
-            @yield('content')
-        </main>
-        @includeWhen(!request()->is('checkout'), 'rapidez::layouts.partials.footer')
-        @includeWhen(request()->is('checkout'), 'rapidez::layouts.checkout.footer')
-        @stack('page_end')
-    </div>
+    <div id="turbo-wrapper" class="contents">
+        <div id="app" class="flex flex-col min-h-dvh">
+            @includeWhen(!request()->is('checkout'), 'rapidez::layouts.partials.header')
+            @includeWhen(request()->is('checkout'), 'rapidez::layouts.checkout.header')
+            <main>
+                @yield('content')
+            </main>
+            @includeWhen(!request()->is('checkout'), 'rapidez::layouts.partials.footer')
+            @includeWhen(request()->is('checkout'), 'rapidez::layouts.checkout.footer')
+            @stack('page_end')
+        </div>
 
-    <script>window.config = @json(config('frontend'));</script>
-    @if (session('notifications'))
-        <script async>
-            document.addEventListener('vue:loaded', function() {
-                @foreach (session('notifications') ?? [] as $notification)
-                    window.Notify('{{ $notification['message'] }}', '{{ $notification['type'] ?? 'success' }}')
-                @endforeach
-            });
-        </script>
-    @endif
-    @stack('foot')
-    <svg hidden class="hidden">
-        @stack('bladeicons')
-    </svg>
+        <script>window.config = @json(config('frontend'));</script>
+        @if (session('notifications'))
+            <script async>
+                document.addEventListener('vue:loaded', function() {
+                    @foreach (session('notifications') ?? [] as $notification)
+                        window.Notify('{{ $notification['message'] }}', '{{ $notification['type'] ?? 'success' }}')
+                    @endforeach
+                });
+            </script>
+        @endif
+        @stack('foot')
+        <svg hidden class="hidden">
+            @stack('bladeicons')
+        </svg>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This fixes an annoying issue that's been inside Turbo since its inception: Turbo will always replace the *entire* `<body>` tag. As a result, this causes widgets that have been loaded into the body by scripts like GTM to be destroyed on navigation (see internal slack for current examples). Even worse the scripts will persist but their elements will not, so we get a bunch of JS errors.

Turbo doesn't support changing this root node to something else, even though this has been asked in issues since at least 2021. There are some events we can hook into with the renderer to change certain behaviors, but this is unwieldy and doesn't really work well for this use case.

This PR hacks into the PageRenderer class and replaces [the assignNewBody function](https://github.com/hotwired/turbo/blob/ea54ae5ad4b6b28cb62ccd62951352641ed08293/src/core/drive/page_renderer.js#L182) with one that does the exact same except with a `#turbo-wrapper` element (with a fallback to still use the body so it's not a big breaking change).

(Note that this PR goes to `2.x` for now, I will make a 3.x PR only if/when we're sure this is final)