### PR TITLE
[3.x] Query related products on entity id

### DIFF
--- a/resources/views/product/overview.blade.php
+++ b/resources/views/product/overview.blade.php
@@ -66,7 +66,7 @@
         </div>
     @endif
     <div class="container">
-        <x-rapidez::productlist title="Related products" field="id" :value="$product->relation_ids"/>
-        <x-rapidez::productlist title="We found other products you might like!" field="id" :value="$product->upsell_ids"/>
+        <x-rapidez::productlist title="Related products" field="entity_id" :value="$product->relation_ids"/>
+        <x-rapidez::productlist title="We found other products you might like!" field="entity_id" :value="$product->upsell_ids"/>
     </div>
 @endsection


### PR DESCRIPTION
Products in elasticsearch do not have a `id` attribute that corresponds with the entity_id in `related_ids` and or `upsell_ids`.

2.x: #715 