### PR TITLE
[3.x] Use correct show_tax value

### DIFF
--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -68,7 +68,7 @@ class ConfigComposer
             'searchable'                   => array_merge($searchableAttributes, config('rapidez.indexer.searchable')),
             'show_customer_address_fields' => $this->getCustomerAddressFields(),
             'street_lines'                 => Rapidez::config('customer/address/street_lines', 2),
-            'show_tax'                     => (bool) Rapidez::config('tax/display/type', 1),
+            'show_tax'                     => Rapidez::config('tax/display/type', 1) == 2,
             'grid_per_page'                => Rapidez::config('catalog/frontend/grid_per_page', 12),
             'grid_per_page_values'         => explode(',', Rapidez::config('catalog/frontend/grid_per_page_values', '12,24,36')),
         ];

--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -68,7 +68,7 @@ class ConfigComposer
             'searchable'                   => array_merge($searchableAttributes, config('rapidez.indexer.searchable')),
             'show_customer_address_fields' => $this->getCustomerAddressFields(),
             'street_lines'                 => Rapidez::config('customer/address/street_lines', 2),
-            'show_tax'                     => Rapidez::config('tax/display/type', 1) == 2,
+            'show_tax'                     => in_array(Rapidez::config('tax/display/type', 1), [2, 3]),
             'grid_per_page'                => Rapidez::config('catalog/frontend/grid_per_page', 12),
             'grid_per_page_values'         => explode(',', Rapidez::config('catalog/frontend/grid_per_page_values', '12,24,36')),
         ];


### PR DESCRIPTION
For this value the following options are possible:

- `1`: Excluding tax
- `2`: Including tax
- `3`: Including and excluding tax

With the cast to bool this would always return true. Instead we should check for value `2`.