### PR TITLE
Fixed add to cart for simple products

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -274,7 +274,7 @@ export default {
             }
 
             // Check if all super_attributes have an option selected
-            return Object.keys(this.product?.super_attributes).join(',') !== Object.keys(this.options).join(',')
+            return Object.keys(this.product?.super_attributes || {}).join(',') !== Object.keys(this.options).join(',')
         },
 
         simpleProduct: function () {


### PR DESCRIPTION
Currently we were null-coalescing product.super_attributes, however object.keys does not support null being passed.
It requires an object.

For simple products both options and super_attributes would/should be an empty object