### PR TITLE
[Instantsearch] Refactor index settings & index mapping functions to allow for arbitrary functional traits

### DIFF
--- a/src/Commands/IndexCommand.php
+++ b/src/Commands/IndexCommand.php
@@ -40,7 +40,7 @@ class IndexCommand extends Command
             foreach ($types as $model) {
                 $searchableAs = (new $model)->searchableAs();
 
-                $indexMappings = Eventy::filter('index.' . $model::getIndexName() . '.mapping', $model::getIndexMappings());
+                $indexMappings = Eventy::filter('index.' . $model::getIndexName() . '.mapping', $model::getIndexMapping());
                 if ($indexMappings) {
                     config()->set('elasticsearch.indices.mappings.' . $searchableAs, $indexMappings);
                 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -25,6 +25,7 @@ use Rapidez\Core\Models\Traits\Product\CastMultiselectAttributes;
 use Rapidez\Core\Models\Traits\Product\CastSuperAttributes;
 use Rapidez\Core\Models\Traits\Product\Searchable;
 use Rapidez\Core\Models\Traits\Product\SelectAttributeScopes;
+use Rapidez\Core\Models\Traits\UsesSynonyms;
 use TorMorten\Eventy\Facades\Eventy;
 
 class Product extends Model
@@ -34,6 +35,7 @@ class Product extends Model
     use HasAlternatesThroughRewrites;
     use Searchable;
     use SelectAttributeScopes;
+    use UsesSynonyms;
 
     public const VISIBILITY_NOT_VISIBLE = 1;
     public const VISIBILITY_IN_CATALOG = 2;
@@ -261,5 +263,12 @@ class Product extends Model
     public static function exist($productId): bool
     {
         return self::withoutGlobalScopes()->where('entity_id', $productId)->exists();
+    }
+
+    public static function getSynonymFields(): array
+    {
+        return [
+            'name'
+        ];
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -268,7 +268,7 @@ class Product extends Model
     public static function getSynonymFields(): array
     {
         return [
-            'name'
+            'name',
         ];
     }
 }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -119,10 +119,7 @@ trait Searchable
         return $data;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function getIndexMappings(): ?array
+    public static function indexMappingProduct(): array
     {
         return [
             'properties' => [

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Core\Models\Traits;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable as ScoutSearchable;
 use TorMorten\Eventy\Facades\Eventy;
@@ -34,13 +35,27 @@ trait Searchable
         ]));
     }
 
-    public static function getIndexMappings(): ?array
+    public static function getIndexMapping(): array
     {
-        return null;
+        $mapping = [];
+
+        $methods = Arr::where(get_class_methods(static::class), fn($method) => str_starts_with($method, 'indexMapping'));
+        foreach($methods as $method) {
+            $mapping = array_merge_recursive($mapping, static::{$method}());
+        }
+
+        return $mapping;
     }
 
-    public static function getIndexSettings(): ?array
+    public static function getIndexSettings(): array
     {
-        return null;
+        $settings = [];
+
+        $methods = Arr::where(get_class_methods(static::class), fn($method) => str_starts_with($method, 'indexSettings'));
+        foreach($methods as $method) {
+            $settings = array_merge_recursive($settings, static::{$method}());
+        }
+
+        return $settings;
     }
 }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -39,8 +39,8 @@ trait Searchable
     {
         $mapping = [];
 
-        $methods = Arr::where(get_class_methods(static::class), fn($method) => str_starts_with($method, 'indexMapping'));
-        foreach($methods as $method) {
+        $methods = Arr::where(get_class_methods(static::class), fn ($method) => str_starts_with($method, 'indexMapping'));
+        foreach ($methods as $method) {
             $mapping = array_merge_recursive($mapping, static::{$method}());
         }
 
@@ -51,8 +51,8 @@ trait Searchable
     {
         $settings = [];
 
-        $methods = Arr::where(get_class_methods(static::class), fn($method) => str_starts_with($method, 'indexSettings'));
-        foreach($methods as $method) {
+        $methods = Arr::where(get_class_methods(static::class), fn ($method) => str_starts_with($method, 'indexSettings'));
+        foreach ($methods as $method) {
             $settings = array_merge_recursive($settings, static::{$method}());
         }
 

--- a/src/Models/Traits/UsesSynonyms.php
+++ b/src/Models/Traits/UsesSynonyms.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Rapidez\Core\Models\Traits;
+
+use Illuminate\Support\Arr;
+
+trait UsesSynonyms
+{
+    public abstract static function getSynonymFields(): array;
+
+    public static function indexSettingsSynonyms(): array
+    {
+        $fields = static::getSynonymFields();
+
+        if (! count($fields)) {
+            return [];
+        }
+
+        $synonyms = config('rapidez.models.search_synonym')::whereIn('store_id', [0, config('rapidez.store')])
+            ->get()
+            ->map(fn ($synonym) => $synonym->synonyms)
+            ->toArray();
+
+        return [
+            'index' => [
+                'analysis' => [
+                    'filter' => [
+                        'synonym' => [
+                            'type' => 'synonym_graph',
+                            'synonyms' => $synonyms,
+                        ],
+                    ],
+                    'analyzer' => [
+                        'default' => [
+                            'filter' => ['lowercase', 'asciifolding'],
+                            'tokenizer' => 'standard',
+                        ],
+                        'synonym' => [
+                            'filter' => ['lowercase', 'asciifolding', 'synonym'],
+                            'tokenizer' => 'standard',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function indexMappingSynonyms(): array
+    {
+        $fields = static::getSynonymFields();
+
+        if (! count($fields)) {
+            return [];
+        }
+
+        return [
+            'properties' => Arr::mapWithKeys($fields, fn($field) => [
+                $field => [
+                    'type' => 'text',
+                    'analyzer' => 'synonym',
+                    'fields' => [
+                        'keyword' => [
+                            'type' => 'keyword',
+                            'ignore_above' => 256,
+                        ],
+                    ],
+                ],
+            ])
+        ];
+    }
+}

--- a/src/Models/Traits/UsesSynonyms.php
+++ b/src/Models/Traits/UsesSynonyms.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Arr;
 
 trait UsesSynonyms
 {
-    public abstract static function getSynonymFields(): array;
+    abstract public static function getSynonymFields(): array;
 
     public static function indexSettingsSynonyms(): array
     {
@@ -26,17 +26,17 @@ trait UsesSynonyms
                 'analysis' => [
                     'filter' => [
                         'synonym' => [
-                            'type' => 'synonym_graph',
+                            'type'     => 'synonym_graph',
                             'synonyms' => $synonyms,
                         ],
                     ],
                     'analyzer' => [
                         'default' => [
-                            'filter' => ['lowercase', 'asciifolding'],
+                            'filter'    => ['lowercase', 'asciifolding'],
                             'tokenizer' => 'standard',
                         ],
                         'synonym' => [
-                            'filter' => ['lowercase', 'asciifolding', 'synonym'],
+                            'filter'    => ['lowercase', 'asciifolding', 'synonym'],
                             'tokenizer' => 'standard',
                         ],
                     ],
@@ -54,18 +54,18 @@ trait UsesSynonyms
         }
 
         return [
-            'properties' => Arr::mapWithKeys($fields, fn($field) => [
+            'properties' => Arr::mapWithKeys($fields, fn ($field) => [
                 $field => [
-                    'type' => 'text',
+                    'type'     => 'text',
                     'analyzer' => 'synonym',
-                    'fields' => [
+                    'fields'   => [
                         'keyword' => [
-                            'type' => 'keyword',
+                            'type'         => 'keyword',
                             'ignore_above' => 256,
                         ],
                     ],
                 ],
-            ])
+            ]),
         ];
     }
 }


### PR DESCRIPTION
I've gone for a fairly wild approach here, would like to hear your thoughts on this.

With this PR, we can make any trait we want with a `indexSettingsXyz` and `indexMappingXyz` function that apply any settings and mapping we might want for said trait. Have a look at the `UsesSynonyms` trait here. Or, just add those functions to your model without needing a trait, as I've done for the mapping on the product model.

A limitation of this implementation is that we currently cannot guarantee the order that these functions might be executed in. This means you can't (consistently) overwrite mapping values or settings set by other functions. Sorting the methods list could work for this, but then people would just make functions named `indexMappingZZZ` to make sure it goes last.

If we want a more comprehensive solution to this that avoids this issue we could stick to something like the fallback routes (essentially just the Eventy filters), where you can then define all your extra indexing functionalities in the service provider. However I'm not sure if I necessarily like that approach. Using traits for this seems cleaner and more reusable to me.
