### PR TITLE
[3.x] Add getCustomAttributeValue function

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -139,6 +139,24 @@ function init() {
 
                     return `/storage/${store}/resizes/${size}/magento${url}`
                 },
+
+                getCustomAttributeValue(object, code) {
+                    let attribute = object?.custom_attributes?.find((attribute) => attribute.code == code) ?? null
+
+                    if (!attribute) {
+                        return null
+                    }
+
+                    if ('value' in attribute) {
+                        return attribute.value
+                    }
+
+                    if ('selected_options' in attribute) {
+                        return Object.fromEntries(attribute.selected_options.map((option) => [option.value, option.label]))
+                    }
+
+                    return null
+                },
             },
             computed: {
                 // Wrap the local storage in getter and setter functions so you do not have to interact using .value


### PR DESCRIPTION
Right now, if you want to find the value of a custom_attribute value, you need to do something like this:

```js
data.customer.custom_attributes?.find(attribute => attribute.code == 'my_attribute')?.value
```

This is annoying and ugly, especially when found in blade templates and especially when combined into longer statements.

With this function, we can simplify this and make it much more readable:

```js
getCustomAttributeValue(data.customer, 'my_attribute')
```

It also handles `selected_options` and transforms that into an object with the option values as keys. Before this PR, that would have to be written something like this:

```js
data.customer.custom_attributes?.find(attribute => attribute.code == 'my_attribute')?.selected_options?.find(option => option.value == 'my_option')
```

With this PR, it can be written like this instead:

```js
getCustomAttributeValue(data.customer, 'my_attribute')?.my_option
```