### PR TITLE
[2.x] Add fallback for virtualItems not existing

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -182,7 +182,7 @@ export const virtualItems = computed(() => {
 })
 
 export const hasOnlyVirtualItems = computed(() => {
-    return cart.value.total_quantity === virtualItems.value.length
+    return cart.value.total_quantity === virtualItems?.value?.length
 })
 
 export const fixedProductTaxes = computed(() => {


### PR DESCRIPTION
This sometimes threw an error, so I've added a fallback to make it not do that.

Not relevant for 3.x and above because this was fully removed in 3.x.