### PR TITLE
[2.x] Use synonym graph instead of regular synonyms

### DIFF
--- a/src/Commands/ElasticsearchIndexer.php
+++ b/src/Commands/ElasticsearchIndexer.php
@@ -81,7 +81,7 @@ class ElasticsearchIndexer
                 ->map(fn ($synonym) => $synonym->synonyms)
                 ->toArray();
 
-            data_set($settings, 'index.analysis.filter.synonym', ['type' => 'synonym', 'synonyms' => $synonyms]);
+            data_set($settings, 'index.analysis.filter.synonym', ['type' => 'synonym_graph', 'synonyms' => $synonyms]);
             data_set($settings, 'index.analysis.analyzer.synonym', [
                 'filter'    => ['lowercase', 'asciifolding', 'synonym'],
                 'tokenizer' => 'standard',


### PR DESCRIPTION
The difference between the two is here in the documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/analysis-synonym-graph-tokenfilter.html

But in short, this allows you to use synonyms that are multiple words without those words getting broken up into individual tokens. For clarity, here's an example.

---

Say you have a synonym set up with "jacket" and "large shirt". Before this change, that turned searches for "jacket" to also search for "large" and "shirt" individually, returning anything large and your whole stock of shirts. Not really ideal for when you're trying to sell people jackets!

After this change, the "large shirt" automatically gets turned into a phrase where both words *must* exist before it matches. Thus, your search will correctly only return jackets and large shirts, which is more in line with what you would expect.

---

We could also make this configurable, however I currently don't really see a world where you want the other behavior.