### PR TITLE
Keep track of returned results for search queries

### DIFF
--- a/resources/js/components/Search/AisStatsAnalytics.vue
+++ b/resources/js/components/Search/AisStatsAnalytics.vue
@@ -1,0 +1,44 @@
+<script>
+import { connectStats } from 'instantsearch.js/es/connectors';
+import { createSuitMixin } from 'vue-instantsearch/vue2/es/src/mixins/suit';
+import { createWidgetMixin } from 'vue-instantsearch/vue2/es/src/mixins/widget';
+
+export default {
+    name: 'AisStatsAnalytics',
+    mixins: [
+        createWidgetMixin(
+            { connector: connectStats },
+            {
+                $$widgetType: 'ais.stats-analytics',
+            }
+        ),
+        createSuitMixin({ name: 'Stats-Analytics' }),
+    ],
+    watch: {
+        'state.query': {
+            handler(query) {
+                this.instantSearchInstance.sendEventToInsights({
+                    insightsMethod: 'viewedObjectIDs',
+                    eventType: 'search',
+                    eventModifier: 'external',
+                    widgetType: 'ais.stats-analytics',
+                    payload: {
+                        eventName: 'Query',
+                        query: query,
+                        nbHits: this.state.nbHits,
+                        processingTimeMS: this.state.processingTimeMS,
+                    },
+                    instantSearchInstance: this.instantSearchInstance,
+                });
+            },
+        },
+    },
+    computed: {
+        widgetParams() {
+            return {};
+        },
+    },
+};
+</script>
+<template>
+</template>

--- a/resources/js/components/Search/AisStatsAnalytics.vue
+++ b/resources/js/components/Search/AisStatsAnalytics.vue
@@ -1,7 +1,7 @@
 <script>
-import { connectStats } from 'instantsearch.js/es/connectors';
-import { createSuitMixin } from 'vue-instantsearch/vue2/es/src/mixins/suit';
-import { createWidgetMixin } from 'vue-instantsearch/vue2/es/src/mixins/widget';
+import { connectStats } from 'instantsearch.js/es/connectors'
+import { createSuitMixin } from 'vue-instantsearch/vue2/es/src/mixins/suit'
+import { createWidgetMixin } from 'vue-instantsearch/vue2/es/src/mixins/widget'
 
 export default {
     name: 'AisStatsAnalytics',
@@ -10,7 +10,7 @@ export default {
             { connector: connectStats },
             {
                 $$widgetType: 'ais.stats-analytics',
-            }
+            },
         ),
         createSuitMixin({ name: 'Stats-Analytics' }),
     ],
@@ -29,16 +29,15 @@ export default {
                         processingTimeMS: this.state.processingTimeMS,
                     },
                     instantSearchInstance: this.instantSearchInstance,
-                });
+                })
             },
         },
     },
     computed: {
         widgetParams() {
-            return {};
+            return {}
         },
     },
-};
+}
 </script>
-<template>
-</template>
+<template></template>

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -29,6 +29,27 @@ export default {
         this.$nextTick(() => {
             requestAnimationFrame(() => this.$emit('mounted'))
         })
+
+        const stateChanged = useDebounceFn((event) => {
+            const query = event?.payload?.query
+
+            if (!query) {
+                return
+            }
+
+            rapidezAPI('post', '/search', {
+                q: query,
+                results: event?.payload?.nbHits,
+            })
+        }, 3000)
+
+        this.$on('insights-event:viewedObjectIDs', (event) => {
+            if (event?.eventType !== 'search') {
+                return;
+            }
+
+            stateChanged(event);
+        })
     },
 
     methods: {

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -45,10 +45,10 @@ export default {
 
         this.$on('insights-event:viewedObjectIDs', (event) => {
             if (event?.eventType !== 'search') {
-                return;
+                return
             }
 
-            stateChanged(event);
+            stateChanged(event)
         })
     },
 

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -48,12 +48,15 @@ export default {
     },
     computed: {
         middlewares() {
-            return [createInsightsMiddleware({
-                insightsClient: null,
-                onEvent: (event) => {
-                    this.$emit('insights-event:' + event.insightsMethod, event);
-                },
-            }), ...this.getMiddlewares()]
+            return [
+                createInsightsMiddleware({
+                    insightsClient: null,
+                    onEvent: (event) => {
+                        this.$emit('insights-event:' + event.insightsMethod, event)
+                    },
+                }),
+                ...this.getMiddlewares(),
+            ]
         },
     },
 }

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -2,6 +2,7 @@
 import Client from '@searchkit/instantsearch-client'
 import Searchkit from 'searchkit'
 import { instantsearchMiddlewares } from '../../stores/useInstantsearchMiddlewares'
+import { createInsightsMiddleware } from 'instantsearch.js/es/middlewares/createInsightsMiddleware'
 
 export default {
     data: () => ({
@@ -47,7 +48,12 @@ export default {
     },
     computed: {
         middlewares() {
-            return this.getMiddlewares()
+            return [createInsightsMiddleware({
+                insightsClient: null,
+                onEvent: (event) => {
+                    this.$emit('insights-event:' + event.insightsMethod, event);
+                },
+            }), ...this.getMiddlewares()]
         },
     },
 }

--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -47,6 +47,7 @@ export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {
         method: method.toUpperCase(),
         headers: Object.assign(
             {
+                Accept: 'application/json',
                 Store: window.config.store_code,
                 Authorization: token.value ? `Bearer ${token.value}` : null,
                 'Content-Type': 'application/json',

--- a/resources/js/instantsearch.js
+++ b/resources/js/instantsearch.js
@@ -19,3 +19,4 @@ Vue.component('ais-hits-per-page', () => import('vue-instantsearch/vue2/es/src/c
 Vue.component('ais-sort-by', () => import('vue-instantsearch/vue2/es/src/components/SortBy.vue.js'))
 Vue.component('ais-pagination', () => import('vue-instantsearch/vue2/es/src/components/Pagination.vue.js'))
 Vue.component('ais-stats', () => import('vue-instantsearch/vue2/es/src/components/Stats.vue.js'))
+Vue.component('ais-stats-analytics', () => import('./components/Search/AisStatsAnalytics.vue'))

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -9,7 +9,7 @@
             v-cloak
         >
             <div class="contents">
-                <ais-configure :hitsPerPage="3" />
+                <ais-configure :hits-per-page.camel="3" />
                 <div class="searchbox">
                     <ais-search-box>
                         <template v-slot="{ currentRefinement, isSearchStalled, refine }">
@@ -23,6 +23,7 @@
                             />
                         </template>
                     </ais-search-box>
+                    <ais-stats-analytics></ais-stats-analytics>
                 </div>
                 <div class="absolute inset-x-0 bg-white border">
                     @include('rapidez::layouts.partials.header.autocomplete.results')

--- a/resources/views/listing/partials/filter/search.blade.php
+++ b/resources/views/listing/partials/filter/search.blade.php
@@ -13,3 +13,4 @@
         --}}
     </template>
 </ais-search-box>
+<ais-stats-analytics></ais-stats-analytics>

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,7 +9,12 @@ use Rapidez\Core\Http\Middleware\VerifyAdminToken;
 
 Route::middleware('api')->prefix('api')->group(function () {
     Route::post('search', [SearchController::class, 'store'])
-        ->middleware('throttle:search-analytics');
+        ->middleware([
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+            'throttle:search-analytics'
+        ]);
 
     Route::get('order', OrderController::class);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ Route::middleware('api')->prefix('api')->group(function () {
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
-            'throttle:search-analytics'
+            'throttle:search-analytics',
         ]);
 
     Route::get('order', OrderController::class);

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -46,6 +46,7 @@ class SearchController
                     'store_id'   => config('rapidez.store'),
                 ],
                 [
+                    'num_results' => $request->results ?? 0,
                     'popularity' => 1,
                 ]
             );
@@ -56,7 +57,11 @@ class SearchController
             return $searchQuery;
         }
 
-        $searchQuery->increment('popularity');
+        $searchQuery->popularity++;
+        if ($request->has('results')) {
+            $searchQuery->num_results = $request->results;
+        }
+        $searchQuery->save();
 
         return $searchQuery;
     }

--- a/src/Http/Controllers/SearchController.php
+++ b/src/Http/Controllers/SearchController.php
@@ -47,7 +47,7 @@ class SearchController
                 ],
                 [
                     'num_results' => $request->results ?? 0,
-                    'popularity' => 1,
+                    'popularity'  => 1,
                 ]
             );
 

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -27,7 +27,7 @@ class SearchQuery extends Model
     protected function makeAllSearchableUsing(Builder $query)
     {
         return $query
-            ->where(fn($subQuery) => $subQuery
+            ->where(fn ($subQuery) => $subQuery
                 ->where('num_results', '>', 0)
                 ->orWhereNotNull('redirect')
             );

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -27,6 +27,9 @@ class SearchQuery extends Model
     protected function makeAllSearchableUsing(Builder $query)
     {
         return $query
-            ->where('popularity', '>', 10);
+            ->where(fn($subQuery) => $subQuery
+                ->where('num_results', '>', 0)
+                ->orWhereNotNull('redirect')
+            );
     }
 }


### PR DESCRIPTION
This is an extension on #813

It would be more valuable to show suggested results that actually return results.
We had the idea to apply the insights middleware to get this information: https://www.algolia.com/doc/api-reference/widgets/insights/vue/

Unfortunately the insights middleware does not get provided with the data we want.
We do get the _current_ result count, but not the **total** result count.

The `connectStats` connector provides us with the information we'd like.
The search query and the number of **total** results.

The insights values could still be really valuable for other analytics, thus the events will get fired on the components implementing the instantsearchMixin, which means listeners can be added on the Listing and Autocomplete.
