### PR TITLE
[3.x] Skip the login step in the checkout if the user is already logged in

### DIFF
--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -13,6 +13,10 @@ export default {
             type: Boolean,
             default: true,
         },
+        nextUrl: {
+            type: String,
+            default: '',
+        }
     },
 
     data: () => ({
@@ -27,6 +31,14 @@ export default {
 
     render() {
         return this.$scopedSlots.default(this)
+    },
+
+    async mounted() {
+        if (user.value.is_logged_in && config.checkout_steps[config.store_code].length > 1) {
+            this.$root.submitPartials(this.$el.form).then(() => {
+                window.Turbo.visit(this.nextUrl)
+            })
+        }
     },
 
     methods: {

--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -16,7 +16,7 @@ export default {
         nextUrl: {
             type: String,
             default: '',
-        }
+        },
     },
 
     data: () => ({

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -1,4 +1,4 @@
-<checkout-login v-slot="checkoutLogin">
+<checkout-login v-slot="checkoutLogin" next-url="{{ route('checkout', ['step' => 'credentials']) }}">
     <fieldset partial-submit="go" class="flex flex-col gap-3" v-cloak>
         <label>
             <x-rapidez::label>@lang('Email')</x-rapidez::label>


### PR DESCRIPTION
When a user is logged in we don't need the login step. Whenever we just have one checkout step we're assuming it is a onestep checkout. We don't want to submit then.

There's no good way (I think) to get the url of the next step in the javascript. That's why i added a prop for it.