### PR TITLE
[2.x] Use queryParams function instead of as variable

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -45,7 +45,7 @@ export default {
     mounted() {
         this.loaded = Object.keys(this.attributes).length > 0
         if (this.isSearchPage) {
-            document.title = config.translations.search.title + ': ' + this.$root.queryParams.get('q')
+            document.title = config.translations.search.title + ': ' + this.$root.queryParams().get('q')
         }
     },
 

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -88,7 +88,7 @@ export default {
                 .concat(this.additionalSorting)
         },
         isSearchPage: function () {
-            return this.$root.queryParams.has('q')
+            return this.$root.queryParams().has('q')
         },
     },
     watch: {


### PR DESCRIPTION
Because this is a method, and not a computed value (I'd assume because `window.location.search` is not a reactive variable), it's a function to call like this.