### PR TITLE
[Instantsearch] Fix reset filters always showing & category filter jumping

### DIFF
--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -12,11 +12,7 @@
                 </x-slot:title>
                 <recursion :data="items" v-slot="{ data, components }">
                     <ul>
-                        <li
-                            class="pl-3"
-                            v-for="(item, index) in data"
-                            :key="item.value"
-                        >
+                        <li class="pl-3" v-for="(item, index) in data" :key="item.value">
                             <a
                                 :href="createURL(item.value)"
                                 :class="{ 'font-bold': item.isRefined }"

--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -1,5 +1,6 @@
 <ais-hierarchical-menu
     v-bind:attributes="categoryAttributes"
+    v-bind:sort-by="['count','name']"
     @attributes(['root-path' => $rootPath])
     show-more
 >
@@ -11,7 +12,11 @@
                 </x-slot:title>
                 <recursion :data="items" v-slot="{ data, components }">
                     <ul>
-                        <li class="pl-3" v-for="(item, index) in data" :key="item.value">
+                        <li
+                            class="pl-3"
+                            v-for="(item, index) in data"
+                            :key="item.value"
+                        >
                             <a
                                 :href="createURL(item.value)"
                                 :class="{ 'font-bold': item.isRefined }"

--- a/resources/views/listing/partials/filter/selected.blade.php
+++ b/resources/views/listing/partials/filter/selected.blade.php
@@ -1,4 +1,4 @@
-<ais-clear-refinements>
+<ais-clear-refinements v-bind:excluded-attributes="[...categoryAttributes, 'query']">
     <template v-slot="{ canRefine, refine, createURL }">
         <div v-show="canRefine" class="flex flex-wrap items-baseline justify-between gap-2 w-full pb-2">
             <div class="font-semibold text-base">
@@ -6,6 +6,7 @@
             </div>
             <a
                 v-bind:href="createURL()"
+                v-if="canRefine"
                 v-on:click.prevent="refine"
                 class="text-sm text-muted transition-all hover:underline"
             >


### PR DESCRIPTION
Category filter jumping was caused by it sorting in such a way that the selected category was shown first if there were multiple categories with the same amount of items. I've changed it to instead always sort alphabetically for categories with the same amount of items.