### PR TITLE
Update turbo when navigating away and turbo state is missing

### DIFF
--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -5,9 +5,9 @@ Vue.use(TurbolinksAdapter)
 
 Turbo.config.drive.progressBarDelay = 5
 
-document.addEventListener('turbo:before-visit', function(e){
-    if (typeof history.state.turbo === 'undefined'){
+document.addEventListener('turbo:before-visit', function (e) {
+    if (typeof history.state.turbo === 'undefined') {
         // Trigger turbo to add the state.
-        Turbo?.navigator?.history?.replace(window.location);
+        Turbo?.navigator?.history?.replace(window.location)
     }
-});
+})

--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -4,3 +4,10 @@ import TurbolinksAdapter from 'vue-turbolinks'
 Vue.use(TurbolinksAdapter)
 
 Turbo.config.drive.progressBarDelay = 5
+
+document.addEventListener('turbo:before-visit', function(e){
+    if (typeof history.state.turbo === 'undefined'){
+        // Trigger turbo to add the state.
+        Turbo?.navigator?.history?.replace(window.location);
+    }
+});


### PR DESCRIPTION
We have 2 flavors of this functionality.
The reason back navigation fails is because instantsearch sets history.state to the applied filters.
This throws away history.state.turbo so turbo will not track the page.

Method 1 is overriding Instantsearch's routing to use Turbo's push method
https://github.com/algolia/instantsearch/issues/2998#issuecomment-2739987150
This works fine, however this means Turbo will take over EVERY push. 
Meaning back navigating after applying filters also is done via turbo doing a "page reload".
This feels slower and shows flashes of the page and vue loading in again.

Method 2 is outlined in this PR.
This essentially comes back to https://github.com/rapidez/core/commit/dd50542167a52d8d2a678cdb353848869401001c
but with some improvements, now we let Turbo replace the state we're navigating away from. Meaning we get proper `restorationIdentifier` and `restorationIndex`.
Using this method, back to the category page is done using turbo. Navigating back after that is handled by Instantsearch only removing the filters in the order you applied them. No more flashing page, only removing the filters.