### PR TITLE
Always render the listing on categories by default

### DIFF
--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -10,9 +10,10 @@
         @include('rapidez::category.partials.breadcrumbs')
         <h1 class="mb-5 text-3xl font-bold">{{ $category->name }}</h1>
 
-        @if ($category->is_anchor)
-            <x-rapidez::listing query="{ bool: { must: [{ terms: { visibility: [2, 4] } }, { terms: { category_ids: [config.category.entity_id] } }] } }" />
-        @else
+        <x-rapidez::listing query="{ bool: { must: [{ terms: { visibility: [2, 4] } }, { terms: { category_ids: [config.category.entity_id] } }] } }" />
+
+        {{-- It's also possible to render the Magento widgets:
+        @if (!$category->is_anchor)
             <div class="flex max-md:flex-col">
                 <div class="xl:w-1/5">
                     @widget('sidebar.main', 'anchor_categories', 'catalog_category_view_type_layered', $category->entity_id)
@@ -22,6 +23,7 @@
                 </div>
             </div>
         @endif
+        --}}
 
         <div class="prose prose-green max-w-none">
             {!! $category->description !!}


### PR DESCRIPTION
Currently the widgets are rendered, but the content from the sample data isn't really good looking. We could style everything  even more ([luma.css](https://github.com/rapidez/rapidez/blob/master/resources/css/luma.css)) or replace it with something custom, but a listing on every category is the quickest and nobody is actually going to use the sample data.

Leaving the code commented as an example if a user needs it.