### PR TITLE
Run autocomplete submit action without turbo

### DIFF
--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -1,4 +1,11 @@
-<form id="autocomplete-form" method="get" action="{{ route('search') }}" class="flex relative z-header-autocomplete">
+<form
+    id="autocomplete-form"
+    method="get"
+    action="{{ route('search') }}"
+    class="flex relative z-header-autocomplete"
+    {{-- Turbo does not understand redirects to external URLs yet --}}
+    data-turbo="false"
+>
     <x-rapidez::input
         {{ $attributes->merge([
             'id' => 'autocomplete-input',


### PR DESCRIPTION
See: https://github.com/hotwired/turbo/issues/203

Turbo does not handle external redirects after form submission gracefully.
![image](https://github.com/user-attachments/assets/efab5703-ca5b-4dc3-9ffb-f387042af85e)

Since it gets a CORS error it stops, adding data-turbo false results in a regular request after pressing enter or the search button. 
Thus redirects can still work as expected