### PR TITLE
Only select _value fields for int select fields

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -100,7 +100,7 @@ class Category extends Model
         $categoryIds = explode('/', $this->path);
         $categoryIds = array_slice($categoryIds, array_search(config('rapidez.root_category_id'), $categoryIds) + 1);
 
-        return ! $categoryIds ? [] : Category::whereIn($this->getQualifiedKeyName(), $categoryIds)
+        return ! $categoryIds ? collect([]) : Category::whereIn($this->getQualifiedKeyName(), $categoryIds)
             ->orderByRaw('FIELD(' . $this->getQualifiedKeyName() . ',' . implode(',', $categoryIds) . ')')
             ->get();
     }

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -36,7 +36,7 @@ class WithProductAttributesScope implements Scope
             $attribute = (object) $attribute;
 
             if ($attribute->flat) {
-                if ($attribute->input == 'select' && ! in_array($attribute->source_model, [
+                if ($attribute->input == 'select' && $attribute->type === 'int' && ! in_array($attribute->source_model, [
                     'Magento\Tax\Model\TaxClass\Source\Product',
                     'Magento\Eav\Model\Entity\Attribute\Source\Boolean',
                 ])) {


### PR DESCRIPTION
This change fixes an issue where it would try to get `_value` fields for varchar dropdowns, for which magento does not generate a `_value` key