### PR TITLE
[3.x] Fix error on file removal

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -173,6 +173,11 @@ export default {
 
         setCustomOptionFile(event, optionId) {
             let file = event.target.files[0]
+
+            if (!file) {
+                return
+            }
+            
             let reader = new FileReader()
             reader.onerror = (error) => alert(error)
             reader.onload = () => {

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -177,7 +177,7 @@ export default {
             if (!file) {
                 return
             }
-            
+
             let reader = new FileReader()
             reader.onerror = (error) => alert(error)
             reader.onload = () => {


### PR DESCRIPTION
On Chrome and Chromium based browsers, you can remove a selected file in a file input by clicking cancel on the dialog. Because of this, you can select a file and then deselect it. This causes an error in this code because it assumes you always have a file.