### PR TITLE
Fixed onfocus error for autocomplete

### DIFF
--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -7,6 +7,10 @@ import Configure from 'vue-instantsearch/vue2/es/src/components/Configure.js'
 import highlight from 'vue-instantsearch/vue2/es/src/components/Highlight.vue.js'
 import SearchBox from 'vue-instantsearch/vue2/es/src/components/SearchBox.vue.js'
 import Index from 'vue-instantsearch/vue2/es/src/components/Index.js'
+import Stats from 'vue-instantsearch/vue2/es/src/components/Stats.vue.js'
+import StateResults from 'vue-instantsearch/vue2/es/src/components/StateResults.vue.js'
+import StatsAnalytics from './AisStatsAnalytics.vue'
+
 import { useDebounceFn } from '@vueuse/core'
 import { rapidezAPI } from '../../fetch'
 import { searchHistory } from '../../stores/useSearchHistory'
@@ -20,15 +24,34 @@ export default {
         highlight,
         SearchBox,
         Index,
+        Stats,
+        StateResults,
+        StatsAnalytics,
+    },
+
+    data() {
+        return {
+            focusId: null,
+        }
     },
 
     render() {
         return this.$scopedSlots.default(this)
     },
-
+    created() {
+        this.focusId = document.activeElement.id
+    },
     mounted() {
         this.$nextTick(() => {
-            requestAnimationFrame(() => this.$emit('mounted'))
+            this.$emit('mounted');
+            setTimeout(() => {
+                requestAnimationFrame(() => {
+                    let element = null
+                    if (this.focusId && (element = this.$el.querySelector('#' + this.focusId))) {
+                        element?.focus()
+                    }
+                })
+            })
         })
 
         const stateChanged = useDebounceFn((event) => {

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -43,7 +43,7 @@ export default {
     },
     mounted() {
         this.$nextTick(() => {
-            this.$emit('mounted');
+            this.$emit('mounted')
             setTimeout(() => {
                 requestAnimationFrame(() => {
                     let element = null

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,4 +1,4 @@
-<autocomplete v-on:mounted="() => window.document.getElementById('autocomplete-input').focus()" v-slot="{ searchClient, middlewares, searchHistory }">
+<autocomplete v-slot="{ searchClient, middlewares, searchHistory }">
     <div class="relative w-full">
         <ais-instant-search
             v-if="searchClient"


### PR DESCRIPTION
This got caused by the v-on:mounted firing before the elements could be rendered, as they now depended on some more components to be downloaded before being rendered.
Adding them to the local components ensures they are downloaded as well before mounting the component.

This also fixes the focus happening when hovering, and navigating after the component has been mounted.