### PR TITLE
[Instantsearch] Routing

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -283,15 +283,17 @@ export default {
                 return []
             }
 
-            return [{
-                function_score: {
-                    script_score: {
-                        script: {
-                            source: `Integer.parseInt(doc['positions.${window.config.category.entity_id}'].empty ? '0' : doc['positions.${window.config.category.entity_id}'].value)`,
+            return [
+                {
+                    function_score: {
+                        script_score: {
+                            script: {
+                                source: `Integer.parseInt(doc['positions.${window.config.category.entity_id}'].empty ? '0' : doc['positions.${window.config.category.entity_id}'].value)`,
+                            },
                         },
                     },
                 },
-            }]
+            ]
         },
 
         withFilters(items) {

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -55,6 +55,9 @@ export default {
         index: {
             type: String,
         },
+        baseFilters: {
+            type: Function,
+        },
     },
 
     data: () => ({
@@ -181,7 +184,7 @@ export default {
         // directly due the JS size
         initSearchClient() {
             return Client(this.searchkit, {
-                getBaseFilters: this.getBaseFilters,
+                getBaseFilters: this.baseFilters,
             })
         },
 
@@ -276,24 +279,6 @@ export default {
             }
 
             return ''
-        },
-
-        getBaseFilters() {
-            if (!window.config.category?.entity_id) {
-                return []
-            }
-
-            return [
-                {
-                    function_score: {
-                        script_score: {
-                            script: {
-                                source: `Integer.parseInt(doc['positions.${window.config.category.entity_id}'].empty ? '0' : doc['positions.${window.config.category.entity_id}'].value)`,
-                            },
-                        },
-                    },
-                },
-            ]
         },
 
         withFilters(items) {

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -253,7 +253,7 @@ export default {
             }
 
             if ('query' in data) {
-                parameters['query'] = data['query']
+                parameters['q'] = data['query']
             }
 
             return parameters
@@ -265,14 +265,14 @@ export default {
             ))
 
             let refinementList = Object.fromEntries(Object.entries(routeState).filter(([key, _]) =>
-                key != 'query' && !this.rangeAttributes.includes(key)
+                key != 'q' && !this.rangeAttributes.includes(key)
             ))
 
             return {
                 [this.index]: {
                     refinementList: refinementList,
                     range: ranges,
-                    query: routeState.query,
+                    query: routeState.q,
                 }
             }
         },

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -181,22 +181,7 @@ export default {
         // directly due the JS size
         initSearchClient() {
             return Client(this.searchkit, {
-                hooks: {
-                    beforeSearch: async (searchRequests) => {
-                        return searchRequests.map((sr) => {
-                            // TODO: Maybe use deepmerge here so it doesn't
-                            // really matter what query is used? What
-                            // if we want to add something to the
-                            // "must" instead of "filter"?
-                            if (this.getQuery()) {
-                                sr.body.query.bool.filter.push(this.getQuery())
-                            }
-                            // And, this is currently applied on all queries,
-                            // it's only relevant on the listing one.
-                            return sr
-                        })
-                    },
-                },
+                getBaseFilters: this.getBaseFilters,
             })
         },
 
@@ -293,13 +278,12 @@ export default {
             return ''
         },
 
-        getQuery() {
+        getBaseFilters() {
             if (!window.config.category?.entity_id) {
-                return
+                return []
             }
 
-            return {
-                // query: {
+            return [{
                 function_score: {
                     script_score: {
                         script: {
@@ -307,8 +291,7 @@ export default {
                         },
                     },
                 },
-                // },
-            }
+            }]
         },
 
         withFilters(items) {

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -11,7 +11,21 @@
         <h1 class="mb-5 text-3xl font-bold">{{ $category->name }}</h1>
 
         @if ($category->is_anchor)
-            <x-rapidez::listing query="'visibility:(2 OR 4) AND category_ids:'+config.category.entity_id" />
+            <x-rapidez::listing
+                v-bind:base-filters="() => [{
+                    query_string: {
+                        query: 'visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}'
+                    }
+                }, {
+                    function_score: {
+                        script_score: {
+                            script: {
+                                source: `Integer.parseInt(doc['positions.{{ $category->entity_id }}'].empty ? '0' : doc['positions.{{ $category->entity_id }}'].value)`,
+                            },
+                        },
+                    },
+                }]"
+            />
         @else
             <div class="flex max-md:flex-col">
                 <div class="xl:w-1/5">

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -1,5 +1,3 @@
-@props(['query'])
-
 @pushOnce('head', 'es_url-preconnect')
     <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
 
@@ -42,9 +40,6 @@
                     {{ $slot }}
                 @endif
                 {{ $after ?? '' }}
-
-                {{-- NOTE: Do not put this component above the filters if you want routing to work. --}}
-                <ais-configure :filters="{!! $query !!}"/>
             </ais-instant-search>
         </div>
     </listing>

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -18,18 +18,16 @@
             value: config.index_prefix + '_products_' + config.store + '_created_at_desc',
             key: '_created_at_desc'
         }]"
+        :index="config.index_prefix + '_products_' + config.store"
         v-cloak
     >
         <div slot-scope="{ loaded, filters, sortOptions, getQuery, withFilters, withSwatches, filterPrefix, _renderProxy: listingSlotProps }">
             <ais-instant-search
                 v-if="loaded"
                 :search-client="listingSlotProps.searchClient"
-                {{-- TODO: Extract this somewhere? --}}
-                :index-name="config.index_prefix + '_products_' + config.store"
+                :index-name="listingSlotProps.index"
                 :routing="listingSlotProps.routing"
             >
-                <ais-configure :filters="{!! $query !!}"/>
-
                 {{ $before ?? '' }}
                 @if ($slot->isEmpty())
                     <div class="flex flex-col lg:flex-row gap-x-6 gap-y-3">
@@ -44,6 +42,9 @@
                     {{ $slot }}
                 @endif
                 {{ $after ?? '' }}
+
+                {{-- NOTE: Do not put this component above the filters if you want routing to work. --}}
+                <ais-configure :filters="{!! $query !!}"/>
             </ais-instant-search>
         </div>
     </listing>

--- a/resources/views/listing/filters.blade.php
+++ b/resources/views/listing/filters.blade.php
@@ -1,18 +1,15 @@
 @php($id = uniqid('filters-'))
 <x-rapidez::slideover.mobile :$id :title="__('Filters')" position="right">
     <div class="w-full p-2 max-lg:bg-white max-lg:p-5">
-        {{-- On mobile the filters aren't immedately visible so we should defer loading --}}
-        <lazy>
-            @include('rapidez::listing.partials.filter.selected')
-            @include('rapidez::listing.partials.filter.search')
-            @include('rapidez::listing.partials.filter.category')
-            <template v-for="filter in filters">
-                @include('rapidez::listing.partials.filter.price')
-                @include('rapidez::listing.partials.filter.swatch')
-                @include('rapidez::listing.partials.filter.boolean')
-                @include('rapidez::listing.partials.filter.select')
-            </template>
-        </lazy>
+        @include('rapidez::listing.partials.filter.selected')
+        @include('rapidez::listing.partials.filter.search')
+        @include('rapidez::listing.partials.filter.category')
+        <template v-for="filter in filters">
+            @include('rapidez::listing.partials.filter.price')
+            @include('rapidez::listing.partials.filter.swatch')
+            @include('rapidez::listing.partials.filter.boolean')
+            @include('rapidez::listing.partials.filter.select')
+        </template>
         <x-rapidez::button.primary for="{{ $id }}" class="w-full text-sm lg:hidden">
             @lang('Show results')
         </x-rapidez::button.primary>

--- a/resources/views/listing/partials/filter/price.blade.php
+++ b/resources/views/listing/partials/filter/price.blade.php
@@ -1,5 +1,5 @@
 <ais-range-input
-    v-if="filter.input == 'price'"
+    v-if="listingSlotProps.rangeAttributes.includes(filter.code)"
     :attribute="filter.code"
 >
     <template v-slot="{ currentRefinement, range, canRefine, refine, sendEvent }">

--- a/resources/views/listing/partials/filter/search.blade.php
+++ b/resources/views/listing/partials/filter/search.blade.php
@@ -1,5 +1,5 @@
 {{-- TODO: Can/should we hide this filter when there are no results? --}}
-<ais-search-box :value="listingSlotProps.searchTerm">
+<ais-search-box>
     <template v-slot="{ currentRefinement, isSearchStalled, refine }">
         <x-rapidez::input
             type="search"

--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         <h1 class="font-bold text-3xl">@lang('Search for'): {{ request()->q }}</h1>
 
-        <x-rapidez::listing query="'visibility:(3 OR 4)'"/>
+        <x-rapidez::listing v-bind:base-filters="() => [{ query_string: { query: 'visibility:(3 OR 4)' }}]"/>
 
 
         {{--


### PR DESCRIPTION
In this PR:

- Wrote very simple custom routing that keeps the URL somewhat readable and doesn't include the index name, also giving us the power to do whatever we want with these url parameters
    - E.g.: `...?price=50%3A80&super_color[0]=58&material[0]=Wool`
- Refactored the searchkit & searchkitClient data a bit, as it being computed forced us to have the routing functions within `data` which is definitely not nice (also means you can't actually use `this.` within those functions)
- Removed `<lazy>` around the filters and moved the `<ais-configure [...]/>` to the bottom of the page so that the routing doesn't get cleared by instantsearch before the filters get loaded in
- Removed the `searchTerm` variable as we don't actually need it with the routing working
- Somewhat extracted the index name to be a property on the listing component
- Removed the beforeSearch hook in favor of using `getBaseFilters` for the current use case. Note that we may end up using beforeSearch regardless, but as we were using it right now it's cleaner to do this.