### PR TITLE
Fix cookie-notice z-index

### DIFF
--- a/resources/views/components/cookie-notice.blade.php
+++ b/resources/views/components/cookie-notice.blade.php
@@ -8,7 +8,7 @@
         show-until-close
         v-cloak
     >
-        <dialog slot-scope="{ close }" class="container rounded bg-white p-6 shadow fixed inset-x-0 bottom-4 z-30">
+        <dialog slot-scope="{ close }" class="container rounded bg-white p-6 shadow fixed inset-x-0 bottom-4 z-cookie">
             <div class="flex flex-wrap items-center justify-between">
                 <div class="flex-1 items-center">
                     <div class="text-sm text-black">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,7 +83,7 @@ export default {
                 'popup': '130',
                 'popup-actions': '10',
 
-                'cookie': '140'
+                'cookie': '140',
             },
             textColor: (theme) => theme('colors.foreground'),
             borderColor: (theme) => ({

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,8 @@ export default {
 
                 'popup': '130',
                 'popup-actions': '10',
+
+                'cookie': '140'
             },
             textColor: (theme) => theme('colors.foreground'),
             borderColor: (theme) => ({


### PR DESCRIPTION
We use named z-indexes but the cookie notice didn't used it so it would have go under elements like filters or popups. 
