### PR TITLE
[Instantsearch] Remove filterScoreScript

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -58,9 +58,6 @@ export default {
         filterQueryString: {
             type: String,
         },
-        filterScoreScript: {
-            type: String,
-        },
     },
 
     data: () => ({
@@ -223,18 +220,6 @@ export default {
                 extraFilters.push({
                     query_string: {
                         query: this.filterQueryString,
-                    },
-                })
-            }
-
-            if (this.filterScoreScript) {
-                extraFilters.push({
-                    function_score: {
-                        script_score: {
-                            script: {
-                                source: this.filterScoreScript,
-                            },
-                        },
                     },
                 })
             }

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -51,6 +51,9 @@ export default {
         query: {
             type: Function,
         },
+        categoryId: {
+            type: Number,
+        },
         baseFilters: {
             type: Function,
             default: () => [],
@@ -215,6 +218,13 @@ export default {
         },
 
         getBaseFilters() {
+            if (this.categoryId) {
+                return this.baseFilters().concat([
+                    { query_string: { query: 'visibility:(2 OR 4) AND category_ids:' + this.categoryId } },
+                    this.$root.categoryPositions(this.categoryId),
+                ])
+            }
+
             let extraFilters = []
             if (this.filterQueryString) {
                 extraFilters.push({

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -139,6 +139,18 @@ function init() {
 
                     return `/storage/${store}/resizes/${size}/magento${url}`
                 },
+
+                categoryPositions(categoryId) {
+                    return {
+                        function_score: {
+                            script_score: {
+                                script: {
+                                    source: `Integer.parseInt(doc['positions.${categoryId}'].empty ? '0' : doc['positions.${categoryId}'].value)`
+                                }
+                            }
+                        }
+                    }
+                },
             },
             computed: {
                 // Wrap the local storage in getter and setter functions so you do not have to interact using .value

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -145,10 +145,10 @@ function init() {
                         function_score: {
                             script_score: {
                                 script: {
-                                    source: `Integer.parseInt(doc['positions.${categoryId}'].empty ? '0' : doc['positions.${categoryId}'].value)`
-                                }
-                            }
-                        }
+                                    source: `Integer.parseInt(doc['positions.${categoryId}'].empty ? '0' : doc['positions.${categoryId}'].value)`,
+                                },
+                            },
+                        },
                     }
                 },
             },

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -14,7 +14,7 @@
             <x-rapidez::listing
                 :root-path="$category->parentcategories->pluck('name')->join(' > ')"
                 filter-query-string="visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}"
-                filter-score-script="Integer.parseInt(doc['positions.{{ $category->entity_id }}'].empty ? '0' : doc['positions.{{ $category->entity_id }}'].value)"
+                v-bind:base-filters="() => [ categoryPositions({{ $category->entity_id }}) ]"
             />
         @else
             <div class="flex max-md:flex-col">

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -13,8 +13,7 @@
         @if ($category->is_anchor)
             <x-rapidez::listing
                 :root-path="$category->parentcategories->pluck('name')->join(' > ')"
-                filter-query-string="visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}"
-                v-bind:base-filters="() => [ categoryPositions({{ $category->entity_id }}) ]"
+                v-bind:category-id="{{ $category->entity_id }}"
             />
         @else
             <div class="flex max-md:flex-col">


### PR DESCRIPTION
We could also remove the filterQueryString here and also replace that with a function we can call inside of the baseFilters, and maybe by that point we could also aggregate those functions into their own file? Not sure what would be nicer here.

Would look something like this:
```
v-bind:base-filters="() => [
    queryString('visibility:(2 OR 4) AND category_ids:{{ $category->entity_id }}')
    categoryPositions({{ $category->entity_id }}),
]"
```