### PR TITLE
Make queryParams a computed property

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -159,10 +159,6 @@ function init() {
 
                     return `/storage/${store}/resizes/${size}/magento${url}`
                 },
-
-                queryParams() {
-                    return new URLSearchParams(window.location.search)
-                },
             },
             computed: {
                 // Wrap the local storage in getter and setter functions so you do not have to interact using .value
@@ -180,6 +176,10 @@ function init() {
 
                 canOrder() {
                     return this.cart.items?.every((item) => item.is_available)
+                },
+
+                queryParams() {
+                    return new URLSearchParams(window.location.search)
                 },
             },
             watch: {


### PR DESCRIPTION
See:
https://github.com/rapidez/core/pull/803/files#diff-862a032d6992ba9a24c4278dd9a2ff425bfadcef76f9f721673d86967b5175f8R91
https://github.com/rapidez/core/pull/803/files#diff-010087ab0afdd6b69b98a2360a70cf78c331bd83d02424dfad1927873c66a713R7

It was used everywhere as a property, however it was placed within methods causing errors
(3.x does have this implemented correctly)