### PR TITLE
On initial page load run init before turbo:load has been fired

### DIFF
--- a/resources/js/components/Product/Images.vue
+++ b/resources/js/components/Product/Images.vue
@@ -22,6 +22,7 @@ export default {
                     Object.values(window.config.product.super_attributes).filter((attribute) => attribute.update_image).length
                 ) {
                     self.images = simpleProduct.images
+                    self.active = Math.min(self.active, self.images.length - 1)
                 }
             })
         })
@@ -40,10 +41,10 @@ export default {
         },
 
         keyPressed(e) {
-            if (e.key == 'ArrowLeft' && this.active) {
+            if (e.key == 'ArrowLeft' && this.active > 0) {
                 // left
                 this.active--
-            } else if (e.key == 'ArrowRight' && this.active != this.images.length - 1) {
+            } else if (e.key == 'ArrowRight' && this.active < this.images.length - 1) {
                 // right
                 this.active++
             } else if (e.key == 'Escape') {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -15,11 +15,10 @@ import useMask from './stores/useMask'
 import { swatches, clear as clearSwatches } from './stores/useSwatches'
 import { clear as clearAttributes } from './stores/useAttributes.js'
 import './vue'
-import { computed } from 'vue'
 import './fetch'
 import './filters'
 import './mixins'
-import './turbolinks'
+(() => import('./turbolinks'))()
 import './cookies'
 import './callbacks'
 import './vue-components'
@@ -116,7 +115,7 @@ function init() {
                             Turbo.visit(window.url('/search?q=' + encodeURIComponent(value)))
                         }
                     },
-                    
+
                     setSearchParams(url) {
                         window.history.pushState(window.history.state, '', new URL(url))
                     },
@@ -164,6 +163,12 @@ function init() {
                         window.app.$data.loading = count > 0
                     },
                 },
+                mounted() {
+                    setTimeout(() => {
+                        const event = new CustomEvent('vue:mounted', { detail: { vue: window.app } })
+                        document.dispatchEvent(event)
+                    })
+                }
             })
 
             setTimeout(() => {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -25,6 +25,10 @@ import './callbacks'
 import './vue-components'
 
 function init() {
+    if (document.body.contains(window.app.$el)) {
+        return;
+    }
+
     // https://vuejs.org/api/application.html#app-config-performance
     Vue.config.performance = import.meta.env.VITE_PERFORMANCE == 'true'
     Vue.prototype.window = window
@@ -152,3 +156,4 @@ function init() {
     document.dispatchEvent(event)
 }
 document.addEventListener('turbo:load', init)
+setTimeout(init)

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -24,7 +24,7 @@
 
                     <div slot="renderNoResults"></div>
 
-                    <div class="relative" slot="render" slot-scope="{ data, loading }" v-if="!loading">
+                    <div class="relative" slot="render" slot-scope="{ data, loading }" v-if="!loading && data?.length">
                         <slider>
                             <div slot-scope="{ navigate, showLeft, showRight, currentSlide, slidesTotal }">
                                 <div class="-mx-2 flex mt-5 overflow-x-auto snap-x scrollbar-hide scroll-smooth snap-mandatory" ref="slider">

--- a/tests/Browser/CartTest.php
+++ b/tests/Browser/CartTest.php
@@ -15,6 +15,7 @@ class CartTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->addProductToCart($this->testProduct->url)
                 ->visit('/cart')
+                ->waitUntilVueLoaded()
                 ->waitUntilIdle()
                 ->waitFor('@cart-content', 15)
                 ->waitUntilIdle()
@@ -43,6 +44,7 @@ class CartTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/cart')
+                ->waitUntilVueLoaded()
                 ->waitUntilIdle()
                 ->waitFor('@cart-content', 15)
                 ->waitUntilIdle()
@@ -60,6 +62,7 @@ class CartTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/cart')
+                ->waitUntilVueLoaded()
                 ->waitUntilIdle()
                 ->waitFor('@cart-content', 15)
                 ->waitUntilIdle()

--- a/tests/Browser/CheckoutTest.php
+++ b/tests/Browser/CheckoutTest.php
@@ -34,6 +34,7 @@ class CheckoutTest extends DuskTestCase
         // Go through checkout as guest and log in.
         $this->browse(function (Browser $browser) use ($email) {
             $browser->waitForReload(fn ($browser) => $browser->visit('/'), 4)
+                ->waitUntilVueLoaded()
                 ->waitUntilIdle()
                 ->waitFor('@account_menu')
                 ->click('@account_menu')
@@ -71,6 +72,7 @@ class CheckoutTest extends DuskTestCase
     {
         $browser
             ->visit('/checkout')
+            ->waitUntilVueLoaded()
             ->waitUntilIdle()
             ->type('@email', $email ?: 'wayne@enterprises.com')
             ->waitUntilIdle();

--- a/tests/Browser/DialogTest.php
+++ b/tests/Browser/DialogTest.php
@@ -14,6 +14,7 @@ class DialogTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/?show-cookie-notice')
+                ->waitUntilVueLoaded()
                 ->waitUntilIdle()
                 ->assertSee('Accept cookies')
                 ->waitForReload(function (Browser $browser) {

--- a/tests/Browser/HomepageTest.php
+++ b/tests/Browser/HomepageTest.php
@@ -13,7 +13,7 @@ class HomepageTest extends DuskTestCase
     public function homepage()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit('/')->assertSee('All rights reserved.');
+            $browser->visit('/')->waitUntilVueLoaded()->assertSee('All rights reserved.');
         });
     }
 }

--- a/tests/Browser/NewsletterTest.php
+++ b/tests/Browser/NewsletterTest.php
@@ -18,6 +18,7 @@ class NewsletterTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $email = $this->faker->email;
             $browser->visit('/')
+                ->waitUntilVueLoaded()
                 ->scrollIntoView('@newsletter')
                 ->waitUntilIdle()
                 ->type('@newsletter-email', $email)

--- a/tests/DuskTestCaseSetup.php
+++ b/tests/DuskTestCaseSetup.php
@@ -44,6 +44,13 @@ trait DuskTestCaseSetup
             return $this;
         });
 
+        Browser::macro('waitUntilVueLoaded', function () {
+            /** @var Browser $this */
+            $this->waitUntil('document.body.contains(window.app.$el) || await new Promise((resolve, reject) => document.addEventListener("vue:loaded", resolve))', 120);
+
+            return $this;
+        });
+
         Browser::macro('assertFormValid', function ($selector) {
             /** @var Browser $this */
             $fullSelector = $this->resolver->format($selector);

--- a/tests/DuskTestCaseSetup.php
+++ b/tests/DuskTestCaseSetup.php
@@ -75,7 +75,7 @@ trait DuskTestCaseSetup
             $this
                 ->waitUntilIdle()
                 ->waitUntilEnabled('@add-to-cart')
-                ->pressAndWaitFor('@add-to-cart', 60)
+                ->pressAndWaitFor('@add-to-cart', 120)
                 ->waitForText('Added', 60)
                 ->waitUntilIdle();
 

--- a/tests/DuskTestCaseSetup.php
+++ b/tests/DuskTestCaseSetup.php
@@ -67,12 +67,14 @@ trait DuskTestCaseSetup
             /** @var Browser $this */
             if ($productUrl) {
                 $this
-                    ->visit($productUrl);
+                    ->visit($productUrl)
+                    ->waitUntilVueLoaded();
             }
 
             // @phpstan-ignore-next-line
             $this
                 ->waitUntilIdle()
+                ->waitUntilEnabled('@add-to-cart')
                 ->pressAndWaitFor('@add-to-cart', 60)
                 ->waitForText('Added', 60)
                 ->waitUntilIdle();

--- a/tests/DuskTestCaseSetup.php
+++ b/tests/DuskTestCaseSetup.php
@@ -46,7 +46,10 @@ trait DuskTestCaseSetup
 
         Browser::macro('waitUntilVueLoaded', function () {
             /** @var Browser $this */
-            $this->waitUntil('document.body.contains(window.app.$el) || await new Promise((resolve, reject) => document.addEventListener("vue:loaded", resolve))', 120);
+            $this
+                ->waitUntilIdle()
+                ->waitUntilTrueForDuration('document.body.contains(window.app?.$el) && window.app?._isMounted && console.log("mounted") === undefined', 10, 1)
+                ->waitUntilIdle();
 
             return $this;
         });
@@ -68,15 +71,16 @@ trait DuskTestCaseSetup
             if ($productUrl) {
                 $this
                     ->visit($productUrl)
-                    ->waitUntilVueLoaded();
+                    ->waitUntilVueLoaded()
+                    ->waitUntilIdle();
             }
 
             // @phpstan-ignore-next-line
             $this
                 ->waitUntilIdle()
-                ->waitUntilEnabled('@add-to-cart')
+                ->waitUntilEnabled('@add-to-cart', 200)
                 ->pressAndWaitFor('@add-to-cart', 120)
-                ->waitForText('Added', 60)
+                ->waitForText(__('Added'), 120)
                 ->waitUntilIdle();
 
             return $this;


### PR DESCRIPTION
This will make Rapidez initialize before marketing scripts, browser extensions and other scripts run.
Improving startup times of Rapidez.

Before:
![image](https://github.com/user-attachments/assets/74f036c7-7ca4-45ce-a40b-c78a411206b3)

After:
![image](https://github.com/user-attachments/assets/fb208bae-1bf0-4335-8249-85dd98121af4)

Currently as draft as we should figure out the best method/event to run this on in order not to impact LCP