### PR TITLE
[3.x] Allow access to configured variant data on configured product

### DIFF
--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -4,6 +4,14 @@
             <td class="w-24">
                 <a :href="item.product.url_key + item.product.url_suffix | url">
                     <img
+                        v-if="item.configured_variant?.image"
+                        class="mx-auto"
+                        :alt="item.product.name"
+                        :src="resizedPath(item.configured_variant.image.url + '.webp', '80x80')"
+                        height="80"
+                    />
+                    <img
+                        v-else-if="item.product.image"
                         class="mx-auto"
                         :alt="item.product.name"
                         :src="resizedPath(item.product.image.url + '.webp', '80x80')"

--- a/resources/views/cart/queries/fragments/cart.graphql
+++ b/resources/views/cart/queries/fragments/cart.graphql
@@ -38,6 +38,9 @@ fragment cart on Cart {
                 option_label
                 value_label
             }
+            configured_variant {
+                ...product
+            }
         }
         ... on BundleCartItem {
             @include('rapidez::cart.queries.partials.customizable_options')


### PR DESCRIPTION
This fixes the thumbnail in the cart not matching that of the selected variant, instead just showing the main image.

I assume there are other uses for this too, however this was the most noticeable issue.
