### PR TITLE
Reorder turbolinks startup & event to ensure teardown on first page

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -174,6 +174,7 @@ function init() {
                     document.dispatchEvent(event)
                 })
             },
+            destroyEvent: 'turbo:before-cache-timeout',
         })
 
         setTimeout(() => {
@@ -185,4 +186,7 @@ function init() {
 }
 
 document.addEventListener('turbo:load', init)
+document.addEventListener('turbo:before-cache', () =>
+    setTimeout(() => document.dispatchEvent(new CustomEvent('turbo:before-cache-timeout'))),
+)
 setTimeout(init)

--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -1,6 +1,3 @@
 import * as Turbo from '@hotwired/turbo'
 
-import TurbolinksAdapter from 'vue-turbolinks'
-Vue.use(TurbolinksAdapter)
-
 Turbo.config.drive.progressBarDelay = 5

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -1,3 +1,6 @@
+import TurbolinksAdapter from 'vue-turbolinks'
+Vue.use(TurbolinksAdapter)
+
 import Teleport from 'vue2-teleport'
 Vue.component('teleport', Teleport)
 


### PR DESCRIPTION
Due to the turbolinks.js file loading later than Vue sometimes, the teardown wouldn't happen on the first page load.

This fixes that issue