### PR TITLE
[3.x] Make sure JSON can't be empty

### DIFF
--- a/src/Models/Scopes/Attribute/OnlyProductAttributesScope.php
+++ b/src/Models/Scopes/Attribute/OnlyProductAttributesScope.php
@@ -38,9 +38,9 @@ class OnlyProductAttributesScope implements Scope
                     FROM catalog_product_super_attribute
                     WHERE catalog_product_super_attribute.attribute_id = eav_attribute.attribute_id
                 ) AS `super`'),
-                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.swatch_input_type')) = 'text' AS `text_swatch`"),
-                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.swatch_input_type')) = 'visual' AS `visual_swatch`"),
-                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(additional_data, '$.update_product_preview_image')) = 1 AS `update_image`"),
+                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), '$.swatch_input_type')) = 'text' AS `text_swatch`"),
+                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), '$.swatch_input_type')) = 'visual' AS `visual_swatch`"),
+                DB::raw("JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), '$.update_product_preview_image')) = 1 AS `update_image`"),
                 'position'
             )
             ->join('catalog_eav_attribute', 'eav_attribute.attribute_id', '=', 'catalog_eav_attribute.attribute_id')

--- a/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
@@ -41,9 +41,9 @@ class WithProductSuperAttributesScope implements Scope
             ->selectRaw('JSON_OBJECTAGG(eav_attribute.attribute_id, JSON_OBJECT(
                 "code", `attribute_code`,
                 "label", COALESCE(NULLIF(`value`, ""), `frontend_label`),
-                "text_swatch", JSON_UNQUOTE(JSON_EXTRACT(additional_data, "$.swatch_input_type")) = "text",
-                "visual_swatch", JSON_UNQUOTE(JSON_EXTRACT(additional_data, "$.swatch_input_type")) = "visual",
-                "update_image", JSON_UNQUOTE(JSON_EXTRACT(additional_data, "$.update_product_preview_image")) = 1
+                "text_swatch", JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), "$.swatch_input_type")) = "text",
+                "visual_swatch", JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), "$.swatch_input_type")) = "visual",
+                "update_image", JSON_UNQUOTE(JSON_EXTRACT(IF(JSON_VALID(additional_data), additional_data, null), "$.update_product_preview_image")) = 1
             )) AS `super_attributes`')
             ->join('eav_attribute', 'eav_attribute.attribute_id', '=', 'catalog_product_super_attribute.attribute_id')
             ->join('catalog_eav_attribute', 'catalog_eav_attribute.attribute_id', '=', 'catalog_product_super_attribute.attribute_id')


### PR DESCRIPTION
If the `additional_data` column is `EMPTY` (or invalid JSON) instead of `NULL`, this query throws an error. By adding in this check we can fix this.