### PR TITLE
[3.x] Use @content for 404 content

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -18,7 +18,7 @@
     <div class="container">
         <h1 class="mb-5 text-4xl font-bold">{{ $page->content_heading }}</h1>
         <div class="prose prose-green mb-5">
-            {!! $page->content !!}
+            @content($page->content)
         </div>
     </div>
 @endsection


### PR DESCRIPTION
This content comes from magento and may end up causing you to have broken links:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/af9e68f8-edc0-4c8c-887d-cf3d51c23827" />



```html
[...]
<a href="{{store url=""}}">Store Home</a>
<span class="separator">|</span>
<a href="{{store url="customer/account"}}">My Account</a>
[...]
```

This fixes that.