### PR TITLE
[3.x] Null coalescing for csrf token

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -101,7 +101,7 @@ function init() {
                 loadingCount: 0,
                 loading: false,
                 loadAutocomplete: false,
-                csrfToken: document.querySelector('[name=csrf-token]').content,
+                csrfToken: document.querySelector('[name=csrf-token]')?.content,
                 cart: useCart(),
                 order: useOrder(),
                 user: useUser(),


### PR DESCRIPTION
Some semi-rare cases happen where the page doesn't have the `csrf-token` element, causing there to be a js error here.

I can't really figure out how I might reproduce this issue myself, but I can see it happening in Sentry for multiple users. Could have something to do with a browser extension like an ad blocker that's being a little overly aggressive.