### PR TITLE
Check if category array has values before passing it

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -157,13 +157,16 @@ export default {
                 ),
             )
 
-            let rootPath = this.rootPath || []
-            let categoryPath = routeState.category?.split('--') || []
+            const categories = [
+                ...(this.rootPath || []),
+                ...(routeState.category?.split('--') || [])
+            ];
+
             return {
                 [this.index]: {
                     range: ranges,
                     refinementList: refinementList,
-                    hierarchicalMenu: { category_lvl1: [...rootPath, ...categoryPath] },
+                    hierarchicalMenu: { category_lvl1: categories.length ? categories : null },
                     query: routeState.q,
                     page: Number(routeState.page),
                     sortBy: routeState.sort,

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -157,10 +157,7 @@ export default {
                 ),
             )
 
-            const categories = [
-                ...(this.rootPath || []),
-                ...(routeState.category?.split('--') || [])
-            ];
+            const categories = [...(this.rootPath || []), ...(routeState.category?.split('--') || [])]
 
             return {
                 [this.index]: {


### PR DESCRIPTION
The issue seems to be caused by passing an empty array to the `category_lvl1` which sometimes confuses instantsearch making it filter the `category_lvl1` for an empty string.

passing null instead of an empty array seems to ensure instantsearch will not try to filter it.