### PR TITLE
Fixed navigation on firefox

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -174,8 +174,8 @@ function init() {
                     document.dispatchEvent(event)
                 })
             },
-            // Chromium handles task scheduling differently than Firefox, so we need to use a different event for the destroy event.
-            destroyEvent: !!window.chrome ? 'turbo:before-cache-timeout' : 'turbo:before-cache',
+            // If we have view transitions, we need to make sure we destroy after render.
+            destroyEvent: !!document.startViewTransition ? 'turbo:before-cache-timeout' : 'turbo:before-cache',
         })
 
         setTimeout(() => {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -174,7 +174,8 @@ function init() {
                     document.dispatchEvent(event)
                 })
             },
-            destroyEvent: 'turbo:before-cache-timeout',
+            // Chromium handles task scheduling differently than Firefox, so we need to use a different event for the destroy event.
+            destroyEvent: !!window.chrome ? 'turbo:before-cache-timeout' : 'turbo:before-cache',
         })
 
         setTimeout(() => {


### PR DESCRIPTION
Different task scheduling between chrome and firefox would cause issues, on firefox the timeout is triggered later than on chromium.
This check will handle all chromium based browsers.

Firefox and safari seem to want the same event so we check chromium