### PR TITLE
[3.x] Merge the frontend config for all translations within a rapidez namespace

### DIFF
--- a/src/Actions/CollectFrontendTranslations.php
+++ b/src/Actions/CollectFrontendTranslations.php
@@ -14,34 +14,32 @@ class CollectFrontendTranslations
         $translator = app(Translator::class);
         $loader = $translator->getLoader();
 
-        $allTranslations = [];;
-
         $allTranslations = collect($loader->namespaces())
             ->filter(function (string $path, string $namespace): bool {
                 return str($namespace)->startsWith('rapidez');
             })->map(function (string $path, string $namespace): array {
-            $file = $path . '/' . App::getLocale() . '/frontend.php';
+                $file = $path . '/' . App::getLocale() . '/frontend.php';
 
-            if (File::exists($file)) {
-                $translations = collect(File::getRequire($file));
+                if (File::exists($file)) {
+                    $translations = collect(File::getRequire($file));
 
-                if ($namespace !== 'rapidez') {
-                    return [
-                        'packages' => [
-                            str($namespace)->after('rapidez-')->toString() => $translations->toArray(),
-                        ],
-                    ];
+                    if ($namespace !== 'rapidez') {
+                        return [
+                            'packages' => [
+                                str($namespace)->after('rapidez-')->toString() => $translations->toArray(),
+                            ],
+                        ];
+                    }
+
+                    return $translations->toArray();
                 }
 
-                return $translations->toArray();
-            }
-
-            return [];
-        })
-        ->filter()
-        ->reduce(function (array $allTranslations, array $translations): array {
-            return array_merge_recursive($allTranslations, $translations);
-        }, []);
+                return [];
+            })
+            ->filter()
+            ->reduce(function (array $allTranslations, array $translations): array {
+                return array_merge_recursive($allTranslations, $translations);
+            }, []);
 
         return $allTranslations;
     }

--- a/src/Actions/CollectFrontendTranslations.php
+++ b/src/Actions/CollectFrontendTranslations.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rapidez\Core\Actions;
+
+use Illuminate\Translation\Translator;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\File;
+
+class CollectFrontendTranslations
+{
+    public static function collect(): array
+    {
+        /** @var Translator $translator */
+        $translator = app(Translator::class);
+        $loader = $translator->getLoader();
+
+        $allTranslations = [];;
+
+        $allTranslations = collect($loader->namespaces())
+            ->filter(function (string $path, string $namespace): bool {
+                return str($namespace)->startsWith('rapidez');
+            })->map(function (string $path, string $namespace): array {
+            $file = $path . '/' . App::getLocale() . '/frontend.php';
+
+            if (File::exists($file)) {
+                $translations = collect(File::getRequire($file));
+
+                if ($namespace !== 'rapidez') {
+                    return [
+                        'packages' => [
+                            str($namespace)->after('rapidez-')->toString() => $translations->toArray(),
+                        ],
+                    ];
+                }
+
+                return $translations->toArray();
+            }
+
+            return [];
+        })
+        ->filter()
+        ->reduce(function (array $allTranslations, array $translations): array {
+            return array_merge_recursive($allTranslations, $translations);
+        }, []);
+
+        return $allTranslations;
+    }
+}

--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Rapidez\Core\Actions\CollectFrontendTranslations;
 use Rapidez\Core\Facades\Rapidez;
 
 class ConfigComposer
@@ -63,7 +64,7 @@ class ConfigComposer
             'cachekey'             => Cache::rememberForever('cachekey', fn () => md5(Str::random())),
             'redirect_cart'        => (bool) Rapidez::config('checkout/cart/redirect_to_cart'),
             'show_swatches'        => (bool) Rapidez::config('catalog/frontend/show_swatches_in_product_list'),
-            'translations'         => __('rapidez::frontend'),
+            'translations'         => CollectFrontendTranslations::collect(),
             'recaptcha'            => Rapidez::config('recaptcha_frontend/type_recaptcha_v3/public_key', null, true),
             'searchable'           => array_merge($searchableAttributes, config('rapidez.indexer.searchable')),
             'street_lines'         => Rapidez::config('customer/address/street_lines'),


### PR DESCRIPTION
This code will get every translation that is defined in a 'rapidez-*' namepsace within a frontend.php file. This will allow packages to add frontend translations with ease. 

Docs; incoming