### PR TITLE
Remove no-cache from cache-control

### DIFF
--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -17,7 +17,6 @@ class CategoryController extends Controller
 
         $response = response()->view('rapidez::category.overview', compact('category'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $category->updated_at]);
-        $response->isNotModified(request());
 
         return $response;
     }

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -16,8 +16,9 @@ class CategoryController extends Controller
         session(['latest_category_path' => $category->path]);
 
         $response = response()->view('rapidez::category.overview', compact('category'));
-        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $category->updated_at]);
 
-        return $response;
+        return $response
+            ->setEtag(md5($response->getContent() ?? ''))
+            ->setLastModified($category->updated_at);
     }
 }

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -2,9 +2,7 @@
 
 namespace Rapidez\Core\Http\Controllers;
 
-use Illuminate\Routing\Controller;
-
-class CategoryController extends Controller
+class CategoryController
 {
     public function show(int $categoryId)
     {

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -2,7 +2,9 @@
 
 namespace Rapidez\Core\Http\Controllers;
 
-class CategoryController
+use Illuminate\Routing\Controller;
+
+class CategoryController extends Controller
 {
     public function show(int $categoryId)
     {
@@ -13,6 +15,9 @@ class CategoryController
         config(['frontend.subcategories' => $category->subcategories->pluck('name', 'entity_id')]);
         session(['latest_category_path' => $category->path]);
 
-        return view('rapidez::category.overview', compact('category'));
+        $response = response()->view('rapidez::category.overview', compact('category'));
+        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $category->updated_at]);
+        $response->isNotModified(request());
+        return $response;
     }
 }

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -18,6 +18,7 @@ class CategoryController extends Controller
         $response = response()->view('rapidez::category.overview', compact('category'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $category->updated_at]);
         $response->isNotModified(request());
+
         return $response;
     }
 }

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -10,7 +10,6 @@ class PageController
     {
         $response = response()->view('rapidez::page.overview', compact('page'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->update_time]);
-        $response->isNotModified(request());
 
         return $response;
     }

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -11,6 +11,7 @@ class PageController
         $response = response()->view('rapidez::page.overview', compact('page'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->updated_at]);
         $response->isNotModified(request());
+
         return $response;
     }
 }

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -9,8 +9,9 @@ class PageController
     public function show(Page $page)
     {
         $response = response()->view('rapidez::page.overview', compact('page'));
-        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->update_time]);
 
-        return $response;
+        return $response
+            ->setEtag(md5($response->getContent() ?? ''))
+            ->setLastModified($page->update_time);
     }
 }

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -9,7 +9,7 @@ class PageController
     public function show(Page $page)
     {
         $response = response()->view('rapidez::page.overview', compact('page'));
-        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->updated_at]);
+        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->update_time]);
         $response->isNotModified(request());
 
         return $response;

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -8,6 +8,9 @@ class PageController
 {
     public function show(Page $page)
     {
-        return view('rapidez::page.overview', compact('page'));
+        $response = response()->view('rapidez::page.overview', compact('page'));
+        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $page->updated_at]);
+        $response->isNotModified(request());
+        return $response;
     }
 }

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -43,8 +43,9 @@ class ProductController
         config(['frontend.product' => $product->only($attributes)]);
 
         $response = response()->view('rapidez::product.overview', compact('product'));
-        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $product->updated_at]);
 
-        return $response;
+        return $response
+            ->setEtag(md5($response->getContent() ?? ''))
+            ->setLastModified($product->updated_at);
     }
 }

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -42,6 +42,9 @@ class ProductController
 
         config(['frontend.product' => $product->only($attributes)]);
 
-        return view('rapidez::product.overview', compact('product'));
+        $response = response()->view('rapidez::product.overview', compact('product'));
+        $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $product->updated_at]);
+        $response->isNotModified(request());
+        return $response;
     }
 }

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -45,6 +45,7 @@ class ProductController
         $response = response()->view('rapidez::product.overview', compact('product'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $product->updated_at]);
         $response->isNotModified(request());
+
         return $response;
     }
 }

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -44,7 +44,6 @@ class ProductController
 
         $response = response()->view('rapidez::product.overview', compact('product'));
         $response->setCache(['etag' => md5($response->getContent() ?? ''), 'last_modified' => $product->updated_at]);
-        $response->isNotModified(request());
 
         return $response;
     }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -13,7 +13,8 @@ class Category extends Model
     use HasAlternatesThroughRewrites;
 
     protected $casts = [
-        'updated_at' => 'datetime',
+        self::UPDATED_AT => 'datetime',
+        self::CREATED_AT => 'datetime',
     ];
 
     protected $appends = ['url'];
@@ -36,7 +37,7 @@ class Category extends Model
                 'children',
                 'children_count',
                 'position',
-                'updated_at',
+                self::UPDATED_AT,
             ];
 
             $builder

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -36,7 +36,7 @@ class Category extends Model
                 'children',
                 'children_count',
                 'position',
-                'updated_at'
+                'updated_at',
             ];
 
             $builder

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -12,6 +12,10 @@ class Category extends Model
 {
     use HasAlternatesThroughRewrites;
 
+    protected $casts = [
+        'updated_at' => 'datetime',
+    ];
+
     protected $appends = ['url'];
 
     protected static function booting()
@@ -32,6 +36,7 @@ class Category extends Model
                 'children',
                 'children_count',
                 'position',
+                'updated_at'
             ];
 
             $builder

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -11,6 +11,10 @@ class Page extends Model
 
     protected $primaryKey = 'page_id';
 
+    protected $casts = [
+        'updated_at' => 'datetime',
+    ];
+
     protected static function booting()
     {
         static::addGlobalScope(new IsActiveScope);

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -11,8 +11,13 @@ class Page extends Model
 
     protected $primaryKey = 'page_id';
 
+    const CREATED_AT = 'creation_time';
+
+    const UPDATED_AT = 'update_time';
+
     protected $casts = [
-        'update_time' => 'datetime',
+        self::UPDATED_AT => 'datetime',
+        self::CREATED_AT => 'datetime',
     ];
 
     protected static function booting()

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -12,7 +12,7 @@ class Page extends Model
     protected $primaryKey = 'page_id';
 
     protected $casts = [
-        'updated_at' => 'datetime',
+        'update_time' => 'datetime',
     ];
 
     protected static function booting()

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -36,7 +36,12 @@ class Product extends Model
 
     protected $primaryKey = 'entity_id';
 
+    protected $casts = [
+        'updated_at' => 'datetime',
+    ];
+
     protected $appends = ['url'];
+
 
     protected static function booting(): void
     {

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -37,7 +37,8 @@ class Product extends Model
     protected $primaryKey = 'entity_id';
 
     protected $casts = [
-        'updated_at' => 'datetime',
+        self::UPDATED_AT => 'datetime',
+        self::CREATED_AT => 'datetime',
     ];
 
     protected $appends = ['url'];

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -42,7 +42,6 @@ class Product extends Model
 
     protected $appends = ['url'];
 
-
     protected static function booting(): void
     {
         static::addGlobalScope(new WithProductAttributesScope);

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -16,6 +16,7 @@ class WithProductAttributesScope implements Scope
             $model->qualifyColumn('visibility'),
             $model->qualifyColumn('type_id'),
             $model->getQualifiedCreatedAtColumn(),
+            $model->getQualifiedUpdatedAtColumn(),
         ]);
 
         if (empty($model->attributesToSelect)) {


### PR DESCRIPTION
By default Symfony (and thus by extension Laravel) returns no-cache, private as the cache-control headers.

https://github.com/symfony/symfony/blob/6f4f04b98f6134996a57d21d1851d558a34dc45c/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L251


This causes Turbo to skip loading from cache: 

https://github.com/hotwired/turbo/blob/ae14a60e7a5784deeb54cadeb47778693855c57f/src/core/drive/page_snapshot.js#L66

Using the Etag and/or last_modified date (which we have available for categories, pages and products) allows pages to be cached but always needing to be revalidated:
https://github.com/symfony/symfony/blob/6f4f04b98f6134996a57d21d1851d558a34dc45c/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L247

This will allow turbo to use the prefetched page instead of having to fetch the page again before fully showing.

As you can see we first have a request to prefetch the page (this is when i hover the link)
Then after the click it immediately shows the page (as seen by the render function hovered)
~~After the page has fully loaded the revalidation request will trigger.~~ That was incorrect, this was only caused by my mouse still being hovered over the link.
![image](https://github.com/user-attachments/assets/96ec4430-0954-491f-94b4-3799613d43e5)

Full caching would be even better however this could result in stale data, or data from another user being shown in projects where this is rendered in PHP.
This is better left up to the developer and their project by implementing a middleware, like https://laravel.com/docs/11.x/responses#cache-control-middleware

I believe this PR is able to be backported to 2.x, if we want this i'll create a PR for that as well.