### PR TITLE
[4.x] Implement base getModelName function for use within the eventy filters

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -110,7 +110,7 @@ class Category extends Model
      */
     protected function makeAllSearchableUsing(Builder $query)
     {
-        return $query->withEventyGlobalScopes('index.' . static::getEventyName() . '.scopes')
+        return $query->withEventyGlobalScopes('index.' . static::getModelName() . '.scopes')
             ->select((new (config('rapidez.models.category')))->qualifyColumns(['entity_id', 'name']))
             ->whereNotNull('url_key')
             ->whereNot('url_key', 'default-category')
@@ -125,7 +125,7 @@ class Category extends Model
         $data = $this->toArray();
         $data['parents'] = $this->parentcategories->pluck('name')->slice(0, -1)->toArray();
 
-        return Eventy::filter('index.' . static::getEventyName() . '.data', $data, $this);
+        return Eventy::filter('index.' . static::getModelName() . '.data', $data, $this);
     }
 
     public static function synonymFields(): array

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -15,7 +15,7 @@ class Model extends BaseModel
         Macroable::__callStatic as macroCallStatic;
     }
 
-    public static ?string $eventyName;
+    public static ?string $modelName;
 
     public function __call($method, $parameters)
     {
@@ -35,8 +35,8 @@ class Model extends BaseModel
         return parent::__callStatic($method, $parameters);
     }
 
-    public static function getEventyName(): string
+    public static function getModelName(): string
     {
-        return static::$eventyName ?? Str::snake(Str::studly(class_basename(static::class)));
+        return static::$modelName ?? Str::snake(Str::studly(class_basename(static::class)));
     }
 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -91,7 +91,7 @@ class Product extends Model
                 ],
                 $this->getSuperAttributeCasts(),
                 $this->getMultiselectAttributeCasts(),
-                Eventy::filter(static::getEventyName() . '.casts', []),
+                Eventy::filter(static::getModelName() . '.casts', []),
             );
         }
 

--- a/src/Models/Traits/HasEventyGlobalScopeFilter.php
+++ b/src/Models/Traits/HasEventyGlobalScopeFilter.php
@@ -7,11 +7,11 @@ use TorMorten\Eventy\Facades\Eventy;
 
 trait HasEventyGlobalScopeFilter
 {
-    abstract public static function getEventyName(): string;
+    abstract public static function getModelName(): string;
 
     public static function bootHasEventyGlobalScopeFilter()
     {
-        $scopes = Eventy::filter(static::getEventyName() . '.scopes', []);
+        $scopes = Eventy::filter(static::getModelName() . '.scopes', []);
 
         foreach ($scopes as $scope) {
             static::addGlobalScope(new $scope);

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -23,7 +23,7 @@ trait Searchable
     {
         return $query->selectOnlyIndexable()
             ->with(['categoryProducts', 'reviewSummary'])
-            ->withEventyGlobalScopes('index.' . static::getEventyName() . '.scopes');
+            ->withEventyGlobalScopes('index.' . static::getModelName() . '.scopes');
     }
 
     /**
@@ -77,7 +77,7 @@ trait Searchable
             // Turn all positions positive
             ->mapWithKeys(fn ($position, $category_id) => [$category_id => $maxPositions[$category_id] - $position]);
 
-        return Eventy::filter('index.' . static::getEventyName() . '.data', $data, $this);
+        return Eventy::filter('index.' . static::getModelName() . '.data', $data, $this);
     }
 
     /**
@@ -86,7 +86,7 @@ trait Searchable
     public function withCategories(array $data): array
     {
         $categories = Cache::driver('array')->rememberForever('categories-' . config('rapidez.store'), function () {
-            return Category::withEventyGlobalScopes('index.' . config('rapidez.models.category')::getEventyName() . '.scopes')
+            return Category::withEventyGlobalScopes('index.' . config('rapidez.models.category')::getModelName() . '.scopes')
                 ->where('catalog_category_flat_store_' . config('rapidez.store') . '.entity_id', '<>', config('rapidez.root_category_id'))
                 ->pluck('name', 'entity_id');
         });

--- a/src/Models/Traits/Product/SelectAttributeScopes.php
+++ b/src/Models/Traits/Product/SelectAttributeScopes.php
@@ -57,7 +57,7 @@ trait SelectAttributeScopes
                 return true;
             }
 
-            $alwaysInFlat = array_merge(['sku'], Eventy::filter('index.' . static::getEventyName() . '.attributes', []));
+            $alwaysInFlat = array_merge(['sku'], Eventy::filter('index.' . static::getModelName() . '.attributes', []));
             if (in_array($attribute['code'], $alwaysInFlat)) {
                 return true;
             }

--- a/src/Models/Traits/Searchable.php
+++ b/src/Models/Traits/Searchable.php
@@ -19,10 +19,10 @@ trait Searchable
      */
     public function toSearchableArray(): array
     {
-        return Eventy::filter('index.' . static::getEventyName() . '.data', $this->toArray(), $this);
+        return Eventy::filter('index.' . static::getModelName() . '.data', $this->toArray(), $this);
     }
 
-    abstract public static function getEventyName(): string;
+    abstract public static function getModelName(): string;
 
     public static function getIndexName(): string
     {
@@ -55,7 +55,7 @@ trait Searchable
 
     public static function getIndexMapping(): array
     {
-        $synonymFields = Eventy::filter('index.' . static::getEventyName() . '.synonym-fields', static::synonymFields());
+        $synonymFields = Eventy::filter('index.' . static::getModelName() . '.synonym-fields', static::synonymFields());
 
         return static::filter('mapping', [...static::indexMapping(), [WithSynonyms::class, 'fields' => $synonymFields]]);
     }
@@ -68,7 +68,7 @@ trait Searchable
     private static function filter($type, $initialValue): array
     {
         [$data, $classes] = Arr::partition(
-            Eventy::filter('index.' . static::getEventyName() . '.' . $type, $initialValue),
+            Eventy::filter('index.' . static::getModelName() . '.' . $type, $initialValue),
             fn ($value, $key) => is_string($key)
         );
 


### PR DESCRIPTION
I'm not sure if this is as clean as it gets. I wanted to make sure we have a consistent function for all of these. However, it's possible for people to implement the `Searchable` and `HasEventyGlobalScopeFilter` traits on a model that doesn't extend the Rapidez base model. Because of that I've made this function an abstract function in those traits as well, so you don't get unexpected errors when implementing these traits.