### PR TITLE
[3.x] Use correct default default

### DIFF
--- a/src/Rapidez.php
+++ b/src/Rapidez.php
@@ -58,7 +58,7 @@ class Rapidez
         return $this->routes->sortBy('position');
     }
 
-    public function config(string $path, $default = null, bool $sensitive = false): ?string
+    public function config(string $path, $default = false, bool $sensitive = false): ?string
     {
         return config('rapidez.models.config')::getValue($path, options: ['cache' => true, 'decrypt' => $sensitive, 'default' => $default]);
     }


### PR DESCRIPTION
The magento-defaults config will only be queried when the default is `false`, see https://github.com/rapidez/core/blob/master/src/Models/Config.php#L84

This was done because we want to be able to have `null` as an actual default. However, it was not yet changed in this function apparently.

(Note that the config function will never actually return this `false`, so we don't need to add `bool` to the return types)