### PR TITLE
Removed unsupported applied_to and coupon keys

### DIFF
--- a/resources/views/checkout/queries/fragments/item.graphql
+++ b/resources/views/checkout/queries/fragments/item.graphql
@@ -18,10 +18,6 @@ fragment orderItem on OrderItemInterface {
             currency
             value
         }
-        applied_to
-        coupon {
-            code
-        }
         label
     }
     entered_options {


### PR DESCRIPTION
See: https://github.com/magento/magento2/pull/39772
however i have also run into it when trying to get the coupon code.
![image](https://github.com/user-attachments/assets/c711711e-f69e-4b06-9c64-4ac18dff145e)

Looking at the underlying functions the real supported values by the orderItem are label and amount
https://github.com/indykoning/magento2-1/blob/405bee6e61a23e887a3cbc99af6081c787b8594a/app/code/Magento/SalesGraphQl/Model/OrderItem/DataProvider.php#L227