### PR TITLE
[Instantsearch] Use different driver & add synonyms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "illuminate/events": "^11.0|^12.0",
         "illuminate/queue": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
+        "jeroen-g/explorer": "^4.1",
         "justbetter/laravel-http3earlyhints": "^1.4",
         "laravel/scout": "^10.14",
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.0|^5.3",
-        "matchish/laravel-scout-elasticsearch": "^7.11",
         "rapidez/blade-components": "^1.8",
         "rapidez/blade-directives": "^1.1",
         "rapidez/laravel-multi-cache": "^2.0",
@@ -62,8 +62,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Rapidez\\Core\\RapidezServiceProvider",
-                "Matchish\\ScoutElasticSearch\\ElasticSearchServiceProvider"
+                "Rapidez\\Core\\RapidezServiceProvider"
             ],
             "aliases": {
                 "Rapidez": "Rapidez\\Core\\Facades\\Rapidez"

--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -36,7 +36,7 @@ class IndexCommand extends Command
 
             $this->line('Store: ' . $store['name']);
 
-            foreach($types as $model) {
+            foreach ($types as $model) {
                 $this->call('elastic:update', [
                     'index' => (new $model)->searchableAs(),
                 ]);

--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -7,7 +7,6 @@ use Rapidez\Core\Events\IndexAfterEvent;
 use Rapidez\Core\Events\IndexBeforeEvent;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Traits\Searchable;
-use TorMorten\Eventy\Facades\Eventy;
 
 class IndexCommand extends Command
 {
@@ -37,21 +36,9 @@ class IndexCommand extends Command
 
             $this->line('Store: ' . $store['name']);
 
-            foreach ($types as $model) {
-                $searchableAs = (new $model)->searchableAs();
-
-                $indexMappings = Eventy::filter('index.' . $model::getIndexName() . '.mapping', $model::getIndexMappings());
-                if ($indexMappings) {
-                    config()->set('elasticsearch.indices.mappings.' . $searchableAs, $indexMappings);
-                }
-
-                $indexSettings = Eventy::filter('index.' . $model::getIndexName() . '.settings', $model::getIndexSettings());
-                if ($indexSettings) {
-                    config()->set('elasticsearch.indices.settings.' . $searchableAs, $indexSettings);
-                }
-
-                $this->call('scout:import', [
-                    'searchable' => $model,
+            foreach($types as $model) {
+                $this->call('elastic:update', [
+                    'index' => (new $model)->searchableAs(),
                 ]);
             }
         }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -12,7 +12,7 @@ use Rapidez\Core\Models\Scopes\IsActiveScope;
 use Rapidez\Core\Models\Traits\HasAlternatesThroughRewrites;
 use Rapidez\Core\Models\Traits\Searchable;
 
-class Category extends Model implements Explored, IndexSettings, Aliased
+class Category extends Model implements Aliased, Explored, IndexSettings
 {
     use HasAlternatesThroughRewrites;
     use Searchable;

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -5,11 +5,14 @@ namespace Rapidez\Core\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use JeroenG\Explorer\Application\Aliased;
+use JeroenG\Explorer\Application\Explored;
+use JeroenG\Explorer\Application\IndexSettings;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
 use Rapidez\Core\Models\Traits\HasAlternatesThroughRewrites;
 use Rapidez\Core\Models\Traits\Searchable;
 
-class Category extends Model
+class Category extends Model implements Explored, IndexSettings, Aliased
 {
     use HasAlternatesThroughRewrites;
     use Searchable;

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use JeroenG\Explorer\Application\Aliased;
 use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
@@ -26,8 +27,10 @@ use Rapidez\Core\Models\Traits\Product\CastSuperAttributes;
 use Rapidez\Core\Models\Traits\Product\Searchable;
 use Rapidez\Core\Models\Traits\Product\SelectAttributeScopes;
 use TorMorten\Eventy\Facades\Eventy;
+use JeroenG\Explorer\Application\Explored;
+use JeroenG\Explorer\Application\IndexSettings;
 
-class Product extends Model
+class Product extends Model implements Explored, IndexSettings, Aliased
 {
     use CastMultiselectAttributes;
     use CastSuperAttributes;

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use JeroenG\Explorer\Application\Aliased;
+use JeroenG\Explorer\Application\Explored;
+use JeroenG\Explorer\Application\IndexSettings;
 use Rapidez\Core\Casts\Children;
 use Rapidez\Core\Casts\CommaSeparatedToArray;
 use Rapidez\Core\Casts\CommaSeparatedToIntegerArray;
@@ -27,10 +29,8 @@ use Rapidez\Core\Models\Traits\Product\CastSuperAttributes;
 use Rapidez\Core\Models\Traits\Product\Searchable;
 use Rapidez\Core\Models\Traits\Product\SelectAttributeScopes;
 use TorMorten\Eventy\Facades\Eventy;
-use JeroenG\Explorer\Application\Explored;
-use JeroenG\Explorer\Application\IndexSettings;
 
-class Product extends Model implements Explored, IndexSettings, Aliased
+class Product extends Model implements Aliased, Explored, IndexSettings
 {
     use CastMultiselectAttributes;
     use CastSuperAttributes;

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -9,7 +9,7 @@ use JeroenG\Explorer\Application\IndexSettings;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
 use Rapidez\Core\Models\Traits\Searchable;
 
-class SearchQuery extends Model implements Explored, IndexSettings, Aliased
+class SearchQuery extends Model implements Aliased, Explored, IndexSettings
 {
     use Searchable;
 

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -3,10 +3,13 @@
 namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use JeroenG\Explorer\Application\Aliased;
+use JeroenG\Explorer\Application\Explored;
+use JeroenG\Explorer\Application\IndexSettings;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
 use Rapidez\Core\Models\Traits\Searchable;
 
-class SearchQuery extends Model
+class SearchQuery extends Model implements Explored, IndexSettings, Aliased
 {
     use Searchable;
 

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -125,9 +125,9 @@ trait Searchable
     public function indexMapping(): array
     {
         return [
-            'price' => 'double',
-            'children' => 'flattened',
-            'grouped' => 'flattened',
+            'price'     => 'double',
+            'children'  => 'flattened',
+            'grouped'   => 'flattened',
             'positions' => 'flattened',
         ];
     }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -122,23 +122,21 @@ trait Searchable
     /**
      * {@inheritdoc}
      */
-    public static function getIndexMappings(): ?array
+    public function indexMapping(): array
     {
         return [
-            'properties' => [
-                'price' => [
-                    'type' => 'double',
-                ],
-                'children' => [
-                    'type' => 'flattened',
-                ],
-                'grouped' => [
-                    'type' => 'flattened',
-                ],
-                'positions' => [
-                    'type' => 'flattened',
-                ],
-            ],
+            'price' => 'double',
+            'children' => 'flattened',
+            'grouped' => 'flattened',
+            'positions' => 'flattened',
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function synonymFields(): array
+    {
+        return ['name'];
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -56,17 +56,17 @@ trait Searchable
         $synonymFields = Eventy::filter('index.' . static::getIndexName() . '.synonymfields', $this->synonymFields());
 
         $mappings = collect($synonymFields)
-            ->mapWithKeys(fn($field) => [
+            ->mapWithKeys(fn ($field) => [
                 $field => [
-                    'type' => 'text',
+                    'type'     => 'text',
                     'analyzer' => 'synonym',
-                    'fields' => [
+                    'fields'   => [
                         'keyword' => [
-                            'type' => 'keyword',
+                            'type'         => 'keyword',
                             'ignore_above' => 256,
                         ],
                     ],
-                ]
+                ],
             ])
             ->merge($this->indexMapping())
             ->toArray();
@@ -83,7 +83,7 @@ trait Searchable
             ->pluck('synonyms')
             ->toArray();
 
-        $synonymFilter = new SynonymFilter();
+        $synonymFilter = new SynonymFilter;
         $synonymFilter->setSynonyms($synonyms);
         $filters = Eventy::filter('index.' . static::getIndexName() . '.settings.filters', [$synonymFilter]);
 
@@ -91,9 +91,9 @@ trait Searchable
         $synonymAnalyzer->setFilters(['lowercase', $synonymFilter]);
         $analyzers = Eventy::filter('index.' . static::getIndexName() . '.settings.analyzers', [$synonymAnalyzer]);
 
-        $analysis = new Analysis();
+        $analysis = new Analysis;
 
-        foreach($filters as $filter) {
+        foreach ($filters as $filter) {
             $analysis->addFilter($filter);
         }
 

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -3,7 +3,11 @@
 namespace Rapidez\Core\Models\Traits;
 
 use Illuminate\Support\Str;
+use JeroenG\Explorer\Domain\Analysis\Analysis;
+use JeroenG\Explorer\Domain\Analysis\Analyzer\StandardAnalyzer;
+use JeroenG\Explorer\Domain\Analysis\Filter\SynonymFilter;
 use Laravel\Scout\Searchable as ScoutSearchable;
+use Rapidez\Core\Models\SearchSynonym;
 use TorMorten\Eventy\Facades\Eventy;
 
 trait Searchable
@@ -11,14 +15,6 @@ trait Searchable
     use ScoutSearchable;
 
     public static ?string $indexName;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toSearchableArray(): array
-    {
-        return Eventy::filter('index.' . static::getIndexName() . '.data', $this->toArray(), $this);
-    }
 
     public static function getIndexName(): string
     {
@@ -34,13 +30,77 @@ trait Searchable
         ]));
     }
 
-    public static function getIndexMappings(): ?array
+    public function synonymFields(): array
     {
-        return null;
+        return [];
     }
 
-    public static function getIndexSettings(): ?array
+    public function indexMapping(): array
     {
-        return null;
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toSearchableArray(): array
+    {
+        return Eventy::filter('index.' . static::getIndexName() . '.data', $this->toArray(), $this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mappableAs(): array
+    {
+        $synonymFields = Eventy::filter('index.' . static::getIndexName() . '.synonymfields', $this->synonymFields());
+
+        $mappings = collect($synonymFields)
+            ->mapWithKeys(fn($field) => [
+                $field => [
+                    'type' => 'text',
+                    'analyzer' => 'synonym',
+                    'fields' => [
+                        'keyword' => [
+                            'type' => 'keyword',
+                            'ignore_above' => 256,
+                        ],
+                    ],
+                ]
+            ])
+            ->merge($this->indexMapping())
+            ->toArray();
+
+        return Eventy::filter('index.' . static::getIndexName() . '.mapping', $mappings);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function indexSettings(): array
+    {
+        $synonyms = SearchSynonym::whereIn('store_id', [0, config('rapidez.store')])
+            ->pluck('synonyms')
+            ->toArray();
+
+        $synonymFilter = new SynonymFilter();
+        $synonymFilter->setSynonyms($synonyms);
+        $filters = Eventy::filter('index.' . static::getIndexName() . '.settings.filters', [$synonymFilter]);
+
+        $synonymAnalyzer = new StandardAnalyzer('synonym');
+        $synonymAnalyzer->setFilters(['lowercase', $synonymFilter]);
+        $analyzers = Eventy::filter('index.' . static::getIndexName() . '.settings.analyzers', [$synonymAnalyzer]);
+
+        $analysis = new Analysis();
+
+        foreach($filters as $filter) {
+            $analysis->addFilter($filter);
+        }
+
+        foreach ($analyzers as $analyzer) {
+            $analysis->addAnalyzer($analyzer);
+        }
+
+        return $analysis->build();
     }
 }

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -229,7 +229,7 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function bootScout(): self
     {
-        config()->set('scout.driver', 'Matchish\\ScoutElasticSearch\\Engines\\ElasticSearchEngine');
+        config()->set('scout.driver', 'elastic');
 
         return $this;
     }


### PR DESCRIPTION
This PR is a draft, because it implements a different driver which may not be the best solution. I chose to try [this driver](https://github.com/Jeroen-G/Explorer).

Pros that I found:

- It has built-in functionality for filters and analyzers, which we can hook into for the synonyms.
- It has a bit of a nicer way to add mappings and settings to your index from the searchable model.
- You don't have to add the ServiceProvider to the composer.json, and there is an actual alias for the scout driver, allowing you to just `scout.driver` to `elastic` as I've done here.

However, the biggest problems I have with this driver are:

- The synonym filter and standard analyzer are the *only* ones actually implemented currently.
- You have to also configure every individual model that you want to make searchable within the `explorer.php` config file for the driver to recognize its existence. You cannot do without this, as it polls this data in the register function of the serviceprovider and there is no reasonable way to get in between that.
- You have to add `implements Explored, IndexSettings, Aliased` to every single model to get the functionality we want, which can get a bit annoying. These are:
  - `Explored` for the configuration to recognize the model at all;
  - `IndexSettings` for being able to set index settings; and
  - `Aliased` for the zero-downtime indexing.
  - There's also a `BePrepared` interface if you want to hook into the `public function prepare(array $searchable): array` that they've added.
- There is also just a lot of abstraction which makes it hard to find things within the code of the driver.
- The default config doesn't use `.env` values for the connection, so you're forced to overwrite the config just to add those.

I don't know if the pros outweigh the cons here. I'll happily implement the synonyms more simply with the driver we have already been using.