### PR TITLE
[2.x] Use the current version of fetch instead of a cached version

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -26,14 +26,12 @@ export class SessionExpired extends FetchError {
 }
 window.SessionExpired = SessionExpired
 
-export const rapidezFetch = (window.rapidezFetch = ((originalFetch) => {
-    return (...args) => {
-        const result = originalFetch.apply(this, args)
-        addFetch(result)
+export const rapidezFetch = (window.rapidezFetch = (...args) => {
+    const result = originalFetch.apply(this, args)
+    addFetch(result)
 
-        return result
-    }
-})(fetch))
+    return result
+})
 
 export const rapidezAPI = (window.rapidezAPI = async (method, endpoint, data = {}, options = {}) => {
     let response = await rapidezFetch(window.url('/api/' + endpoint.replace(/^\/+/, '')), {


### PR DESCRIPTION
See: #829