### PR TITLE
[3.x] Add infinite-scroll false by default

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -8,6 +8,7 @@
                     component-id="{{ md5(serialize($value)) }}"
                     data-field="{{ $field }}"
                     :size="999"
+                    :infinite-scroll="false"
                     :default-query="function () { return { query: { terms: { '{{ $field }}': {!!
                         is_array($value)
                             ? "['".implode("','", $value)."']"


### PR DESCRIPTION
When there are more than 999 products in the listing (or, more realistically, you lower this size down to a number that causes pagination), you will end up having the infinite scroll functionality automatically enabled.

In this case that causes any sliders on a page to fetch more data when you scroll to the bottom of the page. Potentially can cause dozens of ES requests and a ton of content shifting.