### PR TITLE
[2.x] Only check for logged in state on mounted hook

### DIFF
--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -28,6 +28,9 @@ export default {
 
     created() {
         this.refreshUser(false)
+    },
+
+    mounted() {
         if (this.$root.loggedIn) {
             this.successfulLogin()
         }


### PR DESCRIPTION
When doing this on the `created` hook, we can consistently generate a console error by going to the login page while logged in.

This is because it will try to redirect you to the account overview page, which will then cause turbo to unload the Vue component. Because this happens on the `created` hook, this means it gets destroyed before it is mounted which Vue does not like.