### PR TITLE
[3.x] Fix flashing shipping method

### DIFF
--- a/resources/views/checkout/steps/shipping_method.blade.php
+++ b/resources/views/checkout/steps/shipping_method.blade.php
@@ -16,7 +16,7 @@
     v-slot="{ mutate, variables }"
     v-if="!cart.is_virtual"
 >
-    <fieldset class="flex flex-col gap-3" partial-submit="mutate" v-on:change="window.app.$emit('setShippingAddressesOnCart')">
+    <fieldset class="flex flex-col gap-3" partial-submit="mutate">
         <label class="flex items-center gap-x-1.5 p-5 border rounded bg-white cursor-pointer text-sm text" v-for="(method, index) in cart.shipping_addresses[0]?.available_shipping_methods">
             <x-rapidez::input.radio.base
                 name="shipping_method"


### PR DESCRIPTION
Currently, if you select a shipping method, it will briefly reset the value between the initial `setShippingAddressesOnCart` and then the following `setShippingMethodsOnCart` queries (because of some vue reactivity magic).

As it turns out, this `v-on:change` event is not necessary at all. When removed, the two queries will still both be executed. However, they will then be executed simultaneously, which resolves the flashing issue.
