### PR TITLE
[3.x] Allow for arbitrary options in additionals

### DIFF
--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -90,7 +90,7 @@ export default {
                         fields: Object.fromEntries(fields.map((field) => [field.split('^')[0], {}])),
                         require_field_match: false,
                     },
-                    ...options
+                    ...options,
                 }
 
                 rapidezFetch(`${baseUrl}/${config.es_prefix}_${name}_${config.store}/_search`, {

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -64,6 +64,7 @@ export default {
                 let size = data['size'] ?? self.size ?? undefined
                 let sort = data['sort'] ?? undefined
                 let fuzziness = data['fuzziness'] ?? 'AUTO'
+                let options = data['options'] ?? {}
 
                 let multimatch = self.multiMatchTypes.map((type) => ({
                     multi_match: {
@@ -89,6 +90,7 @@ export default {
                         fields: Object.fromEntries(fields.map((field) => [field.split('^')[0], {}])),
                         require_field_match: false,
                     },
+                    ...options
                 }
 
                 rapidezFetch(`${baseUrl}/${config.es_prefix}_${name}_${config.store}/_search`, {


### PR DESCRIPTION
This can be useful when, for example, trying to define `fields` and setting `_source` to false.