### PR TITLE
[Instantsearch] Use URL helper to remove auth from url

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -84,7 +84,7 @@ export default {
                     auth: {
                         username: url.username,
                         password: url.password,
-                    }
+                    },
                 },
                 search_settings: {
                     // Are we using this? In the autocomplete maybe?

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -76,9 +76,15 @@ export default {
         },
 
         searchkit: function () {
+            let url = new URL(config.es_url)
+
             let searchkit = new Searchkit({
                 connection: {
-                    host: config.es_url,
+                    host: url.origin,
+                    auth: {
+                        username: url.username,
+                        password: url.password,
+                    }
                 },
                 search_settings: {
                     // Are we using this? In the autocomplete maybe?


### PR DESCRIPTION
Searchkit and browsers in general do not like when you do api requests with the auth in the url, a la `http://elastic:rapidez@elasticsearch.local/`

We do the same in [autocomplete.vue](https://github.com/rapidez/core/blob/master/resources/js/components/Search/Autocomplete.vue), using the url helper to split up the url nicely.