### PR TITLE
Prevent body scroll when input checked

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.0|^5.3",
         "mailerlite/laravel-elasticsearch": "^11.1",
-        "rapidez/blade-components": "^1.0",
+        "rapidez/blade-components": "^1.4",
         "rapidez/blade-directives": "^1.0",
         "tormjens/eventy": "^0.8"
     },

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
     @stack('head')
     @config('design/head/includes')
 </head>
-<body class="text antialiased">
+<body class="text antialiased has-[.prevent-scroll:checked]:overflow-clip">
     <div id="app" class="flex flex-col min-h-dvh">
         @includeWhen(!request()->routeIs('checkout'), 'rapidez::layouts.partials.header')
         @includeWhen(request()->routeIs('checkout'), 'rapidez::layouts.checkout.header')


### PR DESCRIPTION
Within the Rapidez Blade components, we use the peer-checked utility for slideovers and popups. When you open a slideover or popup, you get a full-screen view of the component. However, you can still scroll in the background of the components. To prevent this, you can add class="prevent-scroll" to the <input element. When the input is checked, the <body gets overflow: hidden, removing the scroll ability.
