### PR TITLE
[2.x] Remove password check

### DIFF
--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -12,27 +12,17 @@
                 v-on:input="loginInputChange"
                 required
             />
-            <div class="relative">
-                <x-rapidez::input
-                    v-if="!emailAvailable"
-                    :label="false"
-                    class="mt-3"
-                    name="password"
-                    type="password"
-                    placeholder="Password"
-                    ref="password"
-                    v-on:input="loginInputChange"
-                    required
-                />
-
-                <input
-                    type="checkbox"
-                    v-if="!emailAvailable"
-                    oninvalid="this.setCustomValidity('{{ __('Please log in') }}')"
-                    class="absolute h-full inset-0 opacity-0 pointer-events-none"
-                    required
-                />
-            </div>
+            <x-rapidez::input
+                v-if="!emailAvailable"
+                :label="false"
+                class="mt-3"
+                name="password"
+                type="password"
+                placeholder="Password"
+                ref="password"
+                v-on:input="loginInputChange"
+                required
+            />
 
             <x-rapidez::button type="submit" class="w-full mt-5" dusk="continue">
                 @lang('Continue')


### PR DESCRIPTION
As it turns out, the standard core functionality of the login is always self-contained within a form. As long as you don't try to get rid of this and merge it with another step (say, the credentials step), this being its own step works without the need for this check.

This broke the dusk tests as the login form got blocked by this check, making it impossible to continue.

(3.x will require some more investigation w.r.t. a one-step checkout)