### PR TITLE
[3.x] Don't clear cart on invalid coupon code

### DIFF
--- a/resources/views/cart/coupon/add.blade.php
+++ b/resources/views/cart/coupon/add.blade.php
@@ -5,7 +5,6 @@
     :clear="true"
     :watch="false"
     :callback="updateCart"
-    :error-callback="checkResponseForExpiredCart"
     v-slot="{ mutate, variables }"
 >
     <form v-on:submit.prevent="mutate" class="flex gap-3">


### PR DESCRIPTION
When entering an invalid coupon code, graphql will return a `graphql-no-such-entity` error. `checkResponseForExpiredCart` checks for a `graphql-no-such-entity` error and clears your cart if found. This is obviously not the type of behavior that we want.

It might end up being a good idea to change the check in `checkResponseForExpiredCart` at some point because I'm sure this won't be the only bug.