### PR TITLE
Validate shipping address before sending same as shipping

### DIFF
--- a/resources/views/checkout/steps/billing_address.blade.php
+++ b/resources/views/checkout/steps/billing_address.blade.php
@@ -16,7 +16,11 @@
     v-slot="{ mutate, variables }"
 >
     <div partial-submit="mutate">
-        <fieldset v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && window.app.$emit('setBillingAddressOnCart')}">
+        <fieldset v-on:change="function (e) {
+            e.target.closest('fieldset').querySelector(':invalid') === null
+            && (!variables.same_as_shipping || !!cart?.shipping_addresses?.[0]?.postcode)
+            && window.app.$emit('setBillingAddressOnCart')
+        }">
             <template v-if="!cart.is_virtual">
                 <x-rapidez::input.checkbox v-model="variables.same_as_shipping">
                     @lang('My billing and shipping address are the same')


### PR DESCRIPTION
This PR will prevent the 
![image](https://github.com/user-attachments/assets/1dc40fed-f535-40a9-a3a5-01cdd5f916d6)
error when unchecking & checking same as shipping when no valid shipping address was entered.

If same as shipping is selected we check wether a shipping address has been set before sending 