### PR TITLE
[2.x] Clone address when setting

### DIFF
--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -91,7 +91,7 @@ export default {
                 return
             }
 
-            let address = this.$root.user?.addresses?.find((address) => address.id == id) || window.address_defaults
+            let address = JSON.parse(JSON.stringify(this.$root.user?.addresses?.find((address) => address.id == id) || window.address_defaults))
 
             this.$root.checkout[type + '_address'] = Object.assign(
                 this.$root.checkout[type + '_address'],

--- a/resources/js/components/User/mixins/InteractWithUser.js
+++ b/resources/js/components/User/mixins/InteractWithUser.js
@@ -91,7 +91,9 @@ export default {
                 return
             }
 
-            let address = JSON.parse(JSON.stringify(this.$root.user?.addresses?.find((address) => address.id == id) || window.address_defaults))
+            let address = JSON.parse(
+                JSON.stringify(this.$root.user?.addresses?.find((address) => address.id == id) || window.address_defaults),
+            )
 
             this.$root.checkout[type + '_address'] = Object.assign(
                 this.$root.checkout[type + '_address'],


### PR DESCRIPTION
The issue we ran into was that if you have one address set as both default shipping and billing when entering the checkout, they will both be the same object and thus have the same reference.

If you then choose to change your addresses inside of the checkout and try to change one of the two separately, they would both end up getting changed at the same time (as they are the same object reference), causing you to be unable to actually have a billing address that's different from your shipping address.

This is easily fixed by cloning the address object before setting it here.

I do not believe this is a problem in 3.x as the checkout works entirely different there 🙂 