### PR TITLE
Fixed errors indexing and getting config

### DIFF
--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -114,7 +114,7 @@ class ConfigController
         return collect($attributes)
             ->map(fn ($attribute) => [
                 ...$attribute,
-                'code'      => $attribute['prefix'] . $attribute['code'],
+                'code'      => ($attribute['prefix'] ?? '') . $attribute['code'],
                 'base_code' => $attribute['code'],
             ])
             ->sortBy('position')

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -25,7 +25,8 @@ class WithProductAttributesScope implements Scope
 
         $attributeModel = config('rapidez.models.attribute');
         $attributes = $attributeModel::getCachedWhere(function ($attribute) use ($model) {
-            return in_array($attribute['code'], $model->attributesToSelect);
+            return in_array($attribute['code'], $model->attributesToSelect)
+                && !in_array($attribute['code'], ['visibility', 'sku', 'type_id', $model->getKeyName()]);
         });
 
         $attributes = array_filter($attributes, fn ($a) => $a['type'] !== 'static');

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -26,7 +26,7 @@ class WithProductAttributesScope implements Scope
         $attributeModel = config('rapidez.models.attribute');
         $attributes = $attributeModel::getCachedWhere(function ($attribute) use ($model) {
             return in_array($attribute['code'], $model->attributesToSelect)
-                && !in_array($attribute['code'], ['visibility', 'sku', 'type_id', $model->getKeyName()]);
+                && ! in_array($attribute['code'], ['visibility', 'sku', 'type_id', $model->getKeyName()]);
         });
 
         $attributes = array_filter($attributes, fn ($a) => $a['type'] !== 'static');


### PR DESCRIPTION
After #819 i had errors when trying to index or access PDP pages due to
Visibility being a filter attribute.
https://github.com/rapidez/core/pull/706/files#diff-c30e56dd53ffc1b867aebd6fd4ebb19f51b32821dcc882dbff33382189a09039R58

This caused it to look for visibility_value in the flat table.

I've also fixed an error in getting the config.js since prefix can be unset