### PR TITLE
Add endpoint to request a checkout with the given quote hash and customer token

### DIFF
--- a/config/rapidez/system.php
+++ b/config/rapidez/system.php
@@ -30,6 +30,6 @@ return [
 
     'standalone_checkout' => [
         // What cache store should be used to store temporary standalone checkout credentials
-        'cache_store' => env('STANDALONE_CHECKOUT_CACHE_STORE', config('cache.default'))
-    ]
+        'cache_store' => env('STANDALONE_CHECKOUT_CACHE_STORE', config('cache.default')),
+    ],
 ];

--- a/config/rapidez/system.php
+++ b/config/rapidez/system.php
@@ -27,4 +27,9 @@ return [
 
     // Should the stock qty be exposed and indexed within Elasticsearch?
     'expose_stock' => false,
+
+    'standalone_checkout' => [
+        // What cache store should be used to store temporary standalone checkout credentials
+        'cache_store' => env('STANDALONE_CHECKOUT_CACHE_STORE', config('cache.default'))
+    ]
 ];

--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -173,6 +173,10 @@ export const user = computed({
 
 // If token gets changed or emptied we should update the user.
 watch(token, refresh)
+if (userStorage.value?.email && !token.value) {
+    token.value = ''
+    userStorage.value = {}
+}
 
 document.addEventListener('vue:loaded', function (event) {
     event.detail.vue.$on('logout', async function (data = {}) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Rapidez\Core\Http\Controllers\OrderController;
+use Rapidez\Core\Http\Controllers\GetSignedCheckoutController;
 use Rapidez\Core\Http\Middleware\VerifyAdminToken;
 
 Route::middleware('api')->prefix('api')->group(function () {
@@ -21,6 +22,8 @@ Route::middleware('api')->prefix('api')->group(function () {
     });
 
     Route::get('order', OrderController::class);
+
+    Route::post('get-checkout-url', GetSignedCheckoutController::class);
 
     Route::prefix('admin')->middleware(VerifyAdminToken::class)->group(function () {
         Route::match(['get', 'post'], 'cache/clear', fn () => Artisan::call('cache:clear'));

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Core\Http\Controllers\SignedCheckoutController;
 use Rapidez\Core\Http\Middleware\AuthenticateHealthCheck;
 
 Route::get('healthcheck', config('rapidez.routing.controllers.healthcheck'))->middleware(AuthenticateHealthCheck::class);
@@ -15,6 +16,7 @@ Route::middleware('web')->group(function () {
     Route::get('checkout/success', config('rapidez.routing.controllers.checkout-success'))->name('checkout.success');
 
     Route::get('checkout/onepage/success', fn () => redirect(route('checkout.success', request()->query()), 308));
+    Route::get('checkout/signed', SignedCheckoutController::class)->name('signed-checkout');;
     Route::get('checkout/{step?}', config('rapidez.routing.controllers.checkout'))->middleware('auth:magento-cart')->name('checkout');
     Route::get('search', config('rapidez.routing.controllers.search'))->name('search');
     Route::fallback(config('rapidez.routing.controllers.fallback'));

--- a/src/Http/Controllers/GetSignedCheckoutController.php
+++ b/src/Http/Controllers/GetSignedCheckoutController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rapidez\Core\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+class GetSignedCheckoutController
+{
+    /**
+     * Time for the signed route to be valid for, 2 minutes will result in a timeout anyways.
+     * So it's better to remove the mask and token after that time.
+     */
+    public const URL_TIMEOUT = 120;
+
+    public function __invoke(Request $request)
+    {
+        $data = $request->validate([
+            'mask' => 'required',
+            'token' => 'nullable',
+        ]);
+        $cachekey = (string)Str::uuid();
+        Cache::put('checkout-'.$cachekey, $data, static::URL_TIMEOUT);
+
+        return ['url' => URL::signedRoute('signed-checkout', ['key' => $cachekey], static::URL_TIMEOUT)];
+    }
+}

--- a/src/Http/Controllers/GetSignedCheckoutController.php
+++ b/src/Http/Controllers/GetSignedCheckoutController.php
@@ -22,7 +22,7 @@ class GetSignedCheckoutController
             'token' => 'nullable',
         ]);
         $cachekey = (string) Str::uuid();
-        Cache::put('checkout-' . $cachekey, $data, static::URL_TIMEOUT);
+        Cache::store(config('rapidez.standalone_checkout.cache_store'))->put('checkout-' . $cachekey, $data, static::URL_TIMEOUT);
 
         return ['url' => URL::signedRoute('signed-checkout', ['key' => $cachekey], static::URL_TIMEOUT)];
     }

--- a/src/Http/Controllers/SignedCheckoutController.php
+++ b/src/Http/Controllers/SignedCheckoutController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rapidez\Core\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Rapidez\Core\Models\Quote;
+
+class SignedCheckoutController
+{
+    public function __invoke(Request $request)
+    {
+        if (! $request->hasValidSignature() || !Cache::has('checkout-' . $request->get('key'))) {
+            return redirect(config('rapidez.magento_url'), 301);
+        }
+
+        $data = Cache::get('checkout-' . $request->get('key'));
+        Cache::forget('checkout-' . $request->get('key'));
+
+        $response = redirect()->to('checkout');
+
+        if (!Quote::whereQuoteIdOrCustomerToken($data['mask'] ?? $data['token'])->exists()) {
+            return redirect(config('rapidez.magento_url'), 301);
+        }
+
+        if ($data['mask'] ?? false) {
+            $response->withCookie('mask', $data['mask'], 525949, null, null, null, false);
+        }
+
+        if ($data['token'] ?? false) {
+            $response->withCookie('token', $data['token'], 525949, null, null, null, false);
+        }
+
+        return $response;
+    }
+}

--- a/src/Http/Controllers/SignedCheckoutController.php
+++ b/src/Http/Controllers/SignedCheckoutController.php
@@ -23,13 +23,8 @@ class SignedCheckoutController
             return redirect(config('rapidez.magento_url'), 301);
         }
 
-        if ($data['mask'] ?? false) {
-            $response->withCookie('mask', $data['mask'], 525949, null, null, null, false);
-        }
-
-        if ($data['token'] ?? false) {
-            $response->withCookie('token', $data['token'], 525949, null, null, null, false);
-        }
+        $response->withCookie('mask', $data['mask'] ?? null, 525949, null, null, null, false);
+        $response->withCookie('token', $data['token'] ?? null, 525949, null, null, null, false);
 
         return $response;
     }

--- a/src/Http/Controllers/SignedCheckoutController.php
+++ b/src/Http/Controllers/SignedCheckoutController.php
@@ -10,12 +10,13 @@ class SignedCheckoutController
 {
     public function __invoke(Request $request)
     {
-        if (! $request->hasValidSignature() || ! Cache::has('checkout-' . $request->get('key'))) {
+        $cache = Cache::store(config('rapidez.standalone_checkout.cache_store'));
+        if (! $request->hasValidSignature() || ! $cache->has('checkout-' . $request->get('key'))) {
             return redirect(config('rapidez.magento_url'), 301);
         }
 
-        $data = Cache::get('checkout-' . $request->get('key'));
-        Cache::forget('checkout-' . $request->get('key'));
+        $data = $cache->get('checkout-' . $request->get('key'));
+        $cache->forget('checkout-' . $request->get('key'));
 
         $response = redirect()->to('checkout');
 


### PR DESCRIPTION
This PR offers a secure way to share a customer token and cart mask to Rapidez in order to support a standalone checkout.

the data will be sent as POST data and then stored in the client's cookie. 
So this data will never be visible plaintext.

Next action will be creating a new Magento plugin which calls this with the data and redirecting