### PR TITLE
Fix the recursion of the recursion component

### DIFF
--- a/resources/js/components/Recursion.vue
+++ b/resources/js/components/Recursion.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-
 export default {
     props: {
         data: {
@@ -15,22 +14,22 @@ export default {
     },
     computed: {
         childComponents() {
-            const self = this;
+            const self = this
 
             return this.data.map((item) => {
                 return {
                     render: (h) => {
-                        if(!item.data?.length) {
-                            return h('span');
+                        if (!item.data?.length) {
+                            return h('span')
                         }
 
                         return h('recursion', {
                             props: {
                                 data: item.data,
                             },
-                            scopedSlots: self.$scopedSlots
-                        });
-                    }
+                            scopedSlots: self.$scopedSlots,
+                        })
+                    },
                 }
             })
         },

--- a/resources/js/components/Recursion.vue
+++ b/resources/js/components/Recursion.vue
@@ -1,10 +1,11 @@
 <template>
-    <div>
-        <slot :data="data" :component="childComponent" />
+    <div v-if="data?.length">
+        <slot :data="data" :components="childComponents"></slot>
     </div>
 </template>
 
 <script>
+
 export default {
     props: {
         data: {
@@ -13,15 +14,25 @@ export default {
         },
     },
     computed: {
-        childComponent() {
-            return {
-                render: (h) =>
-                    h('recursion', {
-                        props: {
-                            data: this.data,
-                        },
-                    }),
-            }
+        childComponents() {
+            const self = this;
+
+            return this.data.map((item) => {
+                return {
+                    render: (h) => {
+                        if(!item.data?.length) {
+                            return h('span');
+                        }
+
+                        return h('recursion', {
+                            props: {
+                                data: item.data,
+                            },
+                            scopedSlots: self.$scopedSlots
+                        });
+                    }
+                }
+            })
         },
     },
 }

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -17,7 +17,7 @@
         <ais-instant-search
             class="contents"
             :search-client="searchClient"
-            :index-name="config.index"
+            :index-name="config.index_prefix + '_products_' + config.store"
         >
             <div class="contents">
                 <!-- TODO: This is a Vue 3 thing -->

--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -10,9 +10,9 @@
 >
     <template v-slot="{ items, refine, createURL }">
         {{-- See the HierarchicalMenuList.vue --}}
-        <recursion :data="items" v-slot="{ data, component }">
+        <recursion :data="items" v-slot="{ data, components }">
             <ul>
-                <li v-for="item in data" :key="item.value">
+                <li class="pl-3" v-for="(item, index) in data" :key="item.value">
                     <a
                         :href="createURL(item.value)"
                         :class="{ 'font-bold': item.isRefined }"
@@ -21,14 +21,8 @@
                         @{{ item.label }}
                         (@{{ item.count }})
                     </a>
-                    {{--
-                    TODO: Double check this, the data updates,
-                    but the component doesn't. Tried to
-                    make everything working recursive
-                    plus keep it renderless.
-                    --}}
-                    {{-- @{{item.data}} --}}
-                    <component :data="item.data" :is="component" />
+
+                    <component :is="components[index]" />
                 </li>
             </ul>
         </recursion>


### PR DESCRIPTION
Recursively pass scopedslots to the recursion component.
Only create childcomponents for each item in data to prevent infinite recursion.

Unfortunately the root-path removed all categories