### PR TITLE
Use Cache::memo instead of multicache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "php": "^8.2",
         "blade-ui-kit/blade-heroicons": "^2.6",
         "http-interop/http-factory-guzzle": "^1.2",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/events": "^11.0|^12.0",
-        "illuminate/queue": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/database": "^12.0",
+        "illuminate/events": "^12.0",
+        "illuminate/queue": "^12.0",
+        "illuminate/support": "^12.0",
         "justbetter/laravel-http3earlyhints": "^1.4",
         "laravel/scout": "^10.14",
         "lcobucci/clock": "^2.0|^3.2",
@@ -30,7 +30,7 @@
         "matchish/laravel-scout-elasticsearch": "^7.11",
         "rapidez/blade-components": "^1.8",
         "rapidez/blade-directives": "^1.1",
-        "rapidez/laravel-multi-cache": "^2.0",
+        "illuminate/cache": "^12.9",
         "tormjens/eventy": "^0.8"
     },
     "require-dev": {

--- a/src/Models/Attribute.php
+++ b/src/Models/Attribute.php
@@ -46,7 +46,7 @@ class Attribute extends Model
 
     public static function getCachedWhere(callable $callback): array
     {
-        $attributes = Cache::store('rapidez:multi')->rememberForever('attributes.' . config('rapidez.store'), function () {
+        $attributes = Cache::memo()->rememberForever('attributes.' . config('rapidez.store'), function () {
             return self::all()->toArray();
         });
 

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -86,7 +86,7 @@ class Config extends Model
         }
 
         if ($options['cache'] ?? true) {
-            $configCache = Cache::driver('rapidez:multi')->get('magento.config', []);
+            $configCache = Cache::memo()->get('magento.config', []);
             $cacheKey = implode(
                 '.',
                 [
@@ -126,7 +126,7 @@ class Config extends Model
 
         if (($options['cache'] ?? true) && isset($cacheKey)) {
             Arr::set($configCache, $cacheKey, $resultObject ? $result : false);
-            Cache::driver('rapidez:multi')->set('magento.config', $configCache);
+            Cache::memo()->set('magento.config', $configCache);
         }
 
         return (bool) $options['decrypt'] && is_string($result) ? static::decrypt($result) : $result;

--- a/src/Models/OptionValue.php
+++ b/src/Models/OptionValue.php
@@ -13,7 +13,7 @@ class OptionValue extends Model
     public static function getCachedByOptionId(int $optionId): string
     {
         $cacheKey = 'optionvalues.' . config('rapidez.store');
-        $cache = Cache::store('rapidez:multi')->get($cacheKey, []);
+        $cache = Cache::memo()->get($cacheKey, []);
 
         if (! isset($cache[$optionId])) {
             $cache[$optionId] = html_entity_decode(self::where('option_id', $optionId)
@@ -21,7 +21,7 @@ class OptionValue extends Model
                 ->orderByDesc('store_id')
                 ->first('value')
                 ->value ?? false);
-            Cache::store('rapidez:multi')->forever($cacheKey, $cache);
+            Cache::memo()->forever($cacheKey, $cache);
         }
 
         return $cache[$optionId];

--- a/src/Models/Store.php
+++ b/src/Models/Store.php
@@ -27,7 +27,7 @@ class Store extends Model
 
     public static function getCached(): array
     {
-        $stores = Cache::store('rapidez:multi')->rememberForever('stores', function () {
+        $stores = Cache::memo()->rememberForever('stores', function () {
             return self::select([
                 'store_id',
                 'store.name',

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Vite;

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -298,23 +298,6 @@ class RapidezServiceProvider extends ServiceProvider
             $this->mergeConfigFrom(__DIR__ . '/../config/rapidez/' . $configFile . '.php', 'rapidez.' . $configFile);
         }
 
-        if (! config('cache.stores.rapidez:multi', false)) {
-            $fallbackDriver = config('cache.default');
-            if ($fallbackDriver === 'rapidez:multi') {
-                $fallbackDriver = config('cache.multi-fallback', 'file');
-                Log::warning('Default cache driver is rapidez:multi, setting fallback driver to ' . $fallbackDriver);
-            }
-
-            config()->set('cache.stores.rapidez:multi', [
-                'driver' => 'multi',
-                'stores' => [
-                    'array',
-                    $fallbackDriver,
-                ],
-                'sync_missed_stores' => true,
-            ]);
-        }
-
         return $this;
     }
 


### PR DESCRIPTION
**breaking**
Support for Laravel 11 has been dropped as it doesn't have memo

This PR removes the rapidez/laravel-multi-cache package and instead uses the new [Cache::memo()](https://laravel.com/docs/12.x/cache#cache-memoization)