### PR TITLE
Tweaked product tiles and aligned components

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -36,7 +36,7 @@
                                         to a grid, do we also need that here? As
                                         the item partials is shared.
                                         --}}
-                                        <div ref="slider" class="*:sm:w-1/2 *:md:w-1/3 *:xl:w-1/3 *:px-0.5 *:sm:px-2 *:shrink-0 *:snap-start -mx-2 -mx-4 flex snap-x snap-mandatory overflow-x-auto scroll-smooth scrollbar-hide sm:-mx-1">
+                                        <div ref="slider" class="*:w-1/2 *:md:w-1/3 *:xl:w-1/4 *:px-5 *:shrink-0 *:snap-start -mx-5 flex snap-x snap-mandatory overflow-x-auto scrollbar-hide">
                                             <template v-for="(item, count) in items">
                                                 @include('rapidez::listing.partials.item', ['slider' => true])
                                             </template>

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -1,4 +1,4 @@
-<div v-bind:key="item.entity_id" class="border-b px-5 py-10">
+<div v-bind:key="item.entity_id" class="px-5 py-10">
     <add-to-cart v-bind:product="item" v-slot="addToCart" v-cloak>
         <div class="group relative flex flex-1 flex-col rounded bg-white h-full">
             @if (App::providerIsLoaded('Rapidez\Wishlist\WishlistServiceProvider'))

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -23,7 +23,7 @@
     <ais-hits>
         <template v-slot="{ items, sendEvent }">
             <div class="overflow-hidden">
-                <div v-if="items && items.length" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 -mx-5 -mb-px">
+                <div v-if="items && items.length" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 -mx-5 -mb-px *:border-b">
                     <template v-for="(item, count) in items">
                         @include('rapidez::listing.partials.item')
                     </template>

--- a/resources/views/product/overview.blade.php
+++ b/resources/views/product/overview.blade.php
@@ -11,7 +11,7 @@
         <div itemtype="https://schema.org/Product" itemscope>
             @include('rapidez::product.partials.microdata')
             @include('rapidez::product.partials.opengraph')
-            <div class="relative flex max-lg:flex-col gap-8">
+            <div class="relative flex max-lg:flex-col gap-10">
                 <div class="flex-1 flex flex-col shrink-0">
                     @include('rapidez::product.partials.images')
                 </div>
@@ -67,7 +67,7 @@
         </div>
     @endif
 
-    <div class="container flex flex-col gap-5 my-24">
+    <div class="container flex flex-col gap-5 mt-14">
         <x-rapidez::productlist
             title="Related products"
             field="entity_id"


### PR DESCRIPTION
I've tweaked the product tiles visually. I have done the following:

- Removed border in default product tile, added the border manually in the category overview. Now the product slider doesn't contain the border
- Added correct spacing on the product detail to align the gallery with the products

![image](https://github.com/user-attachments/assets/ce2db1ab-d711-4358-a634-666e92050f5c)
![image](https://github.com/user-attachments/assets/fb265a78-05af-4962-8ecf-b146e76586f9)
