### PR TITLE
[Instantsearch] Custom search queries

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -183,14 +183,10 @@ export default {
         // we don't want to load everything
         // directly due the JS size
         initSearchClient() {
-            let options = {}
-
-            options['getBaseFilters'] = this.getBaseFilters
-            if (this.query) {
-                options['getQuery'] = this.query
-            }
-
-            return Client(this.searchkit, options)
+            return Client(this.searchkit, {
+                getBaseFilters: this.getBaseFilters,
+                getQuery: this.query,
+            })
         },
 
         initSearchkit() {

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -55,6 +55,9 @@ export default {
         index: {
             type: String,
         },
+        query: {
+            type: Function,
+        }
     },
 
     data: () => ({
@@ -180,9 +183,14 @@ export default {
         // we don't want to load everything
         // directly due the JS size
         initSearchClient() {
-            return Client(this.searchkit, {
-                getBaseFilters: this.getBaseFilters,
-            })
+            let options = {}
+
+            options['getBaseFilters'] = this.getBaseFilters
+            if (this.query) {
+                options['getQuery'] = this.query
+            }
+
+            return Client(this.searchkit, options)
         },
 
         initSearchkit() {

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -11,7 +11,7 @@
         <h1 class="mb-5 text-3xl font-bold">{{ $category->name }}</h1>
 
         @if ($category->is_anchor)
-            <x-rapidez::listing query="'visibility:(2 OR 4) AND category_ids:'+config.category.entity_id" />
+            <x-rapidez::listing filters="'visibility:(2 OR 4) AND category_ids:'+config.category.entity_id" />
         @else
             <div class="flex max-md:flex-col">
                 <div class="xl:w-1/5">

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -1,4 +1,4 @@
-@props(['query'])
+@props(['filters' => null])
 
 @pushOnce('head', 'es_url-preconnect')
     <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
@@ -10,6 +10,7 @@
 
 <div class="min-h-screen">
     <listing
+        {{ $attributes }}
         :additional-sorting="[{
             label: window.config.translations.newest,
             field: 'created_at',
@@ -21,7 +22,7 @@
         :index="config.index_prefix + '_products_' + config.store"
         v-cloak
     >
-        <div slot-scope="{ loaded, filters, sortOptions, getQuery, withFilters, withSwatches, filterPrefix, _renderProxy: listingSlotProps }">
+        <div slot-scope="{ loaded, filters, sortOptions, withFilters, withSwatches, filterPrefix, _renderProxy: listingSlotProps }">
             <ais-instant-search
                 v-if="loaded"
                 :search-client="listingSlotProps.searchClient"
@@ -44,7 +45,9 @@
                 {{ $after ?? '' }}
 
                 {{-- NOTE: Do not put this component above the filters if you want routing to work. --}}
-                <ais-configure :filters="{!! $query !!}"/>
+                @if ($filters)
+                    <ais-configure :filters="{!! $filters !!}"/>
+                @endif
             </ais-instant-search>
         </div>
     </listing>

--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -8,23 +8,15 @@
     <div class="container">
         <h1 class="font-bold text-3xl">@lang('Search for'): {{ request()->q }}</h1>
 
-        <x-rapidez::listing query="'visibility:(3 OR 4)'"/>
-
-
-        {{--
-        Is it possible to change this query to a "query string query"?
-        Or is there something else we can use better now?
-        --}}
-
-        {{-- <x-rapidez::listing query="{
-            bool: {
-                must: [
-                    { terms: { visibility: [3, 4] } },
-                    { bool: { should: [
-                        {
+        <x-rapidez::listing
+            filters="'visibility:(3 OR 4)'"
+            v-bind:query="(query, searchAttributes, config) => {
+                return {
+                    bool: {
+                        should: [{
                             multi_match: {
-                                query: '{{ request()->q }}',
-                                fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
+                                query: query,
+                                fields: searchAttributes.map((value) => value.field+'^'+value.weight),
                                 type: 'best_fields',
                                 operator: 'or',
                                 fuzziness: 'AUTO',
@@ -32,23 +24,23 @@
                         },
                         {
                             multi_match: {
-                                query: '{{ request()->q }}',
-                                fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
+                                query: query,
+                                fields: searchAttributes.map((value) => value.field+'^'+value.weight),
                                 type: 'phrase',
                                 operator: 'or',
                             }
                         },
                         {
                             multi_match: {
-                                query: '{{ request()->q }}',
-                                fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
+                                query: query,
+                                fields: searchAttributes.map((value) => value.field+'^'+value.weight),
                                 type: 'phrase_prefix',
                                 operator: 'or',
                             }
-                        },
-                    ] } }
-                ],
-            }
-        }"/> --}}
+                        }]
+                    }
+                }
+            }"
+        />
     </div>
 @endsection


### PR DESCRIPTION
This PR builds on top of #744, allowing for a custom search query to be added when you don't want the default SearchKit query. [See the documentation on `getQuery` here](https://www.searchkit.co/docs/api-documentation/searchkit#getquery-optional-function).