### PR TITLE
Made the variables used within the graphql component reactive

### DIFF
--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -50,7 +50,7 @@ export default {
             return null
         }
 
-        return this.$scopedSlots.default({...this, variables: this.dataVariables})
+        return this.$scopedSlots.default({ ...this, variables: this.dataVariables })
     },
 
     created() {

--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -39,6 +39,7 @@ export default {
     },
 
     data: () => ({
+        dataVariables: {},
         data: null,
         cachePrefix: 'graphql_',
         running: false,
@@ -49,10 +50,12 @@ export default {
             return null
         }
 
-        return this.$scopedSlots.default(this)
+        return this.$scopedSlots.default({...this, variables: this.dataVariables})
     },
 
     created() {
+        this.dataVariables = this.variables
+
         if (!this.getCache()) {
             this.runQuery()
         }
@@ -78,8 +81,8 @@ export default {
                 }
 
                 let response = this.group
-                    ? await combiningGraphQL(this.query, this.variables, options, this.group)
-                    : await magentoGraphQL(this.query, this.variables, options)
+                    ? await combiningGraphQL(this.query, this.dataVariables, options, this.group)
+                    : await magentoGraphQL(this.query, this.dataVariables, options)
 
                 if (this.check) {
                     if (!this.check(response?.data)) {
@@ -89,14 +92,14 @@ export default {
                     }
                 }
 
-                this.data = this.callback ? await this.callback(this.variables, response) : response.data
+                this.data = this.callback ? await this.callback(this.dataVariables, response) : response.data
 
                 if (this.cache) {
                     useLocalStorage(this.cachePrefix + this.cache, null, { serializer: StorageSerializers.object }).value = this.data
                 }
             } catch (error) {
                 console.error(error)
-                this.errorCallback(this.variables, await error?.response?.json())
+                this.errorCallback(this.dataVariables, await error?.response?.json())
             } finally {
                 this.running = false
             }


### PR DESCRIPTION
When trying to add a v-model to the variables of the graphql component in the same way as done with the graphql-mutation component they actually get emptied when the query gets sent.

I've found out variables isn't actually reactive for the graphql component.
This makes it work reactive since the value is updated in the data.

I've purposefully left out the "watch" prop as that seems to cause a kind of two way binding.
Where suddenly changes to dataVariables are mirrored to variables, but when runQuery gets called both dataVariables and variables get reset to the initial value.