### PR TITLE
[2.x] Get option labels with attribute options in the cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog 
 
-[Unreleased changes](https://github.com/rapidez/core/compare/2.19.1...2.19.1)
+[Unreleased changes](https://github.com/rapidez/core/compare/2.20.0...2.20.0)
+## [2.20.0](https://github.com/rapidez/core/releases/tag/2.20.0) - 2025-01-29
+
+### Added
+
+- Autocomplete additionals fuzziness config (#709)
+
+### Fixed
+
+- Use the correct ID for related products and upsells (#715)
+- Fix the disabled options to work with one super attribute (#694)
+
 ## [2.19.1](https://github.com/rapidez/core/releases/tag/2.19.1) - 2025-01-21
 
 ### Fixed

--- a/resources/js/stores/useAttributes.js
+++ b/resources/js/stores/useAttributes.js
@@ -1,5 +1,6 @@
 // TODO: In this file there is a lot of duplication compared to useSwatches. Can we improve that?
 import { computedAsync, useLocalStorage } from '@vueuse/core'
+import { computed } from 'vue'
 
 export const attributesStorage = useLocalStorage('attributes', {})
 let isRefreshing = false
@@ -37,8 +38,8 @@ export const attributes = computedAsync(
     { lazy: true, shallow: false },
 )
 
-window.attributeLabel = (attributeCode) => {
+window.attributeLabel = computed((attributeCode) => {
     return Object.values(attributes.value)?.find((attribute) => attribute.code === attributeCode)?.name
-}
+})
 
 export default () => attributes

--- a/resources/js/stores/useAttributes.js
+++ b/resources/js/stores/useAttributes.js
@@ -37,4 +37,8 @@ export const attributes = computedAsync(
     { lazy: true, shallow: false },
 )
 
+window.attributeLabel = (attributeCode) => {
+    return Object.values(attributes.value)?.find((attribute) => attribute.code === attributeCode)?.name
+}
+
 export default () => attributes

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -137,18 +137,18 @@ export const cart = computed({
                         attribute.code,
                         {
                             label: attribute.label,
-                            options: Object.fromEntries(attribute.options.map((value) => [value.value, value.label]))
+                            options: Object.fromEntries(attribute.options.map((value) => [value.value, value.label])),
                         },
                     ]),
                 )
-                
+
                 value.items = value.items?.map((cartItem) => {
                     cartItem.is_available = checkAvailability(cartItem)
                     cartItem.product.attribute_values = {}
 
                     for (const key in mapping) {
                         cartItem.product.attribute_values[key] = cartItem.product[key]
-                        
+
                         if (cartItem.product.attribute_values[key] === null) {
                             continue
                         }
@@ -156,14 +156,14 @@ export const cart = computed({
                         if (typeof cartItem.product.attribute_values[key] === 'string') {
                             cartItem.product.attribute_values[key] = cartItem.product.attribute_values[key].split(',')
                         }
-                        
+
                         if (typeof cartItem.product.attribute_values[key] !== 'object') {
                             cartItem.product.attribute_values[key] = [cartItem.product.attribute_values[key]]
                         }
-                    
+
                         Vue.set(cartItem.product.attribute_values, key, {
                             options: cartItem.product.attribute_values[key].map((value) => mapping[key]?.options[value] || value),
-                            label: mapping[key]?.label
+                            label: mapping[key]?.label,
                         })
                     }
 

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -131,15 +131,14 @@ export const cart = computed({
 
                     return
                 }
-
+                
                 const mapping = Object.fromEntries(
-                    response.data.customAttributeMetadataV2.items.map((attribute) => [
-                        attribute.code,
-                        {
-                            label: attribute.label,
-                            options: Object.fromEntries(attribute.options.map((value) => [value.value, value.label])),
-                        },
-                    ]),
+                    response.data.customAttributeMetadataV2.items.map((attribute) => {
+                        return [
+                            attribute.code,
+                            Object.fromEntries(attribute.options.map((value) => [value.value, value.label])),
+                        ]
+                    })
                 )
 
                 value.items = value.items?.map((cartItem) => {
@@ -161,10 +160,9 @@ export const cart = computed({
                             cartItem.product.attribute_values[key] = [cartItem.product.attribute_values[key]]
                         }
 
-                        Vue.set(cartItem.product.attribute_values, key, {
-                            options: cartItem.product.attribute_values[key].map((value) => mapping[key]?.options[value] || value),
-                            label: mapping[key]?.label,
-                        })
+                        cartItem.product.attribute_values[key] = cartItem.product.attribute_values[key].map(
+                            (value) => mapping[key][value] || value,
+                        )
                     }
 
                     return cartItem

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -27,7 +27,7 @@
                     </div>
                     <div v-for="option in config.cart_attributes">
                         <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-                            @{{ option }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+                            @{{ item.product.attribute_values[option].label }}: <span v-html="item.product.attribute_values[option].options?.join(', ')"></span>
                         </template>
                     </div>
                     @include('rapidez::cart.item.remove')

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -26,8 +26,8 @@
                         @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
                     </div>
                     <div v-for="option in config.cart_attributes">
-                        <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-                            @{{ item.product.attribute_values[option].label }}: <span v-html="item.product.attribute_values[option].options?.join(', ')"></span>
+                        <template v-if="item.product.attribute_values[option] && typeof item.product.attribute_values[option] === 'object'">
+                            @{{ window.attributeLabel(option) }}: <span v-html="item.product.attribute_values[option].join(', ')"></span>
                         </template>
                     </div>
                     @include('rapidez::cart.item.remove')


### PR DESCRIPTION
This PR is a solution to not having option labels in the cart attributes. Sadly the `customAttributeMetadata` query does not support getting the option labels, however `customAttributeMetadataV2` does. We also had to change the mapping a bit.

3.x: #755 