### PR TITLE
[Instantsearch] Add data-turbo to search suggestions & history, make route + replace usage consistent

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete/history.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/history.blade.php
@@ -12,8 +12,9 @@
                     class="flex flex-1 items-center w-full hover:bg-muted"
                 >
                     <a
-                        v-bind:href="'{{ route('search', ['q' => '%query%']) }}'.replaceAll('%25query%25', query)"
+                        v-bind:href="'{{ route('search', ['q' => 'searchPlaceholder']) }}'.replace('searchPlaceholder', encodeURIComponent(query))"
                         class="relative flex items-center group w-full px-5 py-2 text-sm gap-x-4"
+                        data-turbo="false"
                     >
                         @{{ query }}
                     </a>

--- a/resources/views/layouts/partials/header/autocomplete/search-suggestions.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/search-suggestions.blade.php
@@ -21,6 +21,7 @@
                         <a
                             v-bind:href="window.url(item.redirect || '{{ route('search', ['q' => 'searchPlaceholder']) }}'.replace('searchPlaceholder', encodeURIComponent(item.query_text)))"
                             class="relative flex items-center group w-full px-5 py-2 text-sm gap-x-4"
+                            data-turbo="false"
                         >
                             <x-rapidez::highlight attribute="query_text" class="line-clamp-2"/>
                         </a>


### PR DESCRIPTION
The search broke for the search suggestions and history. We also didn't yet have a `data-turbo="false"` on the search suggestions, where we potentially redirect to an external URL.

The `data-turbo="false"` ended up fixing the search breaking bug, however I don't know if this will be the best solution. For that I've made an internal issue to look at this (RAP-1377).

Finally, I changed the `v-bind:href` in the history file just to be consistent with the one in the search suggestions.
