### PR TITLE
[V3] Fixed intermittend error on autocomplete focus

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -13,7 +13,7 @@
 
 <autocomplete
     v-else
-    v-on:mounted="() => window.document.getElementById('autocomplete-input').focus()"
+    v-on:mounted="() => window.requestAnimationFrame(() => window.document.getElementById('autocomplete-input').focus())"
     v-bind:additionals="{{ json_encode(config('rapidez.frontend.autocomplete.additionals')) }}"
     v-bind:debounce="{{ config('rapidez.frontend.autocomplete.debounce') }}"
     v-bind:size="{{ config('rapidez.frontend.autocomplete.size') }}"


### PR DESCRIPTION
What i noticed was happening when the focus trigger failed was that the paint was triggered "way" later than the focus.
![image](https://github.com/user-attachments/assets/3da8d617-2e95-4108-90b9-0f62f0a13661)

Due to us triggering the focus before the task where the paint was actually done.

After adding the RequestAnimationFrame you can see the focus is triggered in the same task as the paint, allowing the element to be focussed
![image](https://github.com/user-attachments/assets/c68078e6-804c-4640-aae0-4f751b3d1e05)
