### PR TITLE
[3.x] Fix autocomplete & some other reactivesearch errors

### DIFF
--- a/resources/js/components/Listing/Filters/CategoryFilter.vue
+++ b/resources/js/components/Listing/Filters/CategoryFilter.vue
@@ -95,7 +95,7 @@ export default {
                     }
 
                     // No child categories, get siblings instead.
-                    let parentCategoryId = categoryPaths[0].key.at(-2)
+                    let parentCategoryId = categoryPaths[0]?.key.at(-2)
                     return allCategoryPaths.filter(
                         (bucket) => bucket.key.includes(parentCategoryId) && bucket.key.at(-1) !== parentCategoryId,
                     )

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -36,7 +36,7 @@ export default {
         loaded: false,
         attributes: useAttributes(),
         pageSize:
-            (Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') ||
+            ('Turbo' in window && Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') ||
             config.grid_per_page,
     }),
 

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -36,8 +36,9 @@ export default {
         loaded: false,
         attributes: useAttributes(),
         pageSize:
-            ('Turbo' in window && Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') ||
-            config.grid_per_page,
+            (('Turbo' in window && Turbo?.navigator?.location?.searchParams) || new URLSearchParams(window.location.search)).get(
+                'pageSize',
+            ) || config.grid_per_page,
     }),
 
     render() {

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,5 +1,11 @@
 @php $inputClasses = 'relative z-header-autocomplete border !font-sans !border-default !text-sm !min-h-0 outline-0 ring-0 !h-auto rounded-xl !pl-5 !pr-24 !py-3.5 !bg-white w-full focus:ring-transparent search-input' @endphp
 
+@once
+    @if ($file = vite_filename_path('Autocomplete.vue'))
+        @vite([$file])
+    @endif
+@endonce
+
 <div v-if="!$root.loadAutocomplete" class="relative w-full">
     <label for="autocomplete-input" class="sr-only">@lang('Search')</label>
     <input


### PR DESCRIPTION
This PR most importantly fixes the Autocomplete which breaks when used on a fresh page load.

I don't know if this is the solution we really want here... it works, but it's not very nice. It's the same thing that's used in the [listing](https://github.com/rapidez/core/blob/master/resources/views/components/listing.blade.php#L3-L9), except it doesn't push into the head because for some reason that didn't work.

Other fixes in this PR include a small error caused by going to a category page without subcategories, and checking if turbo actually exists before trying to load the page size from it.