### PR TITLE
[2.x] fix overwriting stack with 404s

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -43,7 +43,7 @@ class FallbackController extends Controller
                 BackedEnumCaseNotFoundException::class,
                 ModelNotFoundException::class,
                 RecordsNotFoundException::class,
-            ])->contains(fn($class) => $exception instanceof $class) || $request->expectsJson();
+            ])->contains(fn ($class) => $exception instanceof $class) || $request->expectsJson();
         });
 
         if ($route && $response = $this->tryRoute($route['route'], $request)) {


### PR DESCRIPTION
Rapidez tries the routes that are in the fallbackcontroller, when they fail and throw a 404, Laravel then wants to render a 404 page overwriting the stack. This can cause for example; not loading in the resizer script added by the startPush in rapidez/statamic: https://github.com/rapidez/statamic/blob/master/src/RapidezStatamicServiceProvider.php#L246 

Alternative of: https://github.com/rapidez/statamic/pull/109

3.x: #702 