### PR TITLE
[3.x] Fix image urls

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -92,11 +92,7 @@ function init() {
                     this.scrollLock = bool
                 }
             },
-            resizedPath(imagePath, size, store = null) {
-                if (!store) {
-                    store = window.config.store
-                }
-
+            resizedPath(imagePath, size, store = config.store) {
                 let url = new URL(imagePath)
                 url = url.pathname.replace('/media', '')
 

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -92,18 +92,15 @@ function init() {
                     this.scrollLock = bool
                 }
             },
-            resizedPath(imagePath, size, store = config.store) {
-                let mediaPosition = imagePath.indexOf('/media/')
-                if (mediaPosition > 0) {
-                    return `/storage/${store}/resizes/${size}/magento` + imagePath.substr(mediaPosition + 6)
+            resizedPath(imagePath, size, store = null) {
+                if (!store) {
+                    store = window.config.store
                 }
 
-                let productPosition = imagePath.indexOf('/product/')
-                if (productPosition > 0) {
-                    return `/storage/${store}/resizes/${size}/magento/catalog` + imagePath.substr(productPosition)
-                }
+                let url = new URL(imagePath)
+                url = url.pathname.replace('/media', '')
 
-                return `/storage/${store}/resizes/${size}/magento/catalog/product` + imagePath
+                return `/storage/${store}/resizes/${size}/magento${url}`
             },
         },
         computed: {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -93,10 +93,17 @@ function init() {
                 }
             },
             resizedPath(imagePath, size, store = config.store) {
-                let url = new URL(imagePath)
-                url = url.pathname.replace('/media', '')
+                let mediaPosition = imagePath.indexOf('/media/')
+                if (mediaPosition > 0) {
+                    return `/storage/${store}/resizes/${size}/magento` + imagePath.substr(mediaPosition + 6)
+                }
 
-                return `/storage/${store}/resizes/${size}/magento${url}`
+                let productPosition = imagePath.indexOf('/product/')
+                if (productPosition > 0) {
+                    return `/storage/${store}/resizes/${size}/magento/catalog` + imagePath.substr(productPosition)
+                }
+
+                return `/storage/${store}/resizes/${size}/magento/catalog/product` + imagePath
             },
         },
         computed: {

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -9,7 +9,7 @@
             <a :href="item.url | url" class="block">
                 <img
                     v-if="item.thumbnail"
-                    :src="resizedPath(item.thumbnail + '.webp', '200')"
+                    :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + item.thumbnail + '.webp'"
                     class="mb-3 h-48 w-full rounded-t object-contain" :alt="item.name" :loading="config.category && count <= 4 ? 'eager' : 'lazy'"
                     width="200"
                     height="200"

--- a/resources/views/product/partials/gallery/slider.blade.php
+++ b/resources/views/product/partials/gallery/slider.blade.php
@@ -5,7 +5,7 @@
         v-on:click.prevent="toggleZoom"
     >
         <img
-            :src="resizedPath(images[active] + '.webp', '400')"
+            :src="'/storage/{{ config('rapidez.store') }}/resizes/400/magento/catalog/product' + images[active] + '.webp'"
             alt="{{ $product->name }}"
             class="object-contain max-h-full"
             width="400"


### PR DESCRIPTION
There's no reason to use the resizedpath helper in places where it's not needed. It will only make the helper unnecessarily complex. The helper function is only needed when graphql returns store specific urls. Which is not the case on the POP, PDP and in product sliders.

V2: #648 