### PR TITLE
[3.x] fix overwriting stack with 404s

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -43,7 +43,7 @@ class FallbackController extends Controller
                 BackedEnumCaseNotFoundException::class,
                 ModelNotFoundException::class,
                 RecordsNotFoundException::class,
-            ])->contains(fn($class) => $exception instanceof $class) || $request->expectsJson();
+            ])->contains(fn ($class) => $exception instanceof $class) || $request->expectsJson();
         });
 
         if ($route && $response = $this->tryRoute($route['route'], $request)) {
@@ -64,7 +64,7 @@ class FallbackController extends Controller
 
             return $response;
         }
-        
+
         Exceptions::shouldRenderJsonWhen(null);
         abort(404);
     }

--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -13,10 +13,12 @@ use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Exceptions;
 use Rapidez\Core\Facades\Rapidez;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Throwable;
 
 class FallbackController extends Controller
 {
@@ -33,6 +35,17 @@ class FallbackController extends Controller
     {
         $cacheKey = 'fallbackroute-' . md5($request->url());
         $route = Cache::get($cacheKey);
+
+        Exceptions::shouldRenderJsonWhen(function ($request, Throwable $exception) {
+            return collect([
+                RouteNotFoundException::class,
+                NotFoundHttpException::class,
+                BackedEnumCaseNotFoundException::class,
+                ModelNotFoundException::class,
+                RecordsNotFoundException::class,
+            ])->contains(fn($class) => $exception instanceof $class) || $request->expectsJson();
+        });
+
         if ($route && $response = $this->tryRoute($route['route'], $request)) {
             return $response;
         }
@@ -51,7 +64,8 @@ class FallbackController extends Controller
 
             return $response;
         }
-
+        
+        Exceptions::shouldRenderJsonWhen(null);
         abort(404);
     }
 


### PR DESCRIPTION
Rapidez tries the routes that are in the fallbackcontroller, when they fail and throw a 404, Laravel then wants to render a 404 page overwriting the stack. This can cause for example; not loading in the resizer script added by the startPush in rapidez/statamic: https://github.com/rapidez/statamic/blob/master/src/RapidezStatamicServiceProvider.php#L246

Alternative of: https://github.com/rapidez/statamic/pull/109

2.x: #701 