### PR TITLE
[3.x] Map special price to double so it can be used in range query

### DIFF
--- a/src/Commands/IndexProductsCommand.php
+++ b/src/Commands/IndexProductsCommand.php
@@ -35,6 +35,9 @@ class IndexProductsCommand extends ElasticsearchIndexCommand
                     'price' => [
                         'type' => 'double',
                     ],
+                    'special_price' => [
+                        'type' => 'double',
+                    ],
                     'children' => [
                         'type' => 'flattened',
                     ],


### PR DESCRIPTION
This PR maps the special price attribute to a double so it can be used in a range query to elasticsearch.