### PR TITLE
[2.x] Make sure you can't place two orders at the same time

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -10,6 +10,7 @@ export default {
 
     data() {
         return {
+            placingOrder: false,
             backEvent: false,
             steps: [],
         }
@@ -211,6 +212,12 @@ export default {
                 return false
             }
 
+            if (this.placingOrder) {
+                return false
+            }
+
+            this.placingOrder = true
+
             try {
                 this.$root.$emit('before-checkout-payment-saved', {
                     order: {
@@ -241,12 +248,15 @@ export default {
                     },
                 })
 
+                this.placingOrder = false
                 return true
             } catch (error) {
                 if (FetchError.prototype.isPrototypeOf(error)) {
                     const response = await error.response.json()
                     Notify(response?.message, 'error', response?.parameters)
                 }
+
+                this.placingOrder = false
                 return false
             }
         },

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -101,6 +101,10 @@ export default {
 
     methods: {
         async mutate() {
+            if (this.mutating) {
+                return
+            }
+
             this.mutating = true
             this.error = false
 


### PR DESCRIPTION
If you click the "Place order" button twice in a very short timespan (e.g. your mouse is broken and double clicks the button) we have seen a very rare edge case where this seemingly actually causes an order to be placed twice. I was not able to reproduce this locally, however I do believe that's the actual root cause.

Originally I made [a patch](https://github.com/rapidez/checkout-theme/pull/165) that caused the button to disable instantly on click. However, it seems that didn't actually fix the issue and caused a race condition to rarely happen that disabled the button without submitting.

Instead, here's an alternative solution to only fix the double orders thing.