### PR TITLE
[2.x] Fix error of undefined when extensions is not set

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -26,7 +26,7 @@ Vue.prototype.checkResponseForExpiredCart = async function (variables, response)
     if (
         response?.errors?.some(
             (error) =>
-                error.extensions.category === 'graphql-no-such-entity' &&
+                error.extensions?.category === 'graphql-no-such-entity' &&
                 error.path.some((path) =>
                     [
                         'cart',


### PR DESCRIPTION
Sometimes `error.extensions.category` is not set, and i'm getting a sentry error on that. This check prevents that.

V3: #635 