### PR TITLE
Remove dependency on global state, use events instead

### DIFF
--- a/resources/js/components/GlobalSlideover.vue
+++ b/resources/js/components/GlobalSlideover.vue
@@ -3,7 +3,7 @@ export default {
     props: {
         title: String,
         position: String,
-        contents: String,
+        content: String,
     },
 
     render() {
@@ -12,19 +12,7 @@ export default {
 
     methods: {
         open() {
-            this.$root.globalSlideover.content = this.slideoverContents
-            this.$root.globalSlideover.title = this.title
-            this.$root.globalSlideover.position = this.position
-        },
-    },
-
-    computed: {
-        slideoverContents() {
-            if (this.contents) {
-                return this.contents
-            }
-
-            return this.$el.querySelector('.global-slideover-wrapper').innerHTML
+            this.$root.$emit('global-slideover-open', {'content': this.content, 'title': this.title, 'position': this.position});
         },
     },
 }

--- a/resources/js/components/GlobalSlideoverInstance.vue
+++ b/resources/js/components/GlobalSlideoverInstance.vue
@@ -1,0 +1,25 @@
+<script>
+export default {
+    render() {
+        return this.$scopedSlots.default(this)
+    },
+
+    data() {
+        return {
+            'content': '',
+            'title': '',
+            'position': 'left',
+        }
+    },
+
+    mounted() {
+        this.$root.$on('global-slideover-open', (data) => {
+            this.content = data.content || '';
+            this.title = data.title || '';
+            this.position = data.position || 'left';
+
+            this.$el.querySelector('#slideover-global').checked = true;
+        })
+    },
+}
+</script>

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -20,6 +20,8 @@ import notifications from './components/Notifications/Notifications.vue'
 Vue.component('notifications', notifications)
 import globalSlideover from './components/GlobalSlideover.vue'
 Vue.component('global-slideover', globalSlideover)
+import globalSlideoverInstance from './components/GlobalSlideoverInstance.vue'
+Vue.component('global-slideover-instance', globalSlideoverInstance)
 
 import images from './components/Product/Images.vue'
 Vue.component('images', images)

--- a/resources/views/components/slideover/global.blade.php
+++ b/resources/views/components/slideover/global.blade.php
@@ -16,10 +16,10 @@ Standard usage may look like this:
 --}}
 
 @props(['title', 'position' => 'left'])
-@slots(['label', 'contents'])
+@slots(['label'])
 
-<global-slideover title="{{ $title }}" position="{{ $position }}" contents="{{ $slot->toHtml() }}" v-slot="slideover">
-    <label {{ $label->attributes->class('global-slideover-label cursor-pointer') }} for="slideover-global" v-on:click="slideover.open">
+<global-slideover title="{{ $title }}" position="{{ $position }}" content="{{ $slot->toHtml() }}" v-slot="slideover">
+    <label {{ $label->attributes->class('global-slideover-label cursor-pointer') }} v-on:click="slideover.open">
         {{ $label }}
     </label>
 </global-slideover>

--- a/resources/views/layouts/partials/global-slideover.blade.php
+++ b/resources/views/layouts/partials/global-slideover.blade.php
@@ -1,12 +1,14 @@
-<template v-if="globalSlideover.content ?? false" v-cloak>
-    <x-rapidez::slideover
-        id="slideover-global"
-        v-bind:class="{ '-right-full peer-checked:right-0 !left-auto': (globalSlideover.position ?? 'left') === 'right' }"
-    >
-        <x-slot:title>
-            <div v-html="globalSlideover.title ?? ''"></div>
-        </x-slot:title>
+<global-slideover-instance>
+    <template v-slot="{ content, title, position }" v-cloak>
+        <x-rapidez::slideover
+            id="slideover-global"
+            v-bind:class="{ '-right-full peer-checked:right-0 !left-auto': (position ?? 'left') === 'right' }"
+        >
+            <x-slot:title>
+                <div v-html="title"></div>
+            </x-slot:title>
 
-        <div v-html="globalSlideover.content ?? ''"></div>
-    </x-rapidez::slideover>
-</template>
+            <div v-html="content"></div>
+        </x-rapidez::slideover>
+    </template>
+</global-slideover-instance>


### PR DESCRIPTION
Instead of requiring the global state to be changed, listen to emit events instead and take that data.

This makes it easier in the long run for arbitrary pieces of code to open a slideover.

> The issue with using Vue slots at least is that you can't really turn a this.$scopedSlots.xxxxx() into actual html, there is no helper function for it and it only returns something that Vue uses internally to generate the html.

In more detailed terms:
Vue slots are transformed into `VNode`s already, so it has already been transformed into VirtualDOM. Vue's VirtualDOM cannot easily be transformed into plaintext HTML as they don't expose functions for it.

There's a package `vue-server-renderer` but this is meant for server-side nodejs implementation so it has dependencies on functions not available for a browser.

That leaves the only option to get that functional, to go down the path of the `CategoryFilter`. Placing the template within the Vue file. 
Then we can render the named slot, get it's HTML from the DOM and pass it through.
However then we lose out on being able to use vue variables and functions in our blade files which we really do want in this case. 