### PR TITLE
Allow empty content when isEmpty is true

### DIFF
--- a/src/Http/Controllers/FallbackController.php
+++ b/src/Http/Controllers/FallbackController.php
@@ -68,7 +68,7 @@ class FallbackController extends Controller
                 ));
 
             // Null response is equal to no response or 404.
-            if (! $response->getContent() || $response->isNotFound()) {
+            if ($response->isNotFound() || (! $response->getContent() && ! $response->isEmpty())) {
                 abort(404);
             }
 


### PR DESCRIPTION
Symfony's isEmpty check explicitly checks the 204 and 304 status codes. Used to signal "noContent" and "notModified"
These are status codes that explicitly state "We processed the request, we don't WANT to send Content" so we must not throw a 404 there.