### PR TITLE
[Instantsearch] Fix closing tag on items breaking some elements

### DIFF
--- a/resources/views/components/highlight.blade.php
+++ b/resources/views/components/highlight.blade.php
@@ -5,7 +5,7 @@
         'v-bind:hit' => $item,
         'attribute' => $attribute,
         'highlighted-tag-name' => $highlightTag,
-    ]) }}/>
+    ]) }}></ais-highlight>
 @else
     <span {{ $attributes }} v-text="{{ $item }}.{{ $attribute }}"></span>
 @endif


### PR DESCRIPTION
Apparently you can't self-close the ais-highlight tag, or it will break anything that comes after it in the same div. Weird. Either way, fixed that here, allowing for swatchless prices and reviews to be shown again.