### PR TITLE
[Instantsearch] Go back to filter method because parent:: doesn't work for trait inheritance

### DIFF
--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -7,6 +7,7 @@ use Rapidez\Core\Events\IndexAfterEvent;
 use Rapidez\Core\Events\IndexBeforeEvent;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Traits\Searchable;
+use TorMorten\Eventy\Facades\Eventy;
 
 class IndexCommand extends Command
 {
@@ -38,11 +39,15 @@ class IndexCommand extends Command
 
             foreach ($types as $model) {
                 $searchableAs = (new $model)->searchableAs();
-                if ($model::getIndexMappings()) {
-                    config()->set('elasticsearch.indices.mappings.' . $searchableAs, $model::getIndexMappings());
+
+                $indexMappings = Eventy::filter('index.' . $model::getIndexName() . '.mapping', $model::getIndexMappings());
+                if ($indexMappings) {
+                    config()->set('elasticsearch.indices.mappings.' . $searchableAs, $indexMappings);
                 }
-                if ($model::getIndexSettings()) {
-                    config()->set('elasticsearch.indices.settings.' . $searchableAs, $model::getIndexSettings());
+
+                $indexSettings = Eventy::filter('index.' . $model::getIndexName() . '.settings', $model::getIndexSettings());
+                if ($indexSettings) {
+                    config()->set('elasticsearch.indices.settings.' . $searchableAs, $indexSettings);
                 }
 
                 $this->call('scout:import', [

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.mapping', [
+        return [
             'properties' => [
                 'price' => [
                     'type' => 'double',
@@ -140,6 +140,6 @@ trait Searchable
                     'type' => 'flattened',
                 ],
             ],
-        ]) ?: null;
+        ];
     }
 }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,7 +125,7 @@ trait Searchable
      */
     public static function getIndexMappings(): ?array
     {
-        return array_merge([
+        return Eventy::filter('index.' . static::getIndexName() . '.mapping', [
             'properties' => [
                 'price' => [
                     'type' => 'double',
@@ -140,6 +140,6 @@ trait Searchable
                     'type' => 'flattened',
                 ],
             ],
-        ], parent::getIndexMappings());
+        ]) ?: null;
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -37,11 +37,11 @@ trait Searchable
 
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.mapping', null) ?: null;
+        return null;
     }
 
     public static function getIndexSettings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.settings', null) ?: null;
+        return null;
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -37,11 +37,11 @@ trait Searchable
 
     public static function getIndexMappings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.mapping', null);
+        return Eventy::filter('index.' . static::getIndexName() . '.mapping', null) ?: null;
     }
 
     public static function getIndexSettings(): ?array
     {
-        return Eventy::filter('index.' . static::getIndexName() . '.settings', null);
+        return Eventy::filter('index.' . static::getIndexName() . '.settings', null) ?: null;
     }
 }


### PR DESCRIPTION
There is a hacky workaround, where you instantiate a new class that has this parent trait (but not this trait) and then call the static function on that. However, that's obviously not a good solution here.

So, instead I've factored the filters out to the index command. I'm not sure if we should keep them within the trait so it can be used elsewhere? Given that it's index-specific I can't imagine any use case outside of it anyway.