### PR TITLE
[3.x] Ignore waitUntilIdle error

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,4 +9,5 @@ parameters:
     ignoreErrors:
         - '#^Result of static method TorMorten\\Eventy\\Events::#'
         - "#Access to an undefined property#"
+        - "#::waitUntilIdle#"
     level: 1

--- a/tests/DuskTestCaseSetup.php
+++ b/tests/DuskTestCaseSetup.php
@@ -75,7 +75,6 @@ trait DuskTestCaseSetup
                     ->waitUntilIdle();
             }
 
-            // @phpstan-ignore-next-line
             $this
                 ->waitUntilIdle()
                 ->waitUntilEnabled('@add-to-cart', 200)


### PR DESCRIPTION
Because of macros, phpstan doesn't really know what to do with this function. We can just ignore it as it doesn't really matter.