### PR TITLE
[Instantsearch] Allow setting of mappings & settings per index for individual models

### DIFF
--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -20,7 +20,7 @@ class IndexCommand extends Command
             ->filter(fn ($class) => in_array(Searchable::class, class_uses_recursive($class)));
 
         $types = $this->option('types')
-            ? $baseSearchableModels->filter(fn ($model) => in_array($model::indexName(), explode(',', $this->option('types'))))
+            ? $baseSearchableModels->filter(fn ($model) => in_array($model::getIndexName(), explode(',', $this->option('types'))))
             : $baseSearchableModels;
 
         $stores = $this->option('store')

--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -36,7 +36,15 @@ class IndexCommand extends Command
 
             $this->line('Store: ' . $store['name']);
 
-            foreach ($types as $type => $model) {
+            foreach ($types as $model) {
+                $searchableAs = (new $model)->searchableAs();
+                if ($model::getIndexMappings()) {
+                    config()->set('elasticsearch.indices.mappings.' . $searchableAs, $model::getIndexMappings());
+                }
+                if ($model::getIndexSettings()) {
+                    config()->set('elasticsearch.indices.settings.' . $searchableAs, $model::getIndexSettings());
+                }
+
                 $this->call('scout:import', [
                     'searchable' => $model,
                 ]);

--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -20,7 +20,7 @@ class IndexCommand extends Command
             ->filter(fn ($class) => in_array(Searchable::class, class_uses_recursive($class)));
 
         $types = $this->option('types')
-            ? $baseSearchableModels->filter(fn ($model) => in_array((new $model)->getIndexName(), explode(',', $this->option('types'))))
+            ? $baseSearchableModels->filter(fn ($model) => in_array($model::indexName(), explode(',', $this->option('types'))))
             : $baseSearchableModels;
 
         $stores = $this->option('store')

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . (new static)->getIndexName() . '.mapping', [
+        return Eventy::filter('index.' . static::indexName() . '.mapping', [
             'properties' => [
                 'price' => [
                     'type' => 'double',

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -119,4 +119,27 @@ trait Searchable
 
         return $data;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getIndexMappings(): ?array
+    {
+        return [
+            'properties' => [
+                'price' => [
+                    'type' => 'double',
+                ],
+                'children' => [
+                    'type' => 'flattened',
+                ],
+                'grouped' => [
+                    'type' => 'flattened',
+                ],
+                'positions' => [
+                    'type' => 'flattened',
+                ],
+            ],
+        ];
+    }
 }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::indexName() . '.mapping', [
+        return Eventy::filter('index.' . static::getIndexName() . '.mapping', [
             'properties' => [
                 'price' => [
                     'type' => 'double',

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.mapping', [
+        return array_merge([
             'properties' => [
                 'price' => [
                     'type' => 'double',
@@ -140,6 +140,6 @@ trait Searchable
                     'type' => 'flattened',
                 ],
             ],
-        ]);
+        ], parent::getIndexMappings());
     }
 }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return [
+        return Eventy::filter('index.' . (new static)->getIndexName() . '.mapping', [
             'properties' => [
                 'price' => [
                     'type' => 'double',
@@ -140,6 +140,6 @@ trait Searchable
                     'type' => 'flattened',
                 ],
             ],
-        ];
+        ]);
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -40,11 +40,11 @@ trait Searchable
 
     public static function getIndexMappings(): ?array
     {
-        return null;
+        return Eventy::filter('index.' . (new static)->getIndexName() . '.mapping', null);
     }
 
     public static function getIndexSettings(): ?array
     {
-        return null;
+        return Eventy::filter('index.' . (new static)->getIndexName() . '.settings', null);
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -29,6 +29,12 @@ trait Searchable
         return $this->indexName ?? Str::snake(Str::pluralStudly(class_basename(static::class)));
     }
 
+    public static function indexName(): string
+    {
+        // @phpstan-ignore-next-line
+        return (new static)->getIndexName();
+    }
+
     public function searchableAs(): string
     {
         return implode('_', array_values([
@@ -40,11 +46,11 @@ trait Searchable
 
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . (new static)->getIndexName() . '.mapping', null);
+        return Eventy::filter('index.' . static::indexName() . '.mapping', null);
     }
 
     public static function getIndexSettings(): ?array
     {
-        return Eventy::filter('index.' . (new static)->getIndexName() . '.settings', null);
+        return Eventy::filter('index.' . static::indexName() . '.settings', null);
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -10,7 +10,7 @@ trait Searchable
 {
     use ScoutSearchable;
 
-    public ?string $indexName;
+    public static ?string $indexName;
 
     /**
      * {@inheritdoc}
@@ -18,39 +18,30 @@ trait Searchable
     public function toSearchableArray(): array
     {
         // TODO: Maybe use the model name here?
-        return Eventy::filter('index.' . $this->getIndexName() . '.data', $this->toArray(), $this);
+        return Eventy::filter('index.' . static::getIndexName() . '.data', $this->toArray(), $this);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIndexName(): string
+    public static function getIndexName(): string
     {
-        return $this->indexName ?? Str::snake(Str::pluralStudly(class_basename(static::class)));
-    }
-
-    public static function indexName(): string
-    {
-        // @phpstan-ignore-next-line
-        return (new static)->getIndexName();
+        return static::$indexName ?? Str::snake(Str::pluralStudly(class_basename(static::class)));
     }
 
     public function searchableAs(): string
     {
         return implode('_', array_values([
             config('scout.prefix'),
-            $this->getIndexName(),
+            static::getIndexName(),
             config('rapidez.store'),
         ]));
     }
 
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::indexName() . '.mapping', null);
+        return Eventy::filter('index.' . static::getIndexName() . '.mapping', null);
     }
 
     public static function getIndexSettings(): ?array
     {
-        return Eventy::filter('index.' . static::indexName() . '.settings', null);
+        return Eventy::filter('index.' . static::getIndexName() . '.settings', null);
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -37,4 +37,14 @@ trait Searchable
             config('rapidez.store'),
         ]));
     }
+
+    public static function getIndexMappings(): ?array
+    {
+        return null;
+    }
+
+    public static function getIndexSettings(): ?array
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Removes the need to overwrite the `elasticsearch.php` config file just to change these.