### PR TITLE
[3.x] Don't return early when only 1 child product exists

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -296,7 +296,7 @@ export default {
                 return isMatching
             })
 
-            if (Object.keys(this.product.children).length == simpleProducts.length) {
+            if (Object.keys(this.product.children).length == simpleProducts.length && simpleProducts.length > 1) {
                 return product
             }
 


### PR DESCRIPTION
This check caused a simpleProduct to never get selected when a configurable product only has one child product.

I've checked a few other scenarios and nothing else breaks as a result of this change.
