### PR TITLE
Improved onestep checkout UX

### DIFF
--- a/lang/nl.json
+++ b/lang/nl.json
@@ -45,6 +45,7 @@
     "Middlename": "Tussenvoegsel",
     "More options": "Meer opties",
     "My billing and shipping address are the same": "Mijn factuur- en verzendadres zijn hetzelfde",
+    "Please enter a shipping address first": "Voer eerst een verzendadres in",
     "New address": "Nieuw adres",
     "Next": "Volgende",
     "No": "Nee",

--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -62,7 +62,7 @@ Vue.prototype.updateCart = async function (data, response) {
     if (!response?.data) {
         return response?.data
     }
-    cart.value = 'cart' in Object.values(response.data)[0] ? Object.values(response.data)[0].cart : Object.values(response.data)[0]
+    cart.value = Object.values(response.data).map((queryResponse) => 'cart' in queryResponse ? queryResponse.cart : queryResponse).findLast((queryResponse) => queryResponse?.is_virtual !== undefined)
 
     return response.data
 }

--- a/resources/views/checkout/steps/billing_address.blade.php
+++ b/resources/views/checkout/steps/billing_address.blade.php
@@ -16,14 +16,15 @@
     v-slot="{ mutate, variables }"
 >
     <div partial-submit="mutate">
-        <template v-if="!cart.is_virtual">
-            <x-rapidez::input.checkbox v-model="variables.same_as_shipping" v-on:change="window.app.$emit('setBillingAddressOnCart')">
-                @lang('My billing and shipping address are the same')
-            </x-rapidez::input.checkbox>
-        </template>
-
-        <fieldset v-if="!variables.same_as_shipping" v-on:change="window.app.$emit('setBillingAddressOnCart')">
-            @include('rapidez::checkout.partials.address', ['type' => 'billing'])
+        <fieldset v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && window.app.$emit('setBillingAddressOnCart')}">
+            <template v-if="!cart.is_virtual">
+                <x-rapidez::input.checkbox v-model="variables.same_as_shipping">
+                    @lang('My billing and shipping address are the same')
+                </x-rapidez::input.checkbox>
+            </template>
+            <template v-if="!variables.same_as_shipping">
+                @include('rapidez::checkout.partials.address', ['type' => 'billing'])
+            </template>
         </fieldset>
     </div>
 </graphql-mutation>

--- a/resources/views/checkout/steps/payment_method.blade.php
+++ b/resources/views/checkout/steps/payment_method.blade.php
@@ -12,7 +12,10 @@
     v-slot="{ mutate, variables }"
 >
     <div class="flex flex-col gap-3" partial-submit="mutate">
-        <label class="flex items-center p-5 border rounded relative bg-white cursor-pointer" v-for="(method, index) in cart.available_payment_methods">
+        <label class="flex items-center p-5 border rounded relative bg-white" v-if="!cart.is_virtual && !cart.shipping_addresses[0]?.uid">
+            <span>@lang('Please enter a shipping address first')</span>
+        </label>
+        <label class="flex items-center p-5 border rounded relative bg-white cursor-pointer" v-else v-for="(method, index) in cart.available_payment_methods">
             <template v-if="false"></template>
             @stack('payment_methods')
             <template v-else>

--- a/resources/views/checkout/steps/shipping_method.blade.php
+++ b/resources/views/checkout/steps/shipping_method.blade.php
@@ -17,6 +17,9 @@
     v-if="!cart.is_virtual"
 >
     <fieldset class="flex flex-col gap-3" partial-submit="mutate" v-on:change="window.app.$emit('setShippingAddressesOnCart')">
+        <label class="flex items-center p-5 border rounded relative bg-white" v-if="!cart.shipping_addresses[0]?.uid">
+            <span>@lang('Please enter a shipping address first')</span>
+        </label>
         <label class="flex items-center gap-x-1.5 p-5 border rounded bg-white cursor-pointer text-sm text" v-for="(method, index) in cart.shipping_addresses[0]?.available_shipping_methods">
             <x-rapidez::input.radio.base
                 name="shipping_method"

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -25,7 +25,7 @@
                             </div>
                         @endif
                     @if (App::providerIsLoaded('Rapidez\Reviews\ReviewsServiceProvider'))
-                        <x-rapidez-reviews::stars v-if="item.reviews_count" count="item.reviews_count" score="item.reviews_score"/>
+                        <x-dynamic-component component="rapidez-reviews::stars" v-if="item.reviews_count" count="item.reviews_count" score="item.reviews_score" />
                     @endif
                     </div>
                 </a>

--- a/resources/views/product/overview.blade.php
+++ b/resources/views/product/overview.blade.php
@@ -20,7 +20,7 @@
                     @includeWhen($product->type_id !== 'grouped', 'rapidez::product.partials.addtocart')
                     @if (App::providerIsLoaded('Rapidez\Reviews\ReviewsServiceProvider'))
                         @if ($product->reviews_score)
-                            <x-rapidez-reviews::stars :score="$product->reviews_score" :count="$product->reviews_count" />
+                            <x-dynamic-component component="rapidez-reviews::stars" :score="$product->reviews_score" :count="$product->reviews_count" />
                         @endif
                     @endif
                     <div>


### PR DESCRIPTION
This PR adds some UX improvements mainly aimed at the onestep checkout, but are also applicable to the default checkout
![image](https://github.com/user-attachments/assets/1b0d9e78-1edc-4e85-a4e1-44ba331cf834)

More in detail:
Now we send the set billing address when the billing address form has all required fields filled so no errors are logged due to missing fields.

When calling updateCart we choose the last cart we find. When running combined queries this should result in us getting the latest cart data.

Now we show a message that the shipping address is required before showing shipping methods.
(This is also the case for payment methods when it is not a virtual order, otherwise errors will be returned by GraphQL)

Additionally i've fixed the 500 errors due to rapidez-reviews missing