### PR TITLE
[4.x] Add error for invalid login

### DIFF
--- a/lang/en/frontend.php
+++ b/lang/en/frontend.php
@@ -21,6 +21,7 @@ return [
         'password_mismatch' => 'Please make sure your passwords match.',
         'email_password'    => 'You did not specify an email or password.',
         'email'             => 'An email address is required.',
+        'login_failed'      => 'This email address and password do not match.',
     ],
 
     'filters' => [

--- a/lang/nl/frontend.php
+++ b/lang/nl/frontend.php
@@ -21,6 +21,7 @@ return [
         'password_mismatch' => 'De wachtwoorden komen niet overeen.',
         'email_password'    => 'Je hebt geen email of wachtwoord opgegeven.',
         'email'             => 'Een email adres is verplicht.',
+        'login_failed'      => 'Het gegeven e-mailadres en wachtwoord komen niet overeen.',
     ],
 
     'asc'       => 'oplopend',

--- a/resources/js/components/User/Login.vue
+++ b/resources/js/components/User/Login.vue
@@ -36,6 +36,8 @@ export default {
                 this.successfulLogin()
                 return true
             }
+
+            Notify(window.config.translations.account.login_failed)
             return false
         },
 


### PR DESCRIPTION
When logging in with incorrect credentials you didn't get an error at all. I've added it here.