### PR TITLE
Get Turbo from window

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -36,7 +36,7 @@ export default {
         loaded: false,
         attributes: useAttributes(),
         pageSize:
-            (Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') ||
+            (window?.Turbo?.navigator?.location?.searchParams || new URLSearchParams(window.location.search)).get('pageSize') ||
             config.grid_per_page,
     }),
 


### PR DESCRIPTION
The current structure will still need Turbo to exist but allows navigator etc. within turbo to not exist.
This can cause problems since turbo might not always be loaded yet.

It actually exists on the window so accessing it using window?.Turbo should allow it to coalesce properly