### PR TITLE
[3.x] Allow for custom fuzziness in additionals

### DIFF
--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -63,13 +63,14 @@ export default {
                 let fields = data['fields'] ?? data
                 let size = data['size'] ?? self.size ?? undefined
                 let sort = data['sort'] ?? undefined
+                let fuzziness = data['fuzziness'] ?? 'AUTO'
 
                 let multimatch = self.multiMatchTypes.map((type) => ({
                     multi_match: {
                         query: query,
                         type: type,
                         fields: fields,
-                        fuzziness: type.includes('phrase') ? undefined : 'AUTO',
+                        fuzziness: type.includes('phrase') ? undefined : fuzziness,
                     },
                 }))
 


### PR DESCRIPTION
This allows you to change the [ES fuzziness parameter](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/common-options.html#fuzziness) to be able to be more specific.