### PR TITLE
[Instantsearch] Hotfix for highlight flickering

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete/search-suggestions.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/search-suggestions.blade.php
@@ -8,6 +8,8 @@
             :query="currentRefinement || ' '"
             :hits-per-page.camel="{{ Arr::get($fields, 'size', config('rapidez.frontend.autocomplete.size', 3)) }}"
             filters="display_in_terms:1"
+            :highlight-pre-tag.camel="'__ais-highlight__'"
+            :highlight-post-tag.camel="'__/ais-highlight__'"
         />
         <ais-hits v-slot="{ items }">
             <div v-if="items && items.length" v-bind:class="{ 'border-b': currentRefinement }" class="py-2.5">


### PR DESCRIPTION
This fixes the weird bug where for a only millisecond you would see `<ais-highlight-0000000000>text<ais-highlight-0000000000/>` in your hits instead of the actual highlight.

This is just a hotfix, as I have not yet found the proper reason for this happening which might allow for a cleaner fix. This specific string is used internally within instantsearch and gets replaced with `<mark>` and `</mark>`, see [here](https://github.com/algolia/instantsearch/blob/5a2d2121c1f82840e59ba69edfe0a4f41450f41b/packages/instantsearch.js/src/lib/utils/escape-highlight.ts#L6)