### PR TITLE
[3.x] Use query params through javascript to better support static caching

### DIFF
--- a/lang/en/frontend.php
+++ b/lang/en/frontend.php
@@ -34,6 +34,10 @@ return [
     'newest'    => 'Newest',
     'all'       => 'All',
 
+    'search' => [
+        'title' => 'Search for',
+    ],
+
     // 'sorting' => [
     //     'attribute' => [
     //         'asc' => 'Attribute asc',

--- a/lang/nl/frontend.php
+++ b/lang/nl/frontend.php
@@ -28,6 +28,10 @@ return [
     'relevance' => 'Relevantie',
     'newest'    => 'Nieuwste',
     'all'       => 'Alles',
+    
+    'search' => [
+        'title' => 'Zoeken naar',
+    ],
 
     'sorting' => [
         'price' => [

--- a/lang/nl/frontend.php
+++ b/lang/nl/frontend.php
@@ -28,7 +28,7 @@ return [
     'relevance' => 'Relevantie',
     'newest'    => 'Nieuwste',
     'all'       => 'Alles',
-    
+
     'search' => [
         'title' => 'Zoeken naar',
     ],

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -46,6 +46,9 @@ export default {
 
     mounted() {
         this.loaded = Object.keys(this.attributes).length > 0
+        if (this.isSearchPage) {
+            document.title = config.translations.search.title + ': ' + this.$root.queryParams.get('q')
+        }
     },
 
     computed: {
@@ -86,6 +89,10 @@ export default {
                 )
                 .concat(this.additionalSorting)
         },
+
+        isSearchPage: function () {
+            return this.$root.queryParams.has('q');
+        }
     },
     watch: {
         attributes: function (value) {

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -91,8 +91,8 @@ export default {
         },
 
         isSearchPage: function () {
-            return this.$root.queryParams.has('q');
-        }
+            return this.$root.queryParams.has('q')
+        },
     },
     watch: {
         attributes: function (value) {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -157,6 +157,10 @@ function init() {
                 canOrder() {
                     return this.cart.items.every((item) => item.is_available)
                 },
+
+                queryParams() {
+                    return new URLSearchParams(window.location.search)
+                }
             },
             watch: {
                 loadingCount: function (count) {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -160,7 +160,7 @@ function init() {
 
                 queryParams() {
                     return new URLSearchParams(window.location.search)
-                }
+                },
             },
             watch: {
                 loadingCount: function (count) {

--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -1,12 +1,10 @@
 @extends('rapidez::layouts.app')
 
-@section('title', __('Search for').': '.request()->q)
-@section('description', __('Search for').': '.request()->q)
 @section('robots', 'NOINDEX,NOFOLLOW')
 
 @section('content')
-    <div class="container">
-        <h1 class="font-bold text-3xl">@lang('Search for'): {{ request()->q }}</h1>
+    <div class="container" v-cloak>
+        <h1 class="font-bold text-3xl">@lang('Search for'): @{{ $root.queryParams.get('q') }}</h1>
         <x-rapidez::listing query="{
             bool: {
                 must: [
@@ -14,7 +12,7 @@
                     { bool: { should: [
                         {
                             multi_match: {
-                                query: '{{ request()->q }}',
+                                query: $root.queryParams.get('q'),
                                 fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
                                 type: 'best_fields',
                                 operator: 'or',
@@ -23,7 +21,7 @@
                         },
                         {
                             multi_match: {
-                                query: '{{ request()->q }}',
+                                query: $root.queryParams.get('q'),
                                 fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
                                 type: 'phrase',
                                 operator: 'or',
@@ -31,7 +29,7 @@
                         },
                         {
                             multi_match: {
-                                query: '{{ request()->q }}',
+                                query: $root.queryParams.get('q'),
                                 fields: Object.entries(config.searchable).map((value) => value[0]+'^'+value[1]),
                                 type: 'phrase_prefix',
                                 operator: 'or',


### PR DESCRIPTION
This grabs the query search parameter through javascript instead of the laravel helper to better support static caching. It also uses this logic to determine if we're on the search page to allow the title of the document to be set.

Once approved I will create a 2.x PR.