### PR TITLE
Lazily load instantsearch globally

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -1,17 +1,6 @@
 <script>
 import { history } from 'instantsearch.js/es/lib/routers'
 
-import AisSearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
-import AisRefinementList from 'vue-instantsearch/vue2/es/src/components/RefinementList.vue.js'
-import AisHierarchicalMenu from 'vue-instantsearch/vue2/es/src/components/HierarchicalMenu.vue.js'
-import AisRangeInput from 'vue-instantsearch/vue2/es/src/components/RangeInput.vue.js'
-import AisCurrentRefinements from 'vue-instantsearch/vue2/es/src/components/CurrentRefinements.vue.js'
-import AisClearRefinements from 'vue-instantsearch/vue2/es/src/components/ClearRefinements.vue.js'
-import AisHitsPerPage from 'vue-instantsearch/vue2/es/src/components/HitsPerPage.vue.js'
-import AisSortBy from 'vue-instantsearch/vue2/es/src/components/SortBy.vue.js'
-import AisPagination from 'vue-instantsearch/vue2/es/src/components/Pagination.vue.js'
-import AisStats from 'vue-instantsearch/vue2/es/src/components/Stats.vue.js'
-
 import categoryFilter from './Filters/CategoryFilter.vue'
 import useAttributes from '../../stores/useAttributes.js'
 
@@ -19,18 +8,6 @@ import InstantSearchMixin from '../Search/InstantSearchMixin.vue'
 
 export default {
     mixins: [InstantSearchMixin],
-    components: {
-        'ais-search-box': AisSearchBox,
-        'ais-refinement-list': AisRefinementList,
-        'ais-hierarchical-menu': AisHierarchicalMenu,
-        'ais-range-input': AisRangeInput,
-        'ais-current-refinements': AisCurrentRefinements,
-        'ais-clear-refinements': AisClearRefinements,
-        'ais-hits-per-page': AisHitsPerPage,
-        'ais-sort-by': AisSortBy,
-        'ais-pagination': AisPagination,
-        'ais-stats': AisStats,
-    },
     props: {
         // TODO: Do we still use/need this?
         // Maybe transform it to a callback

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -1,14 +1,23 @@
 <script>
-import AisSearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
-import AisIndex from 'vue-instantsearch/vue2/es/src/components/Index.js'
-
 import InstantSearchMixin from './InstantSearchMixin.vue'
+
+import InstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
+import Hits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
+import Configure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
+import highlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
+import SearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
+import Index from 'vue-instantsearch/vue2/es/src/components/Index.js';
+
 
 export default {
     mixins: [InstantSearchMixin],
     components: {
-        'ais-search-box': AisSearchBox,
-        'ais-index': AisIndex,
+        InstantSearch,
+        Hits,
+        Configure,
+        highlight,
+        SearchBox,
+        Index,
     },
     data: () => ({
         loaded: false,

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -6,8 +6,7 @@ import Hits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
 import Configure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
 import highlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
 import SearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
-import Index from 'vue-instantsearch/vue2/es/src/components/Index.js';
-
+import Index from 'vue-instantsearch/vue2/es/src/components/Index.js'
 
 export default {
     mixins: [InstantSearchMixin],

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -2,18 +2,7 @@
 import Client from '@searchkit/instantsearch-client'
 import Searchkit from 'searchkit'
 
-import AisInstantSearch from 'vue-instantsearch/vue2/es/src/components/InstantSearch'
-import AisHits from 'vue-instantsearch/vue2/es/src/components/Hits.js'
-import AisConfigure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
-import AisHighlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
-
 export default {
-    components: {
-        'ais-instant-search': AisInstantSearch,
-        'ais-hits': AisHits,
-        'ais-configure': AisConfigure,
-        'ais-highlight': AisHighlight,
-    },
     data: () => ({
         searchkit: null,
         searchClient: null,

--- a/resources/js/instantsearch.js
+++ b/resources/js/instantsearch.js
@@ -6,7 +6,7 @@ Vue.component('ais-highlight', () => import('vue-instantsearch/vue2/es/src/compo
 Vue.component('ais-search-box', () => import('vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'))
 
 // Used by Autocomplete
-Vue.component('ais-index', () => import('vue-instantsearch/vue2/es/src/components/Index.js'));
+Vue.component('ais-index', () => import('vue-instantsearch/vue2/es/src/components/Index.js'))
 
 // Used by Listing
 Vue.component('ais-refinement-list', () => import('vue-instantsearch/vue2/es/src/components/RefinementList.vue.js'))
@@ -18,4 +18,3 @@ Vue.component('ais-hits-per-page', () => import('vue-instantsearch/vue2/es/src/c
 Vue.component('ais-sort-by', () => import('vue-instantsearch/vue2/es/src/components/SortBy.vue.js'))
 Vue.component('ais-pagination', () => import('vue-instantsearch/vue2/es/src/components/Pagination.vue.js'))
 Vue.component('ais-stats', () => import('vue-instantsearch/vue2/es/src/components/Stats.vue.js'))
-

--- a/resources/js/instantsearch.js
+++ b/resources/js/instantsearch.js
@@ -1,0 +1,21 @@
+// Shared between Autocomplete and Listing
+Vue.component('ais-instant-search', () => import('vue-instantsearch/vue2/es/src/components/InstantSearch'))
+Vue.component('ais-hits', () => import('vue-instantsearch/vue2/es/src/components/Hits.js'))
+Vue.component('ais-configure', () => import('vue-instantsearch/vue2/es/src/components/Configure.js'))
+Vue.component('ais-highlight', () => import('vue-instantsearch/vue2/es/src/components/Highlight.vue.js'))
+Vue.component('ais-search-box', () => import('vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'))
+
+// Used by Autocomplete
+Vue.component('ais-index', () => import('vue-instantsearch/vue2/es/src/components/Index.js'));
+
+// Used by Listing
+Vue.component('ais-refinement-list', () => import('vue-instantsearch/vue2/es/src/components/RefinementList.vue.js'))
+Vue.component('ais-hierarchical-menu', () => import('vue-instantsearch/vue2/es/src/components/HierarchicalMenu.vue.js'))
+Vue.component('ais-range-input', () => import('vue-instantsearch/vue2/es/src/components/RangeInput.vue.js'))
+Vue.component('ais-current-refinements', () => import('vue-instantsearch/vue2/es/src/components/CurrentRefinements.vue.js'))
+Vue.component('ais-clear-refinements', () => import('vue-instantsearch/vue2/es/src/components/ClearRefinements.vue.js'))
+Vue.component('ais-hits-per-page', () => import('vue-instantsearch/vue2/es/src/components/HitsPerPage.vue.js'))
+Vue.component('ais-sort-by', () => import('vue-instantsearch/vue2/es/src/components/SortBy.vue.js'))
+Vue.component('ais-pagination', () => import('vue-instantsearch/vue2/es/src/components/Pagination.vue.js'))
+Vue.component('ais-stats', () => import('vue-instantsearch/vue2/es/src/components/Stats.vue.js'))
+

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -21,6 +21,7 @@ import './mixins'
 import './cookies'
 import './callbacks'
 import './vue-components'
+import './instantsearch'
 ;(() => import('./turbolinks'))()
 
 if (import.meta.env.VITE_DEBUG === 'true') {

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -2,10 +2,7 @@
 
 @pushOnce('head', 'es_url-preconnect')
     <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
-
-    @if ($file = vite_filename_path('Listing.vue'))
-        @vite([$file])
-    @endif
+    @vite(vite_filename_paths(['Listing.vue', 'InstantSearch']))
 @endPushOnce
 
 <div class="min-h-screen">

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -1,16 +1,5 @@
 @props(['value', 'title' => false, 'field' => 'sku.keyword'])
 
-{{--
-TODO: We should NOT have this here! It should be loaded
-lazily when "intersected" by scrolling to down
-But it currently doesn't work without it.
---}}
-@pushOnce('head')
-    @if ($file = vite_filename_path('Listing.vue'))
-        @vite([$file])
-    @endif
-@endPushOnce
-
 @if ($value)
     <lazy v-slot="{ intersected }">
         <listing v-if="intersected" v-cloak inline-template>

--- a/resources/views/listing/filters.blade.php
+++ b/resources/views/listing/filters.blade.php
@@ -1,4 +1,17 @@
 @php($id = uniqid('filters-'))
+@pushOnce('head', 'listing-filters')
+    @vite(
+        vite_filename_paths([
+            'ClearRefinements.vue',
+            'CurrentRefinements.vue',
+            'SearchBox.vue',
+            'RangeInput.vue',
+            'RangeSlider.vue',
+            'RefinementList.vue',
+            'HierarchicalMenu.vue',
+        ])
+    )
+@endPushOnce
 <x-rapidez::slideover.mobile :$id :title="__('Filters')">
     <div class="w-full p-2 max-lg:bg-white max-lg:p-5">
         @include('rapidez::listing.partials.filter.selected')

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -1,4 +1,18 @@
 {{-- TODO: Is this wrapper with these classes still the cleanest option? --}}
+@pushOnce('head', 'listing-products')
+    @vite(
+        vite_filename_paths([
+            'HitsPerPage.vue',
+            'SortBy.vue',
+            'Stats.vue',
+            'Hits.vue',
+            'Highlight.vue',
+            'Pagination.vue',
+            'Hits'
+        ])
+    )
+@endPushOnce
+
 <div id="products" class="flex flex-col gap-3 *:flex-wrap *:gap-3 *:max-sm:gap-y-3 *:max-md:justify-end">
     @include('rapidez::listing.partials.toolbar')
 

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -284,7 +284,7 @@ class RapidezServiceProvider extends ServiceProvider
                 array_map(
                     function ($filename) use ($manifest) {
                         foreach ($manifest as $path => $asset) {
-                            if (Str::endsWith($asset['name'] ?? '', $filename)|| Str::endsWith($path, $filename)) {
+                            if (Str::endsWith($asset['name'] ?? '', $filename) || Str::endsWith($path, $filename)) {
                                 return $path;
                             }
                         }

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -275,6 +275,25 @@ class RapidezServiceProvider extends ServiceProvider
                 ->squish();
         });
 
+        Vite::macro('getPathsByFilenames', function ($filenames) {
+            /** @var \Illuminate\Foundation\Vite $this */
+            $filenames = is_array($filenames) ? $filenames : func_get_args();
+            $manifest = $this->manifest($this->buildDirectory);
+
+            return array_filter(
+                array_map(
+                    function ($filename) use ($manifest) {
+                        foreach ($manifest as $path => $asset) {
+                            if (Str::endsWith($asset['name'] ?? '', $filename)|| Str::endsWith($path, $filename)) {
+                                return $path;
+                            }
+                        }
+                    },
+                    $filenames
+                )
+            );
+        });
+
         return $this;
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 if (! function_exists('price')) {
     function price($price)
     {
@@ -28,13 +30,13 @@ if (! function_exists('vite_filename_with_chunkhash')) {
 if (! function_exists('vite_filename_path')) {
     function vite_filename_path($file)
     {
-        $manifest = @json_decode(@file_get_contents(public_path('build/manifest.json')));
-        if ($manifest) {
-            foreach ($manifest as $path => $asset) {
-                if (Str::endsWith($path, $file)) {
-                    return $path;
-                }
-            }
-        }
+        return vite_filename_paths($file)[0] ?? null;
+    }
+}
+
+if (! function_exists('vite_filename_paths')) {
+    function vite_filename_paths($file)
+    {
+        return Vite::getPathsByFilenames($file);
     }
 }


### PR DESCRIPTION
In this PR we've moved the components for instantsearch to be lazily imported, this makes it easier to create your own listings without having to register them again. And prepares us for a Vue 3 update