### PR TITLE
Fix getting pagesize from url if turbo is not yet loaded

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -35,7 +35,7 @@ export default {
     data: () => ({
         loaded: false,
         attributes: useAttributes(),
-        pageSize: Turbo.navigator.location.searchParams.get('pageSize') || config.grid_per_page,
+        pageSize: (Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') || config.grid_per_page,
     }),
 
     render() {


### PR DESCRIPTION
Since #604 turbo does not load ASAP during the initial page load.
Most of the time you don't notice, but on slow connections or when running `dev` this may cause issues.

This PR adds a fallback to the window if turbo is not available