### PR TITLE
Fix the disabled options to work if there's only one super attribute

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -341,6 +341,10 @@ export default {
                     }
 
                     if (!option.in_stock) {
+                        if (Object.keys(this.product.super_attributes).length === 1) {
+                            disabledOptions['super_' + attribute.code].push(option[attribute.code]);
+                        }
+
                         return
                     }
 


### PR DESCRIPTION
When a product has only one super attribute, this happens here: https://github.com/rapidez/core/blame/2.x/resources/js/components/Product/AddToCart.vue#L353

When there's only one super attribute, the cross reference will return right away and because of this the option will never be added to the disabled options array: https://github.com/rapidez/core/blame/2.x/resources/js/components/Product/AddToCart.vue#L370

2.x: #694 
