### PR TITLE
Revert "Always render the listing on categories by default"

### DIFF
--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -10,10 +10,9 @@
         @include('rapidez::category.partials.breadcrumbs')
         <h1 class="mb-5 text-3xl font-bold">{{ $category->name }}</h1>
 
-        <x-rapidez::listing query="{ bool: { must: [{ terms: { visibility: [2, 4] } }, { terms: { category_ids: [config.category.entity_id] } }] } }" />
-
-        {{-- It's also possible to render the Magento widgets:
-        @if (!$category->is_anchor)
+        @if ($category->is_anchor)
+            <x-rapidez::listing query="{ bool: { must: [{ terms: { visibility: [2, 4] } }, { terms: { category_ids: [config.category.entity_id] } }] } }" />
+        @else
             <div class="flex max-md:flex-col">
                 <div class="xl:w-1/5">
                     @widget('sidebar.main', 'anchor_categories', 'catalog_category_view_type_layered', $category->entity_id)
@@ -23,7 +22,6 @@
                 </div>
             </div>
         @endif
-        --}}
 
         <div class="prose prose-green max-w-none">
             {!! $category->description !!}


### PR DESCRIPTION
Reverts rapidez/core#749, as without changing the categories to actually be anchors you'll end up with an empty page. For the test and demo environments I added this to the deploy scripts:
```bash
# Make sure all categories are anchors
$FORGE_PHP artisan tinker --execute="DB::update('UPDATE catalog_category_entity_int SET value = 1 WHERE attribute_id = 54')"
# Hide categories without products
$FORGE_PHP artisan tinker --execute="DB::update('UPDATE catalog_category_entity_int SET value = 0 WHERE attribute_id = 69 AND entity_id IN (37, 38)')"
docker exec MAGENTO-CONTAINER bin/magento cache:clean
docker exec MAGENTO-CONTAINER bin/magento indexer:reindex
```