### PR TITLE
[3.x] Get option labels with attribute options in the cart

### DIFF
--- a/resources/js/stores/useAttributes.js
+++ b/resources/js/stores/useAttributes.js
@@ -37,4 +37,8 @@ export const attributes = computedAsync(
     { lazy: true, shallow: false },
 )
 
+window.attributeLabel = (attributeCode) => {
+    return Object.values(attributes.value)?.find((attribute) => attribute.code === attributeCode)?.name
+}
+
 export default () => attributes

--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -112,16 +112,16 @@ export const fetchCart = async function () {
 
 export const fetchAttributeValues = async function (attributes = []) {
     if (!attributes.length) {
-        return { data: { customAttributeMetadata: { items: null } } }
+        return { data: { customAttributeMetadataV2: { items: null } } }
     }
 
     return await window.magentoGraphQL(
         `
             query attributeValues($attributes: [AttributeInput!]!) {
-                customAttributeMetadata(attributes: $attributes) {
+                customAttributeMetadataV2(attributes: $attributes) {
                     items {
-                        attribute_code
-                        attribute_options {
+                        code
+                        options {
                             label
                             value
                         }
@@ -204,7 +204,7 @@ export const cart = computed({
 
         getAttributeValues()
             .then((response) => {
-                if (!response?.data?.customAttributeMetadata?.items) {
+                if (!response?.data?.customAttributeMetadataV2?.items) {
                     value.items = value.items.map((item) => {
                         item.is_available = checkAvailability(item)
 
@@ -215,9 +215,9 @@ export const cart = computed({
                 }
 
                 const mapping = Object.fromEntries(
-                    response.data.customAttributeMetadata.items.map((attribute) => [
-                        attribute.attribute_code,
-                        Object.fromEntries(attribute.attribute_options.map((value) => [value.value, value.label])),
+                    response.data.customAttributeMetadataV2.items.map((attribute) => [
+                        attribute.code,
+                        Object.fromEntries(attribute.options.map((value) => [value.value, value.label])),
                     ]),
                 )
 

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -35,7 +35,7 @@
                     </div>
                     <div v-for="option in config.cart_attributes">
                         <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-                            @{{ option }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+                            @{{ window.attributeLabel(option) }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
                         </template>
                     </div>
                     @include('rapidez::cart.item.remove')


### PR DESCRIPTION
This PR is a solution to not having option labels in the cart attributes. Sadly the customAttributeMetadata query does not support getting the option labels, however customAttributeMetadataV2 does. We also had to change the mapping a bit.

2.x: #726 