### PR TITLE
[2.x] Fix image breaking when switching

### DIFF
--- a/resources/js/components/Product/Images.vue
+++ b/resources/js/components/Product/Images.vue
@@ -22,6 +22,7 @@ export default {
                     Object.values(window.config.product.super_attributes).filter((attribute) => attribute.update_image).length
                 ) {
                     self.images = simpleProduct.images
+                    self.active = Math.min(self.active, self.images.length - 1)
                 }
             })
         })
@@ -40,10 +41,10 @@ export default {
         },
 
         keyPressed(e) {
-            if (e.key == 'ArrowLeft' && this.active) {
+            if (e.key == 'ArrowLeft' && this.active > 0) {
                 // left
                 this.active--
-            } else if (e.key == 'ArrowRight' && this.active != this.images.length - 1) {
+            } else if (e.key == 'ArrowRight' && this.active < this.images.length - 1) {
                 // right
                 this.active++
             } else if (e.key == 'Escape') {


### PR DESCRIPTION
When you have a product with super attributes, the amount of images in the images array can change depending on what option you select.

The problem is as follows:
- Go to [this product](https://demo.rapidez.io/stellar-solar-jacket.html) on the demo shop and click on the third image
- Change the selected color to either blue or yellow
- The product image on the left will break

What happens here is that the code still has `active` set to `2`, and when we change to the other jacket the images array no longer has a third image, which means it tries to show an undefined image. This then ends up showing the placeholder image that's normally hidden behind.

With this change we clamp the `active` value to make sure it can never go out of bounds (unless the array ends up having 0 images which I've never seen happen, is it even possible?)