### PR TITLE
[Instantsearch] Fix wrong color being shown because it always picked the first child

### DIFF
--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -48,7 +48,7 @@ class ProductController
 
         // Find the first child that matches the given product options
         $selectedChild = collect($product->children)->firstWhere(function ($child) use ($selectedOptions) {
-            return collect($selectedOptions)->every(fn ($value, $code) => $child->{$code} == $value);
+            return count($selectedOptions) && collect($selectedOptions)->every(fn ($value, $code) => $child->{$code} == $value);
         }) ?? $product;
 
         ProductViewEvent::dispatch($product);


### PR DESCRIPTION
When no product options are selected it should not pick the first child, but the parent.