### PR TITLE
Removed ais-configure breaking search

### DIFF
--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -116,7 +116,7 @@ export default {
                 requests = requests.map((request) => {
                     request.params.hitsPerPage = request.params.hitsPerPage || this.hitsPerPage
 
-                    return request;
+                    return request
                 })
 
                 return oldSearch.bind(client)(requests)

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -29,6 +29,13 @@ export default {
         StatsAnalytics,
     },
 
+    props: {
+        hitsPerPage: {
+            type: Number,
+            default: 3,
+        },
+    },
+
     data() {
         return {
             focusId: null,
@@ -105,6 +112,12 @@ export default {
                         })),
                     })
                 }
+
+                requests = requests.map((request) => {
+                    request.params.hitsPerPage = request.params.hitsPerPage || this.hitsPerPage
+
+                    return request;
+                })
 
                 return oldSearch.bind(client)(requests)
             }

--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -23,7 +23,7 @@
         v-on:click="refine('')"
         class="absolute right-14 top-1/2 -translate-y-1/2 transition-opacity opacity-100 peer-placeholder-shown:opacity-0"
         type="reset"
-        title="{{ __('Clear the search query') }}"
+        title="@lang('Clear the search query')"
         v-cloak
     >
         <x-heroicon-s-x-mark class="size-7" />

--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -23,7 +23,7 @@
         v-on:click="refine('')"
         class="absolute right-14 top-1/2 -translate-y-1/2 transition-opacity opacity-100 peer-placeholder-shown:opacity-0"
         type="reset"
-        title="__('Clear the search query')"
+        title="{{ __('Clear the search query') }}"
         v-cloak
     >
         <x-heroicon-s-x-mark class="size-7" />

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,4 +1,4 @@
-<autocomplete v-slot="{ searchClient, middlewares, searchHistory }">
+<autocomplete v-slot="{ searchClient, middlewares, searchHistory }" :hits-per-page="{{ config('rapidez.frontend.autocomplete.size', 3) }}">
     <div class="relative w-full">
         <ais-instant-search
             v-if="searchClient"
@@ -9,7 +9,6 @@
             v-cloak
         >
             <div class="contents">
-                <ais-configure :hits-per-page.camel="{{ config('rapidez.frontend.autocomplete.size', 3) }}" />
                 <div class="searchbox group/autocomplete">
                     <ais-autocomplete>
                         <template v-slot="{ currentRefinement, refine }">


### PR DESCRIPTION
The ais-configure at this spot forced the ais-instantsearch component to reset when the exact search term was used.

This way it no longer resets the autocomplete.