### PR TITLE
Listing default product index

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -7,7 +7,7 @@ export default {
     props: {
         index: {
             type: String,
-            default: window.config.index.product
+            default: window.config.index.product,
         },
         query: {
             type: Function,

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -5,14 +5,10 @@ import InstantSearchMixin from '../Search/InstantSearchMixin.vue'
 export default {
     mixins: [InstantSearchMixin],
     props: {
-        configCallback: {
-            type: Function,
-        },
         index: {
             type: String,
+            default: window.config.index.product
         },
-
-        // TODO: Document these four props in the Rapidez docs
         query: {
             type: Function,
         },
@@ -25,6 +21,9 @@ export default {
         },
         filterQueryString: {
             type: String,
+        },
+        configCallback: {
+            type: Function,
         },
     },
 

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -8,7 +8,6 @@
 <div class="min-h-screen">
     <listing
         {{ $attributes }}
-        v-bind:index="config.index.product"
         v-slot="{ loaded, index, searchClient, rangeAttributes, categoryAttributes, hitsPerPage, filters, sortOptions, withFilters, withSwatches, routing }"
         v-cloak
     >

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -4,9 +4,8 @@
     <lazy v-slot="{ intersected }">
         <listing
             v-if="intersected"
-            :index="config.index.product"
-            v-cloak
             v-slot="{ loaded, index, searchClient }"
+            v-cloak
         >
             <div>
                 <ais-instant-search


### PR DESCRIPTION
99% it will be the product index, so having that as default. Also changed the props order to be inline with the docs and importance: https://github.com/rapidez/docs/commit/67e168141d9f07161b17d410eb596f325a40eb01#diff-c4bd4e225533416f9d38a25dec4e436684cfc7a49bf4477df9db229445560d54R170-R188