### PR TITLE
[3.x] Update ReactiveSearch version (fix dusk tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "prod": "vite build"
     },
     "devDependencies": {
-        "@appbaseio/reactivesearch-vue": "https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=fixes&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es",
+        "@appbaseio/reactivesearch-vue": "https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=v1.34.0-vue&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es",
         "@babel/core": "^7.23.9",
         "@hotwired/turbo": "^8.0.2",
         "@tailwindcss/forms": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,9 +26,9 @@
     redux-thunk "^2.3.0"
     xdate "^0.8.2"
 
-"@appbaseio/reactivesearch-vue@https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=fixes&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es":
+"@appbaseio/reactivesearch-vue@https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=v1.34.0-vue&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es":
   version "2.0.0-alpha.4"
-  resolved "https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=fixes&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es#1ac0368c6aa09acacc48f18809498bad42b7607f"
+  resolved "https://gitpkg.vercel.app/api/pkg?url=rapidez/reactivesearch/packages/vue&commit=v1.34.0-vue&scripts.postinstall=yarn%20install%20--ignore-scripts%20%26%26%20yarn%20run%20build-es&scripts.build-es=nps%20build.es#aa3e3bf8a01901a56f123e8022c5df7e57798801"
   dependencies:
     "@appbaseio/reactivecore" "9.14.25"
     "@appbaseio/vue-emotion" "0.4.4"


### PR DESCRIPTION
The dusk tests failed because npm doesn't really like when the url stays the same but the contents of the package changes. This is what happened after a small PR was merged.

Now that we have tagged a release we can use that tag so that this (hopefully) never breaks again.