### PR TITLE
Added search history in autocomplete

### DIFF
--- a/config/rapidez/frontend.php
+++ b/config/rapidez/frontend.php
@@ -31,6 +31,7 @@ return [
         // Attach additional indexes to the autocomplete
         // Uses the views in rapidez::layouts.partials.header.autocomplete
         'additionals' => [
+            'history' => [],
             'categories' => [],
 
             // For example:

--- a/config/rapidez/frontend.php
+++ b/config/rapidez/frontend.php
@@ -31,7 +31,7 @@ return [
         // Attach additional indexes to the autocomplete
         // Uses the views in rapidez::layouts.partials.header.autocomplete
         'additionals' => [
-            'history' => [],
+            'history'    => [],
             'categories' => [],
 
             // For example:

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -106,6 +106,7 @@
     "Total": "Totaal",
     "Update": "Update",
     "Use other search terms": "Andere zoektermen te gebruiken",
+    "Previous Searches": "Vorige zoekopdrachten",
     "View all products": "Bekijk alle producten",
     "Want product news and updates?": "Wil je productnieuws en updates?",
     "We care about the protection of your data. Read our": "Wij geven om de bescherming van uw gegevens. Lees onze",

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -9,6 +9,7 @@ import SearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js
 import Index from 'vue-instantsearch/vue2/es/src/components/Index.js'
 import { useDebounceFn } from '@vueuse/core'
 import { rapidezAPI } from '../../fetch'
+import { searchHistory } from '../../stores/useSearchHistory'
 
 export default {
     mixins: [InstantSearchMixin],
@@ -52,6 +53,13 @@ export default {
         })
     },
 
+    computed: {
+        searchHistory() {
+            return Object.entries(searchHistory.value).sort((a, b) => {
+                return Date.parse(b[1].lastSearched) - Date.parse(a[1].lastSearched)
+            })
+        },
+    },
     methods: {
         async initSearchClient() {
             const client = await InstantSearchMixin.methods.initSearchClient.bind(this).call()

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -53,6 +53,15 @@ export default {
                     insightsClient: null,
                     onEvent: (event) => {
                         this.$emit('insights-event:' + event.insightsMethod, event)
+                        this.$el.dispatchEvent(
+                            new CustomEvent(
+                                'insights-event:' + event.insightsMethod,
+                                {
+                                    bubbles: true,
+                                    detail: { insightsEvent: event }
+                                }
+                            )
+                        )
                     },
                 }),
                 ...this.getMiddlewares(),

--- a/resources/js/components/Search/InstantSearchMixin.vue
+++ b/resources/js/components/Search/InstantSearchMixin.vue
@@ -54,13 +54,10 @@ export default {
                     onEvent: (event) => {
                         this.$emit('insights-event:' + event.insightsMethod, event)
                         this.$el.dispatchEvent(
-                            new CustomEvent(
-                                'insights-event:' + event.insightsMethod,
-                                {
-                                    bubbles: true,
-                                    detail: { insightsEvent: event }
-                                }
-                            )
+                            new CustomEvent('insights-event:' + event.insightsMethod, {
+                                bubbles: true,
+                                detail: { insightsEvent: event },
+                            }),
                         )
                     },
                 }),

--- a/resources/js/instantsearch.js
+++ b/resources/js/instantsearch.js
@@ -29,17 +29,20 @@ document.addEventListener('insights-event:viewedObjectIDs', (event) => {
             return
         }
 
-        let url = new URL(window.location.href);
-        if (url.pathname !== '/search' || !url.searchParams.has('q') || url.searchParams.get('q') !== event.detail.insightsEvent.payload.query) {
+        let url = new URL(window.location.href)
+        if (
+            url.pathname !== '/search' ||
+            !url.searchParams.has('q') ||
+            url.searchParams.get('q') !== event.detail.insightsEvent.payload.query
+        ) {
             // Do not track autocomplete
-            return;
+            return
         }
 
         if (event.detail.insightsEvent.payload.nbHits < 1) {
-            return;
+            return
         }
 
-        addQuery(event.detail.insightsEvent.payload.query, {hits: event.detail.insightsEvent.payload.nbHits})
+        addQuery(event.detail.insightsEvent.payload.query, { hits: event.detail.insightsEvent.payload.nbHits })
     })
 })
-

--- a/resources/js/instantsearch.js
+++ b/resources/js/instantsearch.js
@@ -1,3 +1,5 @@
+import { addQuery } from './stores/useSearchHistory'
+
 // Shared between Autocomplete and Listing
 Vue.component('ais-instant-search', () => import('vue-instantsearch/vue2/es/src/components/InstantSearch'))
 Vue.component('ais-hits', () => import('vue-instantsearch/vue2/es/src/components/Hits.js'))
@@ -20,3 +22,24 @@ Vue.component('ais-sort-by', () => import('vue-instantsearch/vue2/es/src/compone
 Vue.component('ais-pagination', () => import('vue-instantsearch/vue2/es/src/components/Pagination.vue.js'))
 Vue.component('ais-stats', () => import('vue-instantsearch/vue2/es/src/components/Stats.vue.js'))
 Vue.component('ais-stats-analytics', () => import('./components/Search/AisStatsAnalytics.vue'))
+
+document.addEventListener('insights-event:viewedObjectIDs', (event) => {
+    setTimeout(() => {
+        if (event?.detail?.insightsEvent?.eventType !== 'search') {
+            return
+        }
+
+        let url = new URL(window.location.href);
+        if (url.pathname !== '/search' || !url.searchParams.has('q') || url.searchParams.get('q') !== event.detail.insightsEvent.payload.query) {
+            // Do not track autocomplete
+            return;
+        }
+
+        if (event.detail.insightsEvent.payload.nbHits < 1) {
+            return;
+        }
+
+        addQuery(event.detail.insightsEvent.payload.query, {hits: event.detail.insightsEvent.payload.nbHits})
+    })
+})
+

--- a/resources/js/stores/useSearchHistory.js
+++ b/resources/js/stores/useSearchHistory.js
@@ -1,0 +1,30 @@
+import { useLocalStorage } from '@vueuse/core'
+
+/**
+ * @typedef {Object} SearchHistory
+ * {
+ *  [query: string]: {
+ *    count: number,
+ *    lastSearched: string,
+ *    hits: number,
+ * }
+ */
+export const searchHistory = useLocalStorage('search_history', {})
+
+export const addQuery = (query, metadata = {}) => {
+    query = query.toLowerCase();
+    Vue.set(searchHistory.value, query, {
+        ...searchHistory.value[query],
+        count: (searchHistory.value[query]?.count || 0) + 1,
+        lastSearched: new Date().toISOString(),
+        ...metadata,
+    })
+}
+
+export const removeQuery = (query) => {
+    if (searchHistory.value[query]) {
+        delete searchHistory.value[query]
+    }
+}
+
+export default () => searchHistory

--- a/resources/js/stores/useSearchHistory.js
+++ b/resources/js/stores/useSearchHistory.js
@@ -12,7 +12,7 @@ import { useLocalStorage } from '@vueuse/core'
 export const searchHistory = useLocalStorage('search_history', {})
 
 export const addQuery = (query, metadata = {}) => {
-    query = query.toLowerCase();
+    query = query.toLowerCase()
     Vue.set(searchHistory.value, query, {
         ...searchHistory.value[query],
         count: (searchHistory.value[query]?.count || 0) + 1,

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -44,6 +44,7 @@ Vue.component('autocomplete', () => ({
         data: () => ({
             loaded: false,
             searchClient: null,
+            searchHistory: {},
         }),
 
         render() {

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,4 +1,4 @@
-<autocomplete v-on:mounted="() => window.document.getElementById('autocomplete-input').focus()" v-slot="{ searchClient, middlewares }">
+<autocomplete v-on:mounted="() => window.document.getElementById('autocomplete-input').focus()" v-slot="{ searchClient, middlewares, searchHistory }">
     <div class="relative w-full">
         <ais-instant-search
             v-if="searchClient"
@@ -10,7 +10,7 @@
         >
             <div class="contents">
                 <ais-configure :hits-per-page.camel="{{ config('rapidez.frontend.autocomplete.size', 3) }}" />
-                <div class="searchbox">
+                <div class="searchbox group/autocomplete">
                     <ais-search-box>
                         <template v-slot="{ currentRefinement, isSearchStalled, refine }">
                             <x-rapidez::autocomplete.input
@@ -20,8 +20,9 @@
                                     $root.autocompleteFacadeQuery = null;
                                 }"
                                 v-on:input="refine($event.currentTarget.value)"
+                                list="search-history"
                             />
-                            <div v-if="currentRefinement" class="absolute inset-x-0 top-full mt-1 bg-white border rounded-md z-header-autocomplete">
+                            <div v-bind:class="{hidden: !currentRefinement}" class="absolute inset-x-0 top-full mt-1 bg-white border rounded-md z-header-autocomplete group-has-[:focus]/autocomplete:block hover:block">
                                 @include('rapidez::layouts.partials.header.autocomplete.results')
                             </div>
                             <div v-if="currentRefinement" v-on:click="refine('')" class="fixed inset-0 bg-backdrop z-header-autocomplete-overlay"></div>

--- a/resources/views/layouts/partials/header/autocomplete/history.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/history.blade.php
@@ -1,0 +1,28 @@
+<ais-state-results v-slot="{ state: { query: searchQuery } }">
+    <div>
+        <div class="border-b p-2" v-if="searchHistory && searchHistory?.filter(([query, metadata]) => query.includes(searchQuery.toLowerCase())).length">
+            <x-rapidez::autocomplete.title>
+                @lang('Previous Searches')
+            </x-rapidez::autocomplete.title>
+            <ul class="flex flex-col font-sans">
+                <li
+                    v-for="[query, metadata] in searchHistory
+                        .filter(([query, metadata]) => query.includes(searchQuery.toLowerCase()))
+                        .slice(0, {{ Arr::get($fields, 'size', config('rapidez.frontend.autocomplete.size', 3)) }})"
+                    class="flex flex-1 items-center w-full hover:bg-muted"
+                >
+                    <a
+                        v-bind:href="'{{ route('search', ['q' => '%query%']) }}'.replaceAll('%25query%25', query)"
+                        class="relative flex items-center group w-full px-5 py-2 text-sm gap-x-4"
+                    >
+                        @{{ query }}
+                    </a>
+                </li>
+            </ul>
+            {{-- Add search suggestions to the phone's keyboard --}}
+            <datalist id="search-history" v-if="window.matchMedia('(pointer:coarse)').matches">
+                <option v-bind:value="query" v-for="[query, metadata] in searchHistory"></option>
+            </datalist>
+        </div>
+    </div>
+</ais-state-results>


### PR DESCRIPTION
This PR adds the search history in your autocomplete.
This can be controlled and (re)moved using the frontend.php

It will listen to the global size unless overwritten in the config, it will filter the history using the current search