### PR TITLE
Display search suggestions if no results are available

### DIFF
--- a/lang/nl.json
+++ b/lang/nl.json
@@ -86,6 +86,7 @@
     "Sorry! No image": "Sorry! Geen afbeelding",
     "Sorry! This product is currently out of stock.": "Sorry! Dit product is momenteel niet op voorraad.",
     "Sorry! We did not find any products.": "Sorry! We hebben geen producten gevonden.",
+    "But here are some suggestions!": "Maar hier zijn enkele suggesties!",
     "Specifications": "Specificaties",
     "Street": "Straat",
     "Subscribe": "Inschrijven",

--- a/resources/js/components/Listing/SearchSuggestions.vue
+++ b/resources/js/components/Listing/SearchSuggestions.vue
@@ -1,0 +1,89 @@
+<script>
+import InstantSearchMixin from '../Search/InstantSearchMixin.vue'
+
+export default {
+    mixins: [InstantSearchMixin],
+
+    render() {
+        return this.$scopedSlots.default(this)
+    },
+
+    mounted() {
+        this.$nextTick(() => {
+            requestAnimationFrame(() => this.$emit('mounted'))
+        })
+    },
+
+    methods: {
+        async getInstantSearchClientConfig() {
+            const config = await InstantSearchMixin.methods.getInstantSearchClientConfig.bind(this).call()
+
+            config.getQuery = (query, search_attributes) => {
+                return [
+                    {
+                        function_score: {
+                            functions: [
+                                {
+                                    filter: { match: { query_text: query } },
+                                    weight: 18
+                                },
+                                {
+                                    filter: { term: { redirect: query } },
+                                    weight: 24
+                                },
+                                {
+                                    field_value_factor: {
+                                        field: "popularity",
+                                        factor: 1,
+                                        modifier: "log1p",
+                                        missing: 0
+                                    },
+                                    weight: 5
+                                },
+                                {
+                                    filter: { exists: { field: "redirect" } },
+                                    weight: 10
+                                },
+                                {
+                                    filter: { term: { display_in_terms: 1 } },
+                                    weight: 2
+                                },
+                                {
+                                    filter: { term: { is_processed: 1 } },
+                                    weight: 2
+                                }
+                            ]
+                        },
+                    },
+                ]
+            }
+
+            return config
+        },
+
+        async getSearchSettings() {
+            return {
+                highlight_attributes: ['query_text'],
+                search_attributes: [
+                    {
+                        field: 'query_text',
+                        weight: 2.0,
+                    },
+                    {
+                        field: 'redirect',
+                        weight: 8.0,
+                    },
+                ],
+                result_attributes: [
+                    'query_text',
+                    'redirect',
+                    'popularity',
+                    'num_results',
+                    'display_in_terms',
+                    'is_processed',
+                ],
+            }
+        },
+    },
+}
+</script>

--- a/resources/js/components/Listing/SearchSuggestions.vue
+++ b/resources/js/components/Listing/SearchSuggestions.vue
@@ -25,34 +25,34 @@ export default {
                             functions: [
                                 {
                                     filter: { match: { query_text: query } },
-                                    weight: 18
+                                    weight: 18,
                                 },
                                 {
                                     filter: { term: { redirect: query } },
-                                    weight: 24
+                                    weight: 24,
                                 },
                                 {
                                     field_value_factor: {
-                                        field: "popularity",
+                                        field: 'popularity',
                                         factor: 1,
-                                        modifier: "log1p",
-                                        missing: 0
+                                        modifier: 'log1p',
+                                        missing: 0,
                                     },
-                                    weight: 5
+                                    weight: 5,
                                 },
                                 {
-                                    filter: { exists: { field: "redirect" } },
-                                    weight: 10
+                                    filter: { exists: { field: 'redirect' } },
+                                    weight: 10,
                                 },
                                 {
                                     filter: { term: { display_in_terms: 1 } },
-                                    weight: 2
+                                    weight: 2,
                                 },
                                 {
                                     filter: { term: { is_processed: 1 } },
-                                    weight: 2
-                                }
-                            ]
+                                    weight: 2,
+                                },
+                            ],
                         },
                     },
                 ]
@@ -74,14 +74,7 @@ export default {
                         weight: 8.0,
                     },
                 ],
-                result_attributes: [
-                    'query_text',
-                    'redirect',
-                    'popularity',
-                    'num_results',
-                    'display_in_terms',
-                    'is_processed',
-                ],
+                result_attributes: ['query_text', 'redirect', 'popularity', 'num_results', 'display_in_terms', 'is_processed'],
             }
         },
     },

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -55,6 +55,7 @@ Vue.component('autocomplete', () => ({
 Vue.component('checkout-login', () => import('./components/Checkout/CheckoutLogin.vue'))
 Vue.component('login', () => import('./components/User/Login.vue'))
 Vue.component('listing', () => import('./components/Listing/Listing.vue'))
+Vue.component('search-suggestions', () => import('./components/Listing/SearchSuggestions.vue'))
 Vue.component('checkout-success', () => import('./components/Checkout/CheckoutSuccess.vue'))
 Vue.component('popup', () => import('./components/Popup.vue'))
 Vue.component('selected-filters-values', () => import('./components/Listing/Filters/SelectedFiltersValues.vue'))

--- a/resources/views/listing/partials/no-results.blade.php
+++ b/resources/views/listing/partials/no-results.blade.php
@@ -1,2 +1,25 @@
 @lang('Sorry! We did not find any products.')
-{{-- TODO: Can we make this more useful? --}}
+{{-- TODO: We will want to make this look better --}}
+<search-suggestions v-slot="searchSuggestions">
+    <ais-instant-search
+        v-if="searchSuggestions.searchClient"
+        {{-- TODO: Use the new index names --}}
+        :index-name="config.index_prefix + '_search_query_' + config.store"
+        :search-client="searchSuggestions.searchClient"
+    >
+        <ais-search-box value="{{ request()->q ?? ' ' }}" />
+        <ais-configure :hits-per-page.camel="5"/>
+        <ais-hits v-slot="{ items }">
+            <div class="mt-1" v-if="items && items.length">
+                @lang('But here are some suggestions!')
+                <ul class="flex flex-row font-sans">
+                    <li v-for="(item, count) in items" class="flex flex-1 items-center w-full">
+                        <a v-bind:href="window.url(item.redirect || '{{ route('search', ['q' => 'searchPlaceholder']) }}'.replace('searchPlaceholder', encodeURIComponent(item.query_text)))" class="relative flex items-center group w-full py-2 text-sm gap-x-4">
+                            <span v-text="item.query_text"></span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </ais-hits>
+    </ais-instant-search>
+</search-suggestions>

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -18,7 +18,7 @@
 
     <ais-hits>
         <template v-slot="{ items }">
-            <div v-if="items" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 md:gap-5 overflow-hidden">
+            <div v-if="items && items.length" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-2 md:gap-5 overflow-hidden">
                 <template v-for="(item, count) in items">
                     @include('rapidez::listing.partials.item')
                 </template>

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -10,7 +10,7 @@ class SearchController
 {
     public function __invoke(Request $request)
     {
-        if (!$request->q) {
+        if (! $request->q) {
             return view('rapidez::search.overview');
         }
 

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -4,12 +4,17 @@ namespace Rapidez\Core\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Rapidez\Core\Models\Scopes\IsActiveScope;
 
 class SearchController
 {
     public function __invoke(Request $request)
     {
-        $searchQuery = config('rapidez.models.search_query')::firstOrNew([
+        if (!$request->q) {
+            return view('rapidez::search.overview');
+        }
+
+        $searchQuery = config('rapidez.models.search_query')::withoutGlobalScope(IsActiveScope::class)->firstOrNew([
             'query_text' => Str::lower($request->q),
             'store_id'   => config('rapidez.store'),
         ], ['popularity' => 1]);

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -2,8 +2,14 @@
 
 namespace Rapidez\Core\Models;
 
+use Rapidez\Core\Models\Traits\Searchable;
+use Illuminate\Database\Eloquent\Builder;
+use Rapidez\Core\Models\Scopes\IsActiveScope;
+
 class SearchQuery extends Model
 {
+    use Searchable;
+
     const CREATED_AT = null;
 
     protected $table = 'search_query';
@@ -11,4 +17,16 @@ class SearchQuery extends Model
     protected $primaryKey = 'query_id';
 
     protected $guarded = [];
+
+    protected static function booting()
+    {
+        static::addGlobalScope('ForCurrentStore', fn (Builder $query) => $query->where('store_id', config('rapidez.store')));
+        static::addGlobalScope(new IsActiveScope);
+    }
+
+    protected function makeAllSearchableUsing(Builder $query)
+    {
+        return $query
+            ->where('popularity', '>', 10);
+    }
 }

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -2,9 +2,9 @@
 
 namespace Rapidez\Core\Models;
 
-use Rapidez\Core\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Builder;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
+use Rapidez\Core\Models\Traits\Searchable;
 
 class SearchQuery extends Model
 {


### PR DESCRIPTION
This will add a list of search suggestions when there are no results to be shown.

So long as there are search queries in the database it will always have suggestions. This has been forced by using the function score. 

Instead of using a MUST on the results, we boost matching queries so suggestions matching your query will be sorted first.
An additional weight is added based on popularity (which will not outrank the search query)
and the existence of a redirect url on this query, indicating it has gotten special attention