### PR TITLE
[3.x] Make sure you can't do a mutation twice simultaneously

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -106,6 +106,10 @@ export default {
 
     methods: {
         async mutate() {
+            if (this.running) {
+                return
+            }
+
             this.running = true
             this.error = false
 


### PR DESCRIPTION
If you have a broken mouse that double clicks (or you just click twice very fast for some reason) you can bypass the standard disabled state and mutate twice. Magento generally does not like this---in most cases it will just mean one of the queries is eaten, but sometimes this can break things (e.g. create 2 exact same orders from 1 cart).