### PR TITLE
[4.x] Fix title being set after destroy

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -135,7 +135,7 @@ export default {
         },
 
         windowTitle(routeState) {
-            if(this.destroyed) {
+            if (this.destroyed) {
                 return null
             }
 

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -37,10 +37,15 @@ export default {
     data: () => ({
         searchkit: null,
         searchClient: null,
+        destroyed: false,
     }),
 
     render() {
         return this.$scopedSlots.default(this)
+    },
+
+    destroyed() {
+        this.destroyed = true
     },
 
     computed: {
@@ -130,6 +135,10 @@ export default {
         },
 
         windowTitle(routeState) {
+            if(this.destroyed) {
+                return null
+            }
+
             if (!routeState.q) {
                 return window.config.translations.search.title
             }


### PR DESCRIPTION
The router still calls the window title function after the listing has been destroyed. This is because all of the filters get destroyed, which causes InstantSearch to update the state, which includes calling this function.

By checking whether the listing has been destroyed and returning `null` when it has been, we avoid this from affecting the title.