### PR TITLE
[2.x] Only apply default value when config option is not found

### DIFF
--- a/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
+++ b/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
@@ -5,6 +5,7 @@ namespace Rapidez\Core\Listeners\Healthcheck;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use PDOException;
+use Rapidez\Core\Facades\Rapidez;
 
 class MagentoSettingsHealthcheck extends Base
 {
@@ -25,8 +26,7 @@ class MagentoSettingsHealthcheck extends Base
             return $response;
         }
 
-        $configModel = config('rapidez.models.config');
-        if (! $configModel::getCachedByPath('catalog/frontend/flat_catalog_product', 0)) {
+        if (! Rapidez::config('catalog/frontend/flat_catalog_product', 0)) {
             $response['messages'][] = ['type' => 'error', 'value' => __('The product flat tables are disabled!')];
         }
 
@@ -37,7 +37,7 @@ class MagentoSettingsHealthcheck extends Base
             $response['messages'][] = ['type' => 'error', 'value' => __('Flat table ":flatTable" is missing! Don\'t forget to run bin/magento indexer:reindex', ['flatTable' => $flatTable])];
         }
 
-        if (! $configModel::getCachedByPath('catalog/frontend/flat_catalog_category', 0)) {
+        if (! Rapidez::config('catalog/frontend/flat_catalog_category', 0)) {
             $response['messages'][] = ['type' => 'error', 'value' => __('The category flat tables are disabled!')];
         }
 

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -21,6 +21,10 @@ class Config extends Model
 
     protected $primaryKey = 'config_id';
 
+    const CREATED_AT = null;
+
+    protected $guarded = [];
+
     protected static function booting()
     {
         static::addGlobalScope('scope-fallback', function (Builder $builder) {

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -98,6 +98,9 @@ class Config extends Model
             // Catch the case it is intentionally set to null
             if (Arr::has($configCache, $cacheKey)) {
                 $result = Arr::get($configCache, $cacheKey);
+                if ($result === false) {
+                    $result = $options['default'] ?? null;
+                }
 
                 return (bool) $options['decrypt'] && is_string($result) ? static::decrypt($result) : $result;
             }
@@ -118,7 +121,7 @@ class Config extends Model
         $result = $resultObject ? $resultObject->value : ($options['default'] ?? null);
 
         if ($options['cache'] ?? true) {
-            Arr::set($configCache, $cacheKey, $result);
+            Arr::set($configCache, $cacheKey, $resultObject ? $result : false);
             Cache::driver('rapidez:multi')->set('magento.config', $configCache);
         }
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -12,6 +12,7 @@ use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
 use Rapidez\Core\Casts\DecodeHtmlEntities;
+use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Scopes\Product\WithProductAttributesScope;
 use Rapidez\Core\Models\Scopes\Product\WithProductCategoryInfoScope;
 use Rapidez\Core\Models\Scopes\Product\WithProductChildrenScope;
@@ -201,9 +202,7 @@ class Product extends Model
 
     public function getUrlAttribute(): string
     {
-        $configModel = config('rapidez.models.config');
-
-        return '/' . ($this->url_key ? $this->url_key . $configModel::getCachedByPath('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
+        return '/' . ($this->url_key ? $this->url_key . Rapidez::config('catalog/seo/product_url_suffix', '.html') : 'catalog/product/view/id/' . $this->entity_id);
     }
 
     public function getImagesAttribute(): array

--- a/src/Rapidez.php
+++ b/src/Rapidez.php
@@ -59,7 +59,7 @@ class Rapidez
 
     public function config(string $path, $default = null, bool $sensitive = false): ?string
     {
-        return config('rapidez.models.config')::getValue($path, options: ['cache' => true, 'decrypt' => $sensitive]) ?? $default;
+        return config('rapidez.models.config')::getValue($path, options: ['cache' => true, 'decrypt' => $sensitive, 'default' => $default]);
     }
 
     public function content($content)

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -219,9 +219,7 @@ class RapidezServiceProvider extends ServiceProvider
         });
 
         Blade::directive('config', function ($expression) {
-            $configModel = config('rapidez.models.config');
-
-            return "<?php echo {$configModel}::getCachedByPath({$expression}) ?>";
+            return "<?php echo Rapidez::config({$expression}) ?>";
         });
 
         Blade::if('storecode', function ($value) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,11 +1,12 @@
 <?php
 
+use Rapidez\Core\Facades\Rapidez;
+
 if (! function_exists('price')) {
     function price($price)
     {
-        $configModel = config('rapidez.models.config');
-        $currency = $configModel::getCachedByPath('currency/options/default');
-        $locale = $configModel::getCachedByPath('general/locale/code', 'en_US');
+        $currency = Rapidez::config('currency/options/default');
+        $locale = Rapidez::config('general/locale/code', 'en_US');
         $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
 
         return $formatter->formatCurrency($price, $currency);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,12 +1,10 @@
 <?php
 
-use Rapidez\Core\Facades\Rapidez;
-
 if (! function_exists('price')) {
     function price($price)
     {
-        $currency = Rapidez::config('currency/options/default');
-        $locale = Rapidez::config('general/locale/code', 'en_US');
+        $currency = \Rapidez\Core\Facades\Rapidez::config('currency/options/default');
+        $locale = \Rapidez\Core\Facades\Rapidez::config('general/locale/code', 'en_US');
         $formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
 
         return $formatter->formatCurrency($price, $currency);

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rapidez\Core\Tests\Feature;
+
+use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Core\Models\Config;
+use Rapidez\Core\Tests\TestCase;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function config_can_be_intentionally_null()
+    {
+        $test = Config::create([
+            'path'  => 'rapidez/test/value_null',
+            'value' => null,
+        ]);
+
+        $this->assertNull(Rapidez::config('rapidez/test/value_null', 'default'));
+        $this->assertEquals('default', Rapidez::config('rapidez/test/nonexistent_value', 'default'));
+
+        $test->delete();
+    }
+}


### PR DESCRIPTION
When retrieving a config option you may end up getting a value of `NULL`. The current implementation uses null-coalescing after getting the value, which causes that `NULL` to be replaced by the default value. However, if the config key does actually exist then this is not the correct behavior.

For example, if you don't want a `.html` suffix on your product pages, you set the config value to `NULL`. This then gets converted back into `.html` when indexing products, causing the wrong urls to be indexed.

This PR fixes that by implementing a `default` option into the `getValue` function and using that instead of the null-coalescing operator.