### PR TITLE
[2.x] Fix var name in function

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -139,7 +139,7 @@ export const cart = computed({
                 )
 
                 value.items = value.items.map((cartItem) => {
-                    cartItem.is_available = checkAvailability(item)
+                    cartItem.is_available = checkAvailability(cartItem)
                     cartItem.product.attribute_values = {}
 
                     for (const key in mapping) {


### PR DESCRIPTION
This was just the wrong variable name, should be `cartItem` here but it seems to have been copied from above where it is `item` :)