### PR TITLE
Input type number remove Firefox arrows

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,12 +29,12 @@ listing {
 }
 
 /* Remove default browser arrows for input type="number" */
-input[type='number']::-webkit-inner-spin-button,
-input[type='number']::-webkit-outer-spin-button {
+.arrows-hidden[type='number']::-webkit-inner-spin-button,
+.arrows-hidden[type='number']::-webkit-outer-spin-button {
     @apply appearance-none m-0;
 }
 
 /* Firefox */
-input[type='number'] {
+.arrows-hidden[type='number'] {
     -moz-appearance: textfield;
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -33,3 +33,8 @@ input[type='number']::-webkit-inner-spin-button,
 input[type='number']::-webkit-outer-spin-button {
     @apply appearance-none m-0;
 }
+
+/* Firefox */
+input[type=number] {
+    -moz-appearance: textfield;
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -35,6 +35,6 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 /* Firefox */
-input[type=number] {
+input[type='number'] {
     -moz-appearance: textfield;
 }

--- a/resources/views/components/quantity.blade.php
+++ b/resources/views/components/quantity.blade.php
@@ -19,7 +19,7 @@ is present on the input and the quantity select component.
             type="number"
             dusk="qty"
             value="1"
-            class="outline-0 ring-0 border-none w-12 bg-transparent font-medium text-center px-0 sm:text-base focus:ring-transparent"
+            class="outline-0 ring-0 border-none w-12 bg-transparent font-medium text-center px-0 sm:text-base focus:ring-transparent arrows-hidden"
             aria-label="@lang('Quantity')"
             {{ $attributes }}
         />


### PR DESCRIPTION
Removed arrows in type number on Firefox
<img width="214" alt="Scherm­afbeelding 2025-05-09 om 15 59 11" src="https://github.com/user-attachments/assets/7302abbc-c8c5-48a0-b2dd-e56306d0c323" />

