### PR TITLE
Correctly handle combiningGraphql allowing catching

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -112,7 +112,7 @@ export const combiningGraphQL = (window.combiningGraphQL = async (query, variabl
 
                     pendingQuery[pendingQueryName] = null
 
-                    magentoGraphQL(query, variables, options).then(resolve)
+                    magentoGraphQL(query, variables, options).then(resolve).catch(reject)
                 }, 5),
             ),
         }


### PR DESCRIPTION
By not catching and rejecting the promise you will always gets and uncaught exception when using combining graphql.
This breaks the notifying of the graphql-mutation component.

By catching and rejecting the current promise all functionality is restored.