### PR TITLE
Move duplicate instantsearch code to mixin, improve autocomplete loading

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -14,7 +14,8 @@
     -webkit-tap-highlight-color: transparant;
 }
 
-listing, autocomplete {
+listing,
+autocomplete {
     /*  Reset browser added styling causing unexpected behavior */
     display: contents;
     font-family: unset;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -14,7 +14,7 @@
     -webkit-tap-highlight-color: transparant;
 }
 
-listing {
+listing, autocomplete {
     /*  Reset browser added styling causing unexpected behavior */
     display: contents;
     font-family: unset;

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -184,16 +184,16 @@ export default {
 
     methods: {
         async getInstantSearchClientConfig() {
-            const config = await InstantSearchMixin.methods.getInstantSearchClientConfig.bind(this).call();
+            const config = await InstantSearchMixin.methods.getInstantSearchClientConfig.bind(this).call()
 
-            config.getBaseFilters = this.getBaseFilters;
-            config.getQuery = this.query;
+            config.getBaseFilters = this.getBaseFilters
+            config.getQuery = this.query
 
-            return config;
+            return config
         },
 
         async getSearchSettings() {
-            let config = await InstantSearchMixin.methods.getSearchSettings.bind(this).call();
+            let config = await InstantSearchMixin.methods.getSearchSettings.bind(this).call()
 
             return {
                 ...config,
@@ -214,7 +214,7 @@ export default {
                     }
                     return acc
                 }),
-            };
+            }
         },
 
         getBaseFilters() {

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -1,14 +1,7 @@
 <script>
-import Client from '@searchkit/instantsearch-client'
-import Searchkit from 'searchkit'
-
 import { history } from 'instantsearch.js/es/lib/routers'
 
-import AisInstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
 import AisSearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
-import AisHits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
-import AisConfigure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
-
 import AisRefinementList from 'vue-instantsearch/vue2/es/src/components/RefinementList.vue.js'
 import AisHierarchicalMenu from 'vue-instantsearch/vue2/es/src/components/HierarchicalMenu.vue.js'
 import AisRangeInput from 'vue-instantsearch/vue2/es/src/components/RangeInput.vue.js'
@@ -22,12 +15,12 @@ import AisStats from 'vue-instantsearch/vue2/es/src/components/Stats.vue.js'
 import categoryFilter from './Filters/CategoryFilter.vue'
 import useAttributes from '../../stores/useAttributes.js'
 
+import InstantSearchMixin from '../Search/InstantSearchMixin.vue'
+
 export default {
+    mixins: [InstantSearchMixin],
     components: {
-        'ais-instant-search': AisInstantSearch,
         'ais-search-box': AisSearchBox,
-        'ais-hits': AisHits,
-        'ais-configure': AisConfigure,
         'ais-refinement-list': AisRefinementList,
         'ais-hierarchical-menu': AisHierarchicalMenu,
         'ais-range-input': AisRangeInput,
@@ -54,7 +47,7 @@ export default {
             type: String,
         },
 
-        // TODO: Document these two props in the Rapidez docs
+        // TODO: Document these Four props in the Rapidez docs
         query: {
             type: Function,
         },
@@ -83,9 +76,6 @@ export default {
     },
 
     mounted() {
-        this.searchkit = this.initSearchkit()
-        this.searchClient = this.initSearchClient()
-
         this.loaded = Object.keys(this.attributes).length > 0
     },
 
@@ -193,57 +183,38 @@ export default {
     },
 
     methods: {
-        // TODO: Not sure if this is the right place,
-        // the autocomplete also needs this but
-        // we don't want to load everything
-        // directly due the JS size
-        initSearchClient() {
-            return Client(this.searchkit, {
-                getBaseFilters: this.getBaseFilters,
-                getQuery: this.query,
-            })
+        async getInstantSearchClientConfig() {
+            const config = await InstantSearchMixin.methods.getInstantSearchClientConfig.bind(this).call();
+
+            config.getBaseFilters = this.getBaseFilters;
+            config.getQuery = this.query;
+
+            return config;
         },
 
-        initSearchkit() {
-            let url = new URL(config.es_url)
+        async getSearchSettings() {
+            let config = await InstantSearchMixin.methods.getSearchSettings.bind(this).call();
 
-            return new Searchkit({
-                connection: {
-                    host: url.origin,
-                    auth: {
-                        username: url.username,
-                        password: url.password,
-                    },
-                },
+            return {
+                ...config,
 
-                // TODO: Maybe just do: search_settings: config.searchkit
-                // so it's possible to add anything to the PHP config
-                // and that will appear here?
-                search_settings: {
-                    highlight_attributes: config.searchkit.highlight_attributes,
-                    search_attributes: config.searchkit.search_attributes,
-                    result_attributes: config.searchkit.result_attributes,
+                // TODO: For consistency maybe make it possible to do this:
+                // facet_attributes: config.searchkit.facet_attributes,
+                facet_attributes: this.facets,
 
-                    // TODO: For consistency maybe make it possible to do this:
-                    // facet_attributes: config.searchkit.facet_attributes,
-                    facet_attributes: this.facets,
-
-                    filter_attributes: config.searchkit.filter_attributes,
-
-                    // TODO: Let's also change this to a PHP config.
-                    // So we start there and that will be merged
-                    // with the Magento configured attributes
-                    // and lastly from a prop it's possible
-                    // to manipulate it from a callback?
-                    sorting: this.sortOptions.reduce((acc, item) => {
-                        acc[item.key] = {
-                            field: item.field,
-                            order: item.order,
-                        }
-                        return acc
-                    }),
-                },
-            })
+                // TODO: Let's also change this to a PHP config.
+                // So we start there and that will be merged
+                // with the Magento configured attributes
+                // and lastly from a prop it's possible
+                // to manipulate it from a callback?
+                sorting: this.sortOptions.reduce((acc, item) => {
+                    acc[item.key] = {
+                        field: item.field,
+                        order: item.order,
+                    }
+                    return acc
+                }),
+            };
         },
 
         getBaseFilters() {

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -1,21 +1,15 @@
 <script>
-import Client from '@searchkit/instantsearch-client'
-import Searchkit from 'searchkit'
-
-import AisInstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
 import AisSearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
-import AisHits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
 import AisIndex from 'vue-instantsearch/vue2/es/src/components/Index.js'
-import AisConfigure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
 import AisHighlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
 
+import InstantSearchMixin from './InstantSearchMixin.vue'
+
 export default {
+    mixins: [InstantSearchMixin],
     components: {
-        'ais-instant-search': AisInstantSearch,
         'ais-search-box': AisSearchBox,
-        'ais-hits': AisHits,
         'ais-index': AisIndex,
-        'ais-configure': AisConfigure,
         'ais-highlight': AisHighlight,
     },
     data: () => ({
@@ -33,19 +27,9 @@ export default {
         })
     },
 
-    computed: {
-        // TODO: Not sure if this is the right place,
-        // the autocomplete also needs this but
-        // we don't want to load everything
-        // directly due the JS size
-        searchClient: function () {
-            let client = Client(this.searchkit, {
-                hooks: {
-                    beforeSearch: async (searchRequests) => {
-                        return searchRequests
-                    },
-                },
-            })
+    methods: {
+        async initSearchClient () {
+            const client = await InstantSearchMixin.methods.initSearchClient.bind(this).call();
 
             // Ensure no query is done if the search field is empty
             const oldSearch = client.search
@@ -70,32 +54,6 @@ export default {
             }
 
             return client
-        },
-
-        // TODO: Maybe extract this so we have this once?
-        searchkit: function () {
-            let url = new URL(config.es_url)
-
-            let searchkit = new Searchkit({
-                connection: {
-                    host: url.origin,
-                    auth: {
-                        username: url.username,
-                        password: url.password,
-                    },
-                },
-
-                // TODO: Should we split this as it could
-                // diff from the settings on listings.
-                search_settings: {
-                    highlight_attributes: config.searchkit.highlight_attributes,
-                    search_attributes: config.searchkit.search_attributes,
-                    result_attributes: config.searchkit.result_attributes,
-                    filter_attributes: config.searchkit.filter_attributes,
-                },
-            })
-
-            return searchkit
         },
     },
 }

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -28,8 +28,8 @@ export default {
     },
 
     methods: {
-        async initSearchClient () {
-            const client = await InstantSearchMixin.methods.initSearchClient.bind(this).call();
+        async initSearchClient() {
+            const client = await InstantSearchMixin.methods.initSearchClient.bind(this).call()
 
             // Ensure no query is done if the search field is empty
             const oldSearch = client.search

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -37,12 +37,12 @@ export default {
                     },
                 },
 
-                search_settings: await this.getSearchSettings()
+                search_settings: await this.getSearchSettings(),
             })
         },
 
         async getInstantSearchClientConfig() {
-            return {};
+            return {}
         },
 
         async getSearchSettings() {
@@ -54,8 +54,8 @@ export default {
                 search_attributes: config.searchkit.search_attributes,
                 result_attributes: config.searchkit.result_attributes,
                 filter_attributes: config.searchkit.filter_attributes,
-            };
+            }
         },
     },
-};
+}
 </script>

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -1,0 +1,61 @@
+<script>
+import Client from '@searchkit/instantsearch-client'
+import Searchkit from 'searchkit'
+
+import AisInstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
+import AisHits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
+import AisConfigure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
+
+export default {
+    components: {
+        'ais-instant-search': AisInstantSearch,
+        'ais-hits': AisHits,
+        'ais-configure': AisConfigure,
+    },
+    data: () => ({
+        searchkit: null,
+        searchClient: null,
+    }),
+    async mounted() {
+        this.searchkit = await this.initSearchkit()
+        this.searchClient = await this.initSearchClient()
+    },
+    methods: {
+        async initSearchClient() {
+            return Client(this.searchkit, await this.getInstantSearchClientConfig())
+        },
+
+        async initSearchkit() {
+            let url = new URL(config.es_url)
+
+            return new Searchkit({
+                connection: {
+                    host: url.origin,
+                    auth: {
+                        username: url.username,
+                        password: url.password,
+                    },
+                },
+
+                search_settings: await this.getSearchSettings()
+            })
+        },
+
+        async getInstantSearchClientConfig() {
+            return {};
+        },
+
+        async getSearchSettings() {
+            // TODO: Maybe just do: return config.searchkit;
+            // so it's possible to add anything to the PHP config
+            // and that will appear here?
+            return {
+                highlight_attributes: config.searchkit.highlight_attributes,
+                search_attributes: config.searchkit.search_attributes,
+                result_attributes: config.searchkit.result_attributes,
+                filter_attributes: config.searchkit.filter_attributes,
+            };
+        },
+    },
+};
+</script>

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -36,8 +36,8 @@ Vue.component('quantity-select', quantitySelect)
 
 Vue.component('autocomplete', () => ({
     // https://v2.vuejs.org/v2/guide/components-dynamic-async.html#Async-Components
-    component: new Promise(function(resolve, reject) {
-       document.addEventListener('loadAutoComplete', () => import('./components/Search/Autocomplete.vue').then(resolve));
+    component: new Promise(function (resolve, reject) {
+        document.addEventListener('loadAutoComplete', () => import('./components/Search/Autocomplete.vue').then(resolve))
     }),
     // https://v2.vuejs.org/v2/guide/components-dynamic-async.html#Handling-Loading-State
     loading: {
@@ -50,7 +50,7 @@ Vue.component('autocomplete', () => ({
             return this.$scopedSlots.default(this)
         },
     },
-    delay: 0
+    delay: 0,
 }))
 Vue.component('checkout-login', () => import('./components/Checkout/CheckoutLogin.vue'))
 Vue.component('login', () => import('./components/User/Login.vue'))

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -34,7 +34,24 @@ Vue.component('images', images)
 import quantitySelect from './components/Product/QuantitySelect.vue'
 Vue.component('quantity-select', quantitySelect)
 
-Vue.component('autocomplete', () => import('./components/Search/Autocomplete.vue'))
+Vue.component('autocomplete', () => ({
+    // https://v2.vuejs.org/v2/guide/components-dynamic-async.html#Async-Components
+    component: new Promise(function(resolve, reject) {
+       document.addEventListener('loadAutoComplete', () => import('./components/Search/Autocomplete.vue').then(resolve));
+    }),
+    // https://v2.vuejs.org/v2/guide/components-dynamic-async.html#Handling-Loading-State
+    loading: {
+        data: () => ({
+            loaded: false,
+            searchClient: null,
+        }),
+
+        render() {
+            return this.$scopedSlots.default(this)
+        },
+    },
+    delay: 0
+}))
 Vue.component('checkout-login', () => import('./components/Checkout/CheckoutLogin.vue'))
 Vue.component('login', () => import('./components/User/Login.vue'))
 Vue.component('listing', () => import('./components/Listing/Listing.vue'))

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -26,7 +26,7 @@
     >
         <div>
             <ais-instant-search
-                v-if="loaded"
+                v-if="loaded && searchClient"
                 :search-client="searchClient"
                 :index-name="index"
                 :routing="routing"

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -20,7 +20,7 @@ But it currently doesn't work without it.
             --}}
             <div>
                 <ais-instant-search
-                    v-if="loaded"
+                    v-if="loaded && searchClient"
                     :search-client="searchClient"
                     :index-name="config.index"
                 >

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,22 +1,11 @@
-<div v-if="!$root.loadAutocomplete" class="relative w-full">
-    {{-- TODO: Do we still need this double input? --}}
-    <form method="get" action="{{ route('search') }}">
-        <x-rapidez::input
-            type="search"
-            name="q"
-            :placeholder="__('What are you looking for?')"
-            v-on:focus="$root.loadAutocomplete = true"
-            v-on:mouseover="$root.loadAutocomplete = true"
-        />
-    </form>
-    <x-rapidez::autocomplete.magnifying-glass />
-</div>
 
-<autocomplete v-else inline-template>
+<autocomplete inline-template>
     <div class="relative w-full">
         <ais-instant-search
+            v-if="searchClient"
+            v-cloak
             class="contents"
-            :search-client="searchClient"
+            :search-client="searchClient "
             :index-name="config.index_prefix + '_products_' + config.store"
         >
             <div class="contents">
@@ -50,5 +39,18 @@
                 </div>
             </div>
         </ais-instant-search>
+        <div v-else class="relative w-full">
+            {{-- TODO: Do we still need this double input? --}}
+            <form name="autocomplete-form" id="autocomplete-form" method="get" action="{{ route('search') }}" class="flex flex-row relative">
+                <x-rapidez::input
+                    type="search"
+                    name="q"
+                    :placeholder="__('What are you looking for?')"
+                    v-on:focus="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"
+                    v-on:mouseover="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"
+                />
+            </form>
+            <x-rapidez::autocomplete.magnifying-glass />
+        </div>
     </div>
 </autocomplete>


### PR DESCRIPTION
Due to the guaranteed merge conflicts with https://github.com/rapidez/core/pull/765 i've based this one on it.

I've centralized the base instantsearch code to the InstantSearchMixin
Any places where the Autocomplete or Listing extend or change the configuration i've made it possible to do so by overriding the function.

This also results in improved bundling:
- The Autocomplete bundle contains the ais-index component as it's the only file using it.
- The Listing bundle contains the components for filtering, sorting and stats. It also contains the instantsearch code for pagination, sorting, stats and current refinements.
- The InstantSearchMixin contains the rest of the instantsearch library + ais-configure, ais-highlight, ais-search-box, ais-hits, ais-instantsearch. Since both the Autocomplete and Listing use them

You might also notice i do not include the `ais-search-box` in the `InstantSearchMixin` and yet it's still in the bundle.
This is because they both use the `InstantSearchMixin` and it's not used anywhere else, and they both use the `ais-search-box`. So it's more efficient to bundle it in the shared file.

I've not included it in the `InstantSearchMixin` myself because it's not necessary to get InstantSearch working and other implementations may not need to use the searchbox.

I've also stumbled upon https://v2.vuejs.org/v2/guide/components-dynamic-async.html#Handling-Loading-State which allows for the autocomplete to switch seamlessly between the facade and full component! 