### PR TITLE
[3.x] Set minimum testbench version to 9.2

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,7 +20,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ~9.2
 
     services:
       mysql:


### PR DESCRIPTION
The bug causing the broken phpunit test is hotfixed in 9.1.5 and then permanently fixed in 9.2.0