### PR TITLE
Implement partial reindexing

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Route;
 use Rapidez\Core\Http\Controllers\GetSignedCheckoutController;
+use Rapidez\Core\Http\Controllers\IndexController;
 use Rapidez\Core\Http\Controllers\OrderController;
 use Rapidez\Core\Http\Middleware\VerifyAdminToken;
 
@@ -19,5 +21,11 @@ Route::middleware('api')->prefix('api')->group(function () {
                 'store' => $request->store ?: false,
             ]);
         });
+
+        Route::post('index/{model}', [IndexController::class, 'store'])
+            ->where('model', '[a-zA-Z0-9_]+');
+
+        Route::delete('index/{model}', [IndexController::class, 'destroy'])
+            ->where('model', '[a-zA-Z0-9_]+');
     });
 });

--- a/src/Commands/UpdateIndexCommand.php
+++ b/src/Commands/UpdateIndexCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Rapidez\Core\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Rapidez\Core\Events\IndexAfterEvent;
+use Rapidez\Core\Events\IndexBeforeEvent;
+use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Core\Models\Traits\Searchable;
+
+class UpdateIndexCommand extends Command
+{
+    protected $signature = 'rapidez:index:update {--t|types= : To specify types of models to index, separated by commas} {--s|store= : To specify store IDs from Magento, separated by commas}';
+
+    protected $description = 'Attempt to update changed searchable models into ElasticSearch';
+
+    private ?Carbon $latestIndexDate = null;
+
+    public function handle()
+    {
+        if (!$this->getLatestIndexDate()) {
+            $this->error(__('No latest index date has been found yet, please run php artisan rapidez:index first.'));
+            return;
+        }
+
+        $baseSearchableModels = collect(config('rapidez.models'))
+            ->filter(fn ($class) => in_array(Searchable::class, class_uses_recursive($class)) && (new $class)->getQualifiedUpdatedAtColumn());
+
+        $types = $this->option('types')
+            ? $baseSearchableModels->filter(fn ($model) => in_array((new $model)->getIndexName(), explode(',', $this->option('types'))))
+            : $baseSearchableModels;
+
+        $stores = $this->option('store')
+            ? Rapidez::getStores(explode(',', $this->option('store')))
+            : Rapidez::getStores();
+
+        IndexBeforeEvent::dispatch($this);
+
+        foreach ($stores as $store) {
+            Rapidez::setStore($store);
+
+            $this->line('Store: ' . $store['name']);
+
+            foreach ($types as $type => $model) {
+                $this->updateSearchable($model);
+            }
+        }
+
+        IndexAfterEvent::dispatch($this);
+    }
+
+    protected function updateSearchable(string $model): void
+    {
+        $model::where(fn($query) => $model::makeAllSearchableUsing($query))
+            ->where(
+                (new $model)->getQualifiedUpdatedAtColumn(),
+                '>=',
+                $this->getLatestIndexDate()
+            )
+            ->searchable();
+    }
+
+    protected function getLatestIndexDate(): ?Carbon
+    {
+        if ($this->latestIndexDate) {
+            return $this->latestIndexDate;
+        }
+
+        if(! Storage::disk('local')->exists('/.last-index')) {
+            return null;
+        }
+
+        return $this->latestIndexDate ??= Carbon::parse(Storage::disk('local')->get('/.last-index'));
+    }
+}

--- a/src/Http/Controllers/IndexController.php
+++ b/src/Http/Controllers/IndexController.php
@@ -2,26 +2,24 @@
 
 namespace Rapidez\Core\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Traits\Searchable;
-use ReflectionMethod;
 
 class IndexController
 {
     public function store(string $model, Request $request)
     {
         $request->validate([
-            'ids' => 'array|required',
+            'ids'   => 'array|required',
             'ids.*' => 'integer',
         ]);
 
-        abort_if(!($model = $this->resolveModel($model)), 404);
+        abort_if(! ($model = $this->resolveModel($model)), 404);
 
         $passedStores = $request->input('stores');
-        if (!$passedStores) {
+        if (! $passedStores) {
             return $this->updateSearchable($model, $request->input('ids'));
         }
 
@@ -43,14 +41,14 @@ class IndexController
     public function destroy(string $model, Request $request)
     {
         $request->validate([
-            'ids' => 'array|required',
+            'ids'   => 'array|required',
             'ids.*' => 'integer',
         ]);
 
-        abort_if(!($model = $this->resolveModel($model)), 404);
+        abort_if(! ($model = $this->resolveModel($model)), 404);
 
         $passedStores = $request->input('stores');
-        if (!$passedStores) {
+        if (! $passedStores) {
             return $this->deleteSearchable($model, $request->input('ids'));
         }
 
@@ -80,7 +78,7 @@ class IndexController
 
     protected function updateSearchable(string $model, array $ids): void
     {
-        $query = $model::where(fn($query) => $model::makeAllSearchableUsing($query));
+        $query = $model::where(fn ($query) => $model::makeAllSearchableUsing($query));
 
         if (empty($ids)) {
             $query->searchable();
@@ -93,7 +91,7 @@ class IndexController
     {
         $modelClass = Arr::get(config('rapidez.models'), $model);
 
-        if (!$modelClass || !in_array(Searchable::class, class_uses_recursive($modelClass))) {
+        if (! $modelClass || ! in_array(Searchable::class, class_uses_recursive($modelClass))) {
             return null;
         }
 

--- a/src/Http/Controllers/IndexController.php
+++ b/src/Http/Controllers/IndexController.php
@@ -20,7 +20,9 @@ class IndexController
 
         $passedStores = $request->input('stores');
         if (! $passedStores) {
-            return $this->updateSearchable($model, $request->input('ids'));
+            $this->updateSearchable($model, $request->input('ids'));
+
+            return;
         }
 
         $passedStores = Arr::wrap($passedStores);
@@ -49,7 +51,9 @@ class IndexController
 
         $passedStores = $request->input('stores');
         if (! $passedStores) {
-            return $this->deleteSearchable($model, $request->input('ids'));
+            $this->deleteSearchable($model, $request->input('ids'));
+
+            return;
         }
 
         $passedStores = Arr::wrap($passedStores);

--- a/src/Http/Controllers/IndexController.php
+++ b/src/Http/Controllers/IndexController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Rapidez\Core\Http\Controllers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Rapidez\Core\Facades\Rapidez;
+use Rapidez\Core\Models\Traits\Searchable;
+use ReflectionMethod;
+
+class IndexController
+{
+    public function store(string $model, Request $request)
+    {
+        $request->validate([
+            'ids' => 'array|required',
+            'ids.*' => 'integer',
+        ]);
+
+        abort_if(!($model = $this->resolveModel($model)), 404);
+
+        $passedStores = $request->input('stores');
+        if (!$passedStores) {
+            return $this->updateSearchable($model, $request->input('ids'));
+        }
+
+        $passedStores = Arr::wrap($passedStores);
+
+        if ($passedStores[0] === 'all' || $passedStores[0] === '*') {
+            $stores = Rapidez::getStores();
+        } else {
+            $stores = Rapidez::getStores($passedStores);
+        }
+
+        foreach ($stores as $store) {
+            Rapidez::setStore($store);
+
+            $this->updateSearchable($model, $request->input('ids'));
+        }
+    }
+
+    public function destroy(string $model, Request $request)
+    {
+        $request->validate([
+            'ids' => 'array|required',
+            'ids.*' => 'integer',
+        ]);
+
+        abort_if(!($model = $this->resolveModel($model)), 404);
+
+        $passedStores = $request->input('stores');
+        if (!$passedStores) {
+            return $this->deleteSearchable($model, $request->input('ids'));
+        }
+
+        $passedStores = Arr::wrap($passedStores);
+
+        if ($passedStores[0] === 'all' || $passedStores[0] === '*') {
+            $stores = Rapidez::getStores();
+        } else {
+            $stores = Rapidez::getStores($passedStores);
+        }
+
+        foreach ($stores as $store) {
+            Rapidez::setStore($store);
+
+            $this->deleteSearchable($model, $request->input('ids'));
+        }
+    }
+
+    protected function deleteSearchable(string $model, array $ids): void
+    {
+        if (empty($ids)) {
+            $model::unsearchable();
+        } else {
+            $model::whereIn((new $model)->getQualifiedKeyName(), $ids)->unsearchable();
+        }
+    }
+
+    protected function updateSearchable(string $model, array $ids): void
+    {
+        $query = $model::where(fn($query) => $model::makeAllSearchableUsing($query));
+
+        if (empty($ids)) {
+            $query->searchable();
+        } else {
+            $query->whereIn((new $model)->getQualifiedKeyName(), $ids)->searchable();
+        }
+    }
+
+    protected function resolveModel(string $model): ?string
+    {
+        $modelClass = Arr::get(config('rapidez.models'), $model);
+
+        if (!$modelClass || !in_array(Searchable::class, class_uses_recursive($modelClass))) {
+            return null;
+        }
+
+        return $modelClass;
+    }
+}

--- a/src/Listeners/UpdateLatestIndexDate.php
+++ b/src/Listeners/UpdateLatestIndexDate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rapidez\Core\Listeners;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Rapidez\Core\Events\IndexAfterEvent;
+
+class UpdateLatestIndexDate
+{
+    public function handle()
+    {
+        return Storage::disk('local')->put(
+            '/.last-index',
+            // With this we're just making sure the comparison
+            // is done within the same timezone in MySQL.
+            DB::selectOne('SELECT NOW() AS `current_time`')->current_time
+        );
+    }
+
+    public static function register()
+    {
+        Event::listen(IndexAfterEvent::class, static::class);
+    }
+}

--- a/src/Listeners/UpdateLatestIndexDate.php
+++ b/src/Listeners/UpdateLatestIndexDate.php
@@ -15,7 +15,7 @@ class UpdateLatestIndexDate
             '/.last-index',
             // With this we're just making sure the comparison
             // is done within the same timezone in MySQL.
-            DB::selectOne('SELECT NOW() AS `current_time`')->current_time
+            DB::scalar('SELECT NOW()')
         );
     }
 

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -20,6 +20,7 @@ use Rapidez\Core\Auth\MagentoCustomerTokenGuard;
 use Rapidez\Core\Commands\IndexCommand;
 use Rapidez\Core\Commands\InstallCommand;
 use Rapidez\Core\Commands\InstallTestsCommand;
+use Rapidez\Core\Commands\UpdateIndexCommand;
 use Rapidez\Core\Commands\ValidateCommand;
 use Rapidez\Core\Events\ProductViewEvent;
 use Rapidez\Core\Facades\Rapidez as RapidezFacade;
@@ -32,6 +33,7 @@ use Rapidez\Core\Listeners\Healthcheck\ElasticsearchHealthcheck;
 use Rapidez\Core\Listeners\Healthcheck\MagentoSettingsHealthcheck;
 use Rapidez\Core\Listeners\Healthcheck\ModelsHealthcheck;
 use Rapidez\Core\Listeners\ReportProductView;
+use Rapidez\Core\Listeners\UpdateLatestIndexDate;
 use Rapidez\Core\ViewComponents\PlaceholderComponent;
 use Rapidez\Core\ViewDirectives\WidgetDirective;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -87,6 +89,7 @@ class RapidezServiceProvider extends ServiceProvider
     {
         $this->commands([
             IndexCommand::class,
+            UpdateIndexCommand::class,
             ValidateCommand::class,
             InstallCommand::class,
             InstallTestsCommand::class,
@@ -230,6 +233,7 @@ class RapidezServiceProvider extends ServiceProvider
         ModelsHealthcheck::register();
         MagentoSettingsHealthcheck::register();
         ElasticsearchHealthcheck::register();
+        UpdateLatestIndexDate::register();
 
         return $this;
     }


### PR DESCRIPTION
This PR adds API endpoints to Rapidez to partially reindex searchable models

By default calling the index controller (`api/admin/index/product`) will result in it updating only for the current store.
Stores can be manually set using `{"stores": [1,2,3]}` or to reindex all stores in 1 api call `{"stores": "*"}`

You are required to add "ids" to the request, this will use the qualifiedKeyName so it does not matter wether the database has `entity_id`, `id`, `order_id`, etc. as primary key

There's also a new command `rapidez:index:update` which aims to update changed data on the current index.
It can only be called if the full indexer has been run since it will not create a new index.
And it will not remove from the index. That is what the API endpoint, or the full indexer is meant for.

docs: https://github.com/rapidez/docs/pull/89