### PR TITLE
[2.x] Only fire product attribute change when it's changed

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -394,9 +394,9 @@ export default {
 
     watch: {
         simpleProduct: {
-            handler(oldProduct, newProduct) {
+            handler(newProduct, oldProduct) {
                 if (newProduct.sku !== oldProduct.sku) {
-                    this.$root.$emit('product-super-attribute-change', product)
+                    this.$root.$emit('product-super-attribute-change', newProduct)
                 }
             }
         },

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -286,8 +286,6 @@ export default {
                 product = simpleProducts[0]
             }
 
-            this.$root.$emit('product-super-attribute-change', product)
-
             return product
         },
 
@@ -395,6 +393,13 @@ export default {
     },
 
     watch: {
+        simpleProduct: {
+            handler(oldProduct, newProduct) {
+                if (newProduct.sku !== oldProduct.sku) {
+                    this.$root.$emit('product-super-attribute-change', product)
+                }
+            }
+        },
         customOptions: {
             handler() {
                 this.calculatePrices()


### PR DESCRIPTION
The product-super-attribute-changed event is also fired when there is no change in simpleproduct. When making any changes that triggers the computed simpleProduct the event will keep getting fired.

3.x: #864 