### PR TITLE
Automatically select default shipping method if no shipping method is entered

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -1,5 +1,5 @@
 import { cart, clear as clearCart } from './stores/useCart'
-import { fillFromGraphqlResponse as updateOrder, order } from './stores/useOrder'
+import { fillFromGraphqlResponse as updateOrder } from './stores/useOrder'
 import { runAfterPlaceOrderHandlers, runBeforePaymentMethodHandlers, runBeforePlaceOrderHandlers } from './stores/usePaymentHandlers'
 import { refresh as refreshUser, token } from './stores/useUser'
 
@@ -65,6 +65,12 @@ Vue.prototype.updateCart = async function (data, response) {
     cart.value = Object.values(response.data)
         .map((queryResponse) => ('cart' in queryResponse ? queryResponse.cart : queryResponse))
         .findLast((queryResponse) => queryResponse?.is_virtual !== undefined)
+
+    document.dispatchEvent(new CustomEvent('cart-updated', {
+        detail: {
+            cart: cart,
+        },
+    }))
 
     return response.data
 }

--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -66,11 +66,13 @@ Vue.prototype.updateCart = async function (data, response) {
         .map((queryResponse) => ('cart' in queryResponse ? queryResponse.cart : queryResponse))
         .findLast((queryResponse) => queryResponse?.is_virtual !== undefined)
 
-    document.dispatchEvent(new CustomEvent('cart-updated', {
-        detail: {
-            cart: cart,
-        },
-    }))
+    document.dispatchEvent(
+        new CustomEvent('cart-updated', {
+            detail: {
+                cart: cart,
+            },
+        }),
+    )
 
     return response.data
 }

--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -213,19 +213,18 @@ document.addEventListener('cart-updated', (event) => {
     // Can be removed once https://github.com/magento/magento2/issues/39828 is fixed
     setTimeout(() => {
         if (cart?.value?.shipping_addresses?.length > 0 || userStorage.value?.addresses?.length < 1) {
-            return;
+            return
         }
 
-        const defaultShipping = userStorage.value?.addresses?.find((address) => address.default_shipping);
+        const defaultShipping = userStorage.value?.addresses?.find((address) => address.default_shipping)
         if (!defaultShipping) {
-            return;
+            return
         }
 
         magentoGraphQL(config.queries.setExistingShippingAddressesOnCart, {
             cart_id: mask.value,
             customer_address_id: defaultShipping.id,
-        })
-            .then((response) => Vue.prototype.updateCart([], response))
+        }).then((response) => Vue.prototype.updateCart([], response))
     })
 })
 

--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -1,10 +1,11 @@
 import { useLocalStorage, useSessionStorage, StorageSerializers } from '@vueuse/core'
 import { useCookies } from '@vueuse/integrations/useCookies'
-import { clear as clearCart, fetchCustomerCart, linkUserToCart } from './useCart'
+import { clear as clearCart, fetchCustomerCart, linkUserToCart, cart } from './useCart'
 import { clear as clearOrder } from './useOrder'
 import { computed, watch } from 'vue'
 import Jwt from '../jwt'
 import { mask } from './useMask'
+import { magentoGraphQL } from '../fetch'
 
 /**
  * @deprecated using localstorage to retrieve the token is deprecated, use the useUser.token instead
@@ -60,7 +61,7 @@ export const refresh = async function () {
 
     return (currentRefresh = (async function () {
         try {
-            userStorage.value = (await window.magentoGraphQL(`{ customer { ${config.queries.customer} } }`))?.data?.customer
+            userStorage.value = (await magentoGraphQL(`{ customer { ${config.queries.customer} } }`))?.data?.customer
         } catch (error) {
             if (error instanceof SessionExpired) {
                 await clear()
@@ -205,6 +206,26 @@ document.addEventListener('vue:loaded', function (event) {
         if (data?.redirect) {
             this.$nextTick(() => (window.location.href = window.url(data?.redirect)))
         }
+    })
+})
+
+document.addEventListener('cart-updated', (event) => {
+    // Can be removed once https://github.com/magento/magento2/issues/39828 is fixed
+    setTimeout(() => {
+        if (cart?.value?.shipping_addresses?.length > 0 || userStorage.value?.addresses?.length < 1) {
+            return;
+        }
+
+        const defaultShipping = userStorage.value?.addresses?.find((address) => address.default_shipping);
+        if (!defaultShipping) {
+            return;
+        }
+
+        magentoGraphQL(config.queries.setExistingShippingAddressesOnCart, {
+            cart_id: mask.value,
+            customer_address_id: defaultShipping.id,
+        })
+            .then((response) => Vue.prototype.updateCart([], response))
     })
 })
 

--- a/resources/views/cart/sidebar.blade.php
+++ b/resources/views/cart/sidebar.blade.php
@@ -6,7 +6,7 @@
     </div>
 
     <template v-if="cart.shipping_addresses?.length">
-        <div v-for="address in cart.shipping_addresses">
+        <div v-for="address in cart.shipping_addresses" v-if="address.selected_shipping_method">
             <dt>@lang('Shipping')</dt>
             <dd v-if="showTax">@{{ address.selected_shipping_method.price_incl_tax.value | price }}</dd>
             <dd v-else>@{{ address.selected_shipping_method.price_excl_tax.value | price }}</dd>


### PR DESCRIPTION
This PR will automatically select the default shipping method on the cart if it does not have an address selected already.

Magento should, and does already set this. But incorrectly, see: https://github.com/magento/magento2/issues/39828
Setting this manually fixes that.