### PR TITLE
[Instantsearch] Add possibilities for simplifying basefilters

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -60,6 +60,13 @@ export default {
         },
         baseFilters: {
             type: Function,
+            default: () => [],
+        },
+        filterQueryString: {
+            type: String,
+        },
+        filterScoreScript: {
+            type: String,
         },
     },
 
@@ -192,7 +199,7 @@ export default {
         // directly due the JS size
         initSearchClient() {
             return Client(this.searchkit, {
-                getBaseFilters: this.baseFilters,
+                getBaseFilters: this.getBaseFilters,
                 getQuery: this.query,
             })
         },
@@ -237,6 +244,31 @@ export default {
                     }),
                 },
             })
+        },
+
+        getBaseFilters() {
+            let extraFilters = []
+            if (this.filterQueryString) {
+                extraFilters.push({
+                    query_string: {
+                        query: this.filterQueryString
+                    }
+                })
+            }
+
+            if (this.filterScoreScript) {
+                extraFilters.push({
+                    function_score: {
+                        script_score: {
+                            script: {
+                                source: this.filterScoreScript,
+                            },
+                        },
+                    },
+                })
+            }
+
+            return this.baseFilters().concat(extraFilters)
         },
 
         stateToRoute(uiState) {

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -13,19 +13,8 @@
         @if ($category->is_anchor)
             <x-rapidez::listing
                 :root-path="$category->parentcategories->pluck('name')->join(' > ')"
-                v-bind:base-filters="() => [{
-                    query_string: {
-                        query: 'visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}'
-                    }
-                }, {
-                    function_score: {
-                        script_score: {
-                            script: {
-                                source: `Integer.parseInt(doc['positions.{{ $category->entity_id }}'].empty ? '0' : doc['positions.{{ $category->entity_id }}'].value)`,
-                            },
-                        },
-                    },
-                }]"
+                filter-query-string="visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}"
+                filter-score-script="Integer.parseInt(doc['positions.{{ $category->entity_id }}'].empty ? '0' : doc['positions.{{ $category->entity_id }}'].value)"
             />
         @else
             <div class="flex max-md:flex-col">

--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -8,6 +8,6 @@
     <div class="container">
         <h1 class="font-bold text-3xl">@lang('Search for'): {{ request()->q }}</h1>
 
-        <x-rapidez::listing v-bind:base-filters="() => [{ query_string: { query: 'visibility:(3 OR 4)' }}]"/>
+        <x-rapidez::listing filter-query-string="visibility:(3 OR 4)"/>
     </div>
 @endsection


### PR DESCRIPTION
Made a simple change that allows you do add simple filter stuff without having to write the whole query object. This only includes two:

- `filterQueryString` which takes a query string like `visibility: (3 OR 4)`
- `filterScoreScript` which lets you modify the scoring by using an ES script.

I've left it quite simple so that we can easily add more options in case we would like them in the future.

Side note: The baseFilters prop is a function on purpose, as we will want to be able to have dynamic things in there in the future. For example, it will be extremely useful in some project to change the filter based on the typed search query.