### PR TITLE
[3.x] Check for resultsType outside of partial

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -55,7 +55,9 @@
                             {{-- The order can be changed with https://tailwindcss.com/docs/order --}}
                             <template v-for="(resultsData, resultsType) in autocompleteScope.results ?? {}" v-if="resultsData?.hits?.length">
                                 @foreach (config('rapidez.frontend.autocomplete.additionals') as $key => $fields)
-                                    @includeIf('rapidez::layouts.partials.header.autocomplete.' . $key)
+                                    <template v-if="resultsType == '{{ $key }}'">
+                                        @includeIf('rapidez::layouts.partials.header.autocomplete.' . $key)
+                                    </template>
                                 @endforeach
                             </template>
                             @include('rapidez::layouts.partials.header.autocomplete.products')

--- a/resources/views/layouts/partials/header/autocomplete/categories.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/categories.blade.php
@@ -1,4 +1,4 @@
-<div class="border-b pb-2" v-if="resultsType == 'categories'">
+<div class="border-b pb-2">
     <x-rapidez::autocomplete.title>@lang('Categories')</x-rapidez::autocomplete.title>
     <ul class="flex flex-col font-sans">
         <li v-for="hit in resultsData.hits" :key="hit._source.id" class="flex flex-1 items-center w-full">


### PR DESCRIPTION
It's a bit weird to check for this inside of the partial, and thus needing to explain in the documentation that this is necessary (see https://github.com/rapidez/docs/pull/69)

I'm not sure why I didn't do this originally when doing the refactor here. This is now a slightly breaking change.