### PR TITLE
[Instantsearch] Fix capitalization in sorting options

### DIFF
--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -237,7 +237,7 @@ class ConfigController
             ->flatMap(fn ($attribute) => Arr::map(($attribute['directions'] ?? null) ?: ['asc', 'desc'], fn ($direction) => [
                 'label' => trans_fallback(
                     "rapidez::frontend.sorting.{$attribute['code']}.{$direction}",
-                    trans_fallback("rapidez::frontend.{$attribute['code']}", $attribute['code']) . ' ' . trans_fallback("rapidez::frontend.{$direction}", $direction),
+                    trans_fallback("rapidez::frontend.{$attribute['code']}", ucfirst($attribute['code'])) . ' ' . trans_fallback("rapidez::frontend.{$direction}", $direction),
                 ),
                 'field' => $attribute['code'] . ($attribute['input'] == 'text' ? '.keyword' : ''),
                 'order' => $direction,


### PR DESCRIPTION
Sorting options without a dedicated translation didn't get capitalized. This PR fixes that.

I considered doing a `ucfirst` around the whole thing but I wanted to leave in the possibility of not having caps if people want.