### PR TITLE
[3.x] Only fire product attribute change when it's changed

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -304,8 +304,6 @@ export default {
                 product = simpleProducts[0]
             }
 
-            this.$root.$emit('product-super-attribute-change', product)
-
             return product
         },
 
@@ -413,6 +411,13 @@ export default {
     },
 
     watch: {
+        simpleProduct: {
+            handler(oldProduct, newProduct) {
+                if (newProduct.sku !== oldProduct.sku) {
+                    this.$root.$emit('product-super-attribute-change', newProduct)
+                }
+            }
+        },
         customOptions: {
             handler() {
                 this.calculatePrices()

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -412,7 +412,7 @@ export default {
 
     watch: {
         simpleProduct: {
-            handler(oldProduct, newProduct) {
+            handler(newProduct, oldProduct) {
                 if (newProduct.sku !== oldProduct.sku) {
                     this.$root.$emit('product-super-attribute-change', newProduct)
                 }


### PR DESCRIPTION
The product-super-attribute-changed event is also fired when there is no change in simpleproduct. When making any changes that triggers the computed simpleProduct the event will keep getting fired.

2.x: #865 