### PR TITLE
[2.x] Return 0 instead of void when no taxes

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -196,7 +196,7 @@ export const fixedProductTaxes = computed(() => {
 
 export const taxTotal = computed(() => {
     if (!cart?.value?.prices?.applied_taxes?.length) {
-        return
+        return 0
     }
 
     return cart.value.prices.applied_taxes.reduce((sum, tax) => sum + tax.amount.value, 0)


### PR DESCRIPTION
By returning void we end up getting `undefined` as our taxTotal, which is obviously not correct as it should be 0.