### PR TITLE
Just mention the Rapidez Statamic install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -291,12 +291,7 @@ class InstallCommand extends Command
 
         if ($this->selectedPackages->contains('rapidez/statamic')) {
             $this->newLine();
-            if (confirm(
-                label: 'Run the Statamic integration installer?',
-                hint: 'This will run `php artisan rapidez-statamic:install`'
-            )) {
-                $this->call('rapidez-statamic:install');
-            }
+            $this->warn('Next thing to do manually, run: php artisan rapidez-statamic:install');
         }
 
         return $this;


### PR DESCRIPTION
Otherwise you'll get:

> There are no commands defined in the "rapidez-statamic" namespace.