### PR TITLE
[Instantsearch] Make basic highlight component that doesn't break when the attribute is not in the config

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,3 +29,7 @@ input[type='number']::-webkit-inner-spin-button,
 input[type='number']::-webkit-outer-spin-button {
     @apply appearance-none m-0;
 }
+
+mark {
+    @apply bg-transparent font-bold
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -31,5 +31,5 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 mark {
-    @apply bg-transparent font-bold
+    @apply bg-transparent font-bold;
 }

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -1,7 +1,6 @@
 <script>
 import AisSearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
 import AisIndex from 'vue-instantsearch/vue2/es/src/components/Index.js'
-import AisHighlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
 
 import InstantSearchMixin from './InstantSearchMixin.vue'
 
@@ -10,7 +9,6 @@ export default {
     components: {
         'ais-search-box': AisSearchBox,
         'ais-index': AisIndex,
-        'ais-highlight': AisHighlight,
     },
     data: () => ({
         loaded: false,

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -5,12 +5,14 @@ import Searchkit from 'searchkit'
 import AisInstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
 import AisHits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
 import AisConfigure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
+import AisHighlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
 
 export default {
     components: {
         'ais-instant-search': AisInstantSearch,
         'ais-hits': AisHits,
         'ais-configure': AisConfigure,
+        'ais-highlight': AisHighlight,
     },
     data: () => ({
         searchkit: null,

--- a/resources/views/components/highlight.blade.php
+++ b/resources/views/components/highlight.blade.php
@@ -1,0 +1,12 @@
+@props(['attribute', 'item' => 'item'])
+
+@if (in_array($attribute, config('rapidez.searchkit.highlight_attributes')))
+    <ais-highlight
+        {{ $attributes }}
+        attribute="{{ $attribute }}"
+        :hit="{{ $item }}"
+        highlighted-tag-name="mark"
+    />
+@else
+    <span {{ $attributes }} v-text="{{ $item }}.{{ $attribute }}"></span>
+@endif

--- a/resources/views/components/highlight.blade.php
+++ b/resources/views/components/highlight.blade.php
@@ -1,12 +1,11 @@
-@props(['attribute', 'item' => 'item'])
+@props(['attribute', 'item' => 'item', 'highlightTag' => 'mark'])
 
 @if (in_array($attribute, config('rapidez.searchkit.highlight_attributes')))
-    <ais-highlight
-        {{ $attributes }}
-        attribute="{{ $attribute }}"
-        :hit="{{ $item }}"
-        highlighted-tag-name="mark"
-    />
+    <ais-highlight {{ $attributes->merge([
+        'v-bind:hit' => $item,
+        'attribute' => $attribute,
+        'highlighted-tag-name' => $highlightTag,
+    ]) }}/>
 @else
     <span {{ $attributes }} v-text="{{ $item }}.{{ $attribute }}"></span>
 @endif

--- a/resources/views/layouts/partials/header/autocomplete/categories.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/categories.blade.php
@@ -5,13 +5,7 @@
             <ul class="flex flex-col font-sans">
                 <li v-for="(item, count) in items" class="flex flex-1 items-center w-full">
                     <a v-bind:href="item.url" class="relative flex items-center group w-full py-2 text-sm gap-x-4">
-                        <span class="ml-2 line-clamp-2">
-                            <ais-highlight
-                                attribute="name"
-                                :hit="item"
-                                highlighted-tag-name="mark"
-                            />
-                        </span>
+                        <x-rapidez::highlight attribute="name" class="ml-2 line-clamp-2"/>
                     </a>
                 </li>
             </ul>

--- a/resources/views/layouts/partials/header/autocomplete/products.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/products.blade.php
@@ -14,13 +14,7 @@
                         />
                         <x-rapidez::no-image v-else class="mb-3 h-48 rounded-t" />
                         <div class="flex flex-1 justify-center flex-col px-2">
-                            <span>
-                                <ais-highlight
-                                    attribute="name"
-                                    :hit="item"
-                                    highlighted-tag-name="mark"
-                                />
-                            </span>
+                            <x-rapidez::highlight attribute="name"/>
 
                             <div class="flex items-center gap-x-0.5 mt-0.5">
                                 <div v-if="item.special_price" class="text-muted font-sans line-through text-xs">

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -16,9 +16,7 @@
                 />
                 <x-rapidez::no-image v-else class="mb-3 h-48 rounded-t" />
                 <div class="px-2">
-                    <div class="text-base font-medium">
-                        <x-rapidez::highlight attribute="name"/>
-                    </div>
+                    <x-rapidez::highlight attribute="name" class="text-base font-medium"/>
                     @if (!Rapidez::config('catalog/frontend/show_swatches_in_product_list', 1))
                         <div class="flex items-center space-x-2">
                             <div class="font-semibold">@{{ (item.special_price || item.price) | price }}</div>

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -16,7 +16,9 @@
                 />
                 <x-rapidez::no-image v-else class="mb-3 h-48 rounded-t" />
                 <div class="px-2">
-                    <div class="text-base font-medium">@{{ item.name }}</div>
+                    <div class="text-base font-medium">
+                        <x-rapidez::highlight attribute="name"/>
+                    </div>
                     @if (!Rapidez::config('catalog/frontend/show_swatches_in_product_list', 1))
                         <div class="flex items-center space-x-2">
                             <div class="font-semibold">@{{ (item.special_price || item.price) | price }}</div>


### PR DESCRIPTION
Adds the `ais-highlight` component to the mixin, allowing you to use it anywhere.

Also made a small component that makes sure you don't try to highlight something that's not in the `highlight_attributes` configuration. Instantsearch will, by default, just not show the value at all if it's not there.

Can be used like this:

```blade
<x-rapidez::highlight attribute="name"/>
```

If the JS variable is not named `item` you can specify it:

```blade
<x-rapidez::highlight attribute="description" item="product"/>
```

And you can add styling:


```blade
<x-rapidez::highlight attribute="name" class="text-red-500"/>
```