### PR TITLE
Show categories on search page if no results

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -96,7 +96,7 @@ export default {
         getBaseFilters() {
             if (this.categoryId) {
                 return this.baseFilters().concat([
-                    { query_string: { query: 'visibility:(2 OR 4) AND category_ids:' + this.categoryId } },
+                    { query_string: { query: '(visibility:(2 OR 4) OR (NOT _exists_:visibility)) AND (category_ids:' + this.categoryId + ' OR (NOT _exists_:category_ids))' } },
                     this.$root.categoryPositions(this.categoryId),
                 ])
             }

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -96,7 +96,14 @@ export default {
         getBaseFilters() {
             if (this.categoryId) {
                 return this.baseFilters().concat([
-                    { query_string: { query: '(visibility:(2 OR 4) OR (NOT _exists_:visibility)) AND (category_ids:' + this.categoryId + ' OR (NOT _exists_:category_ids))' } },
+                    {
+                        query_string: {
+                            query:
+                                '(visibility:(2 OR 4) OR (NOT _exists_:visibility)) AND (category_ids:' +
+                                this.categoryId +
+                                ' OR (NOT _exists_:category_ids))',
+                        },
+                    },
                     this.$root.categoryPositions(this.categoryId),
                 ])
             }

--- a/resources/views/layouts/partials/header/autocomplete/categories.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/categories.blade.php
@@ -1,4 +1,4 @@
-<ais-index v-bind:index-name="config.index.category">
+<ais-index v-bind:index-name="config.index.category" v-bind:index-id="'autocomplete_' + config.index.category">
     @if ($size = Arr::get($fields, 'size'))
         <ais-configure :hits-per-page.camel="{{ $size }}" />
     @endif

--- a/resources/views/layouts/partials/header/autocomplete/products.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/products.blade.php
@@ -1,4 +1,4 @@
-<ais-hits v-bind:index-name="config.index.product">
+<ais-hits v-bind:index-name="config.index.product" v-bind:index-id="'autocomplete_' + config.index.product">
     <template v-slot="{ items, sendEvent }">
         <div v-if="items && items.length" class="py-2.5">
             <x-rapidez::autocomplete.title>

--- a/resources/views/listing/partials/no-results.blade.php
+++ b/resources/views/listing/partials/no-results.blade.php
@@ -1,5 +1,21 @@
 <div class="bg rounded-md mt-6 p-10">
     <h2 class="font-sans text-xl font-medium">@lang('No products found.')</h2>
+
+    <ais-index v-bind:index-name="config.index.category" v-bind:index-id="'listing_' + config.index.category">
+        <ais-hits v-slot="{ items }">
+            <div class="border-b py-2.5" v-if="items && items.length">
+                @lang('Categories'):
+                <ul class="flex flex-col font-sans">
+                    <li v-for="(item, count) in items" class="flex flex-1 items-center w-full hover:bg-muted">
+                        <a v-bind:href="item.url" class="flex items-center group py-1 gap-x-0.5 hover:underline">
+                            <x-heroicon-o-chevron-right class="text-primary size-3.5 shrink-0"/> <x-rapidez::highlight attribute="name" class="line-clamp-2"/>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </ais-hits>
+    </ais-index>
+
     <ais-state-results v-slot="{ state: { query: searchQuery } }">
         <search-suggestions v-slot="searchSuggestions">
             <ais-instant-search

--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -8,7 +8,7 @@
 
 @section('content')
     <div class="container">
-        <x-rapidez::listing filter-query-string="visibility:(3 OR 4)">
+        <x-rapidez::listing filter-query-string="(visibility:(3 OR 4) OR (NOT _exists_:visibility))">
             <x-slot:title>
                 <ais-state-results>
                     <template v-slot="{ state: { query } }">


### PR DESCRIPTION
This PR adds the categories to the "No products found" page after searching.
Visually it looks the same as the search suggestions on the not found page