### PR TITLE
Fixed negative loadingCount

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -33,7 +33,7 @@ export const rapidezFetch = (window.rapidezFetch = ((originalFetch) => {
         }
         const result = originalFetch.apply(this, args)
         return result.finally((...args) => {
-            if (loadingTracked) {
+            if (loadingTracked && window.app.$data && window.app.$data.loadingCount > 0) {
                 window.app.$data.loadingCount--
             }
 

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -27,12 +27,13 @@ window.SessionExpired = SessionExpired
 
 export const rapidezFetch = (window.rapidezFetch = ((originalFetch) => {
     return (...args) => {
-        if (window.app.$data) {
+        let loadingTracked = !!window.app.$data
+        if (loadingTracked) {
             window.app.$data.loadingCount++
         }
         const result = originalFetch.apply(this, args)
         return result.finally((...args) => {
-            if (window.app.$data) {
+            if (loadingTracked) {
                 window.app.$data.loadingCount--
             }
 


### PR DESCRIPTION
When fetches get called earlier than Vue has booted it can be possible that the loading count does not get added, but does get subtracted once the request finishes.

This change will maintain a state wether loadingCount has been tracked when it adds, so it will only get subtracted if the loadingcount has been increased in the first place