### PR TITLE
[3.x] Fix error of undefined when extensions is not set

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -81,7 +81,7 @@ Vue.prototype.checkResponseForExpiredCart = async function (variables, response)
     if (
         response?.errors?.some(
             (error) =>
-                error.extensions.category === 'graphql-no-such-entity' &&
+                error.extensions?.category === 'graphql-no-such-entity' &&
                 // Untested, but something like this is maybe a better idea as
                 // we're using a lot of different mutations in the checkout.
                 error.path.some((path) => path.toLowerCase().includes('cart')),


### PR DESCRIPTION
Sometimes `error.extensions.category` is not set, and i'm getting a sentry error on that. This check prevents that.

V2: #634 