### PR TITLE
Add loading indicator in autocomplete slower connections

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete/no-results.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/no-results.blade.php
@@ -1,28 +1,33 @@
-<ais-hits>
-    <template v-slot="{ items }">
-        <div v-if="items.length === 0 && currentRefinement !== ''" class="p-5">
-            <div class="font-bold text text-lg break-all">
-                @lang('No results found for :searchterm', [
-                    'searchterm' => '<span class="text-primary">"@{{ currentRefinement }}"</span>'
-                ])
+<ais-state-results v-slot="{ status }">
+    <div v-if="status === 'stalled'" class="mx-auto py-2.5">
+        <x-heroicon-o-arrow-path class="w-full animate-spin size-6" />
+    </div>
+    <ais-hits>
+        <template v-slot="{ items }">
+            <div v-if="items.length === 0 && currentRefinement !== '' && status === 'idle'" class="p-5">
+                <div class="font-bold text text-lg break-all">
+                    @lang('No results found for :searchterm', [
+                        'searchterm' => '<span class="text-primary">"@{{ currentRefinement }}"</span>'
+                    ])
+                </div>
+                <div class="flex flex-col text-sm pt-7">
+                    <span class="font-bold">@lang('Have you tried:')</span>
+                    <ul class="flex flex-col pt-1.5 gap-y-1 *:flex *:gap-x-2 *:items-center">
+                        <li>
+                            <x-heroicon-s-check class="size-4"/>
+                            @lang('Check the spelling of your search term')
+                        </li>
+                        <li>
+                            <x-heroicon-s-check class="size-4"/>
+                            @lang('Make your search term less specific')
+                        </li>
+                        <li>
+                            <x-heroicon-s-check class="size-4"/>
+                            @lang('Use other search terms')
+                        </li>
+                    </ul>
+                </div>
             </div>
-            <div class="flex flex-col text-sm pt-7">
-                <span class="font-bold">@lang('Have you tried:')</span>
-                <ul class="flex flex-col pt-1.5 gap-y-1 *:flex *:gap-x-2 *:items-center">
-                    <li>
-                        <x-heroicon-s-check class="size-4"/>
-                        @lang('Check the spelling of your search term')
-                    </li>
-                    <li>
-                        <x-heroicon-s-check class="size-4"/>
-                        @lang('Make your search term less specific')
-                    </li>
-                    <li>
-                        <x-heroicon-s-check class="size-4"/>
-                        @lang('Use other search terms')
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </template>
-</ais-hits>
+        </template>
+    </ais-hits>
+</ais-state-results>


### PR DESCRIPTION
In some cases when you have slow internet connection and you type something in the autocomplete the "no results" view show for a short time before it have results. 

By adding the `<ais-state-results v-slot="{ status }">` in this template we can check the status (https://www.algolia.com/doc/api-reference/widgets/state-results/vue/#status). When we have a slow connection we will see now the loader for a short time instead of the "no results". 