### PR TITLE
Index searchable columns

### DIFF
--- a/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
+++ b/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
@@ -61,7 +61,7 @@ class MagentoSettingsHealthcheck extends Base
 
         $attributeModel = config('rapidez.models.attribute');
         $nonFlatAttributes = Arr::pluck($attributeModel::getCachedWhere(function ($attribute) {
-            return ! $attribute['flat'] && ($attribute['listing'] || $attribute['filter'] || $attribute['productpage']);
+            return ! $attribute['flat'] && ($attribute['listing'] || $attribute['filter'] || $attribute['productpage'] || $attribute['search'] || $attribute['sorting']);
         }), 'code');
 
         if (! empty($nonFlatAttributes)) {

--- a/src/Models/Traits/Product/SelectAttributeScopes.php
+++ b/src/Models/Traits/Product/SelectAttributeScopes.php
@@ -53,7 +53,7 @@ trait SelectAttributeScopes
                 return false;
             }
 
-            if ($attribute['listing'] || $attribute['filter']) {
+            if ($attribute['listing'] || $attribute['filter'] || $attribute['search'] || $attribute['sorting']) {
                 return true;
             }
 


### PR DESCRIPTION
Searchable and sortable columns would not get selected when indexing to elasticsearch. 
This would cause searches for e.g. description content to not return any results, since we are searching in description. But description is not actually indexed to Elasticsearch