### PR TITLE
[2.x] Don't force html suffix

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -198,7 +198,7 @@ class Product extends Model
     {
         $configModel = config('rapidez.models.config');
 
-        return '/' . ($this->url_key ? $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
+        return '/' . ($this->url_key ? $this->url_key . $configModel::getValue('catalog/seo/product_url_suffix') : 'catalog/product/view/id/' . $this->entity_id);
     }
 
     public function getImagesAttribute(): array


### PR DESCRIPTION
When the `catalog/seo/product_url_suffix` or `catalog/seo/category_url_suffix` config setting is set to `null` this causes the  fallback check to return the default because `null` is a `false` value. https://github.com/rapidez/core/blob/4d362bce8cf5e8fd140b58b0315e6175240d353e/src/Models/Config.php#L62 

3.x: #705 
