### PR TITLE
[4.x] Map special price to double so it can be used in range query

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -126,6 +126,9 @@ trait Searchable
                 'price' => [
                     'type' => 'double',
                 ],
+                'special_price' => [
+                    'type' => 'double',
+                ],
                 'children' => [
                     'type' => 'flattened',
                 ],


### PR DESCRIPTION
This PR maps the special price attribute to a double so it can be used in a range query to elasticsearch.