### PR TITLE
Fix image urls

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -111,7 +111,7 @@ function init() {
                     this.scrollLock = bool
                 }
             },
-            resizedPath(imagePath, size, store = null) {
+            resizedPath(imagePath, size, store = config.store) {
                 if (!store) {
                     store = window.config.store
                 }

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -9,7 +9,7 @@
             <a :href="item.url | url" class="block">
                 <img
                     v-if="item.thumbnail"
-                    :src="resizedPath(item.thumbnail + '.webp', '200')"
+                    :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + item.thumbnail + '.webp'"
                     class="mb-3 h-48 w-full rounded-t object-contain" :alt="item.name" :loading="config.category && count <= 4 ? 'eager' : 'lazy'"
                     width="200"
                     height="200"

--- a/resources/views/product/partials/images.blade.php
+++ b/resources/views/product/partials/images.blade.php
@@ -27,7 +27,7 @@
                 >
                     <img
                         v-if="!zoomed"
-                        :src="resizedPath(images[active] + '.webp', '400')"
+                        :src="'/storage/{{ config('rapidez.store') }}/resizes/400/magento/catalog/product' + images[active] + '.webp'"
                         alt="{{ $product->name }}"
                         class="object-contain w-full m-auto max-h-[400px]"
                         width="400"
@@ -58,7 +58,7 @@
                     @click="change(imageId)"
                 >
                     <img
-                        :src="resizedPath(image + '.webp', '80x80')"
+                        :src="'/storage/{{ config('rapidez.store') }}/resizes/80x80/magento/catalog/product' + image + '.webp'"
                         alt="{{ $product->name }}"
                         class="object-contain w-full m-auto max-h-[80px]"
                         loading="lazy"


### PR DESCRIPTION
There's no reason to use the resizedpath helper in places where it's not needed. It will only make the helper unnecessarily complex. The helper function is only needed when graphql returns store specific urls. Which is not the case  on the POP, PDP and in product sliders.