### PR TITLE
Add support for HTTP/3 Early Hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     "require": {
         "php": "^8.1|^8.2|^8.3",
         "blade-ui-kit/blade-heroicons": "^2.4",
-        "mailerlite/laravel-elasticsearch": "^11.1",
         "illuminate/database": "^11.0",
         "illuminate/events": "^11.0",
         "illuminate/queue": "^11.0",
         "illuminate/support": "^11.0",
+        "justbetter/laravel-http3earlyhints": "*",
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.0|^5.3",
+        "mailerlite/laravel-elasticsearch": "^11.1",
         "rapidez/blade-directives": "^0.6",
         "tormjens/eventy": "^0.8"
     },

--- a/config/rapidez/routing.php
+++ b/config/rapidez/routing.php
@@ -23,4 +23,8 @@ return [
         // This does not cache the response, it caches the controller used for that page.
         'cache_duration' => 3600,
     ],
+
+    'earlyhints' => [
+        'enabled' => env('EARLY_HINTS_ENABLED', true),
+    ]
 ];

--- a/config/rapidez/routing.php
+++ b/config/rapidez/routing.php
@@ -24,6 +24,7 @@ return [
         'cache_duration' => 3600,
     ],
 
+    // See: https://docs.rapidez.io/3.x/configuration.html#early-hints
     'earlyhints' => [
         'enabled' => env('EARLY_HINTS_ENABLED', true),
     ]

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -146,6 +146,16 @@ class RapidezServiceProvider extends ServiceProvider
         RapidezFacade::addFallbackRoute(CmsPageController::class, 10);
         RapidezFacade::addFallbackRoute(LegacyFallbackController::class, 99999);
 
+        if (!app()->runningInConsole() && config('rapidez.routing.earlyhints.enabled', true)) {
+            $this->app->call(function (\Illuminate\Contracts\Http\Kernel $kernel) {
+                /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+                $middlewares = $kernel->getGlobalMiddleware();
+                $middlewares[] = \JustBetter\Http3EarlyHints\Middleware\AddHttp3EarlyHints::class;
+
+                $kernel->setGlobalMiddleware($middlewares);
+            });
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
Early hints can improve performance and lighthouse scores by returning Preload and preconnect link headers BEFORE the server has it's response ready. So JS, CSS, and fonts could be loaded before your HTML has finished downloading.

lowering the time to first paint, reducing layout shifts caused by fonts, and improving the speed at which the JS can start executing.

This will automatically install the early hints package, and configure it to work with Rapidez and all it's fallback routes.

docs: https://github.com/rapidez/docs/pull/63

(Do we want this in V2 as well?)