### PR TITLE
Automatically parse types to set as mappings

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -122,54 +122,49 @@ trait Searchable
     protected static function indexMapping(): array
     {
         $attributeModel = config('rapidez.models.attribute');
-        $attributeTypeMapping = Arr::map(
-            Arr::pluck(
-                $attributeModel::getCachedWhere(function ($attribute) {
-                    if (in_array($attribute['code'], ['msrp_display_actual_price_type', 'price_view', 'shipment_type', 'status'])) {
-                        return false;
-                    }
 
-                    if (in_array($attribute['type'], ['varchar', 'text', 'gallery', 'static'])) {
-                        // Types best left up to ES to interpret the type.
-                        return false;
-                    }
-
-                    if (! empty($attribute['source_model'])) {
-                        // Due to the source model value can be mapped to any type, best to let ES interpret them.
-                        return false;
-                    }
-
-                    if ($attribute['listing'] || $attribute['filter'] || $attribute['search'] || $attribute['sorting']) {
-                        return true;
-                    }
-
-                    $alwaysInFlat = array_merge(['sku'], Eventy::filter('index.' . static::getModelName() . '.attributes', []));
-                    if (in_array($attribute['code'], $alwaysInFlat)) {
-                        return true;
-                    }
-
+        $attributeTypeMapping = collect(
+            $attributeModel::getCachedWhere(function ($attribute) {
+                if (in_array($attribute['code'], ['msrp_display_actual_price_type', 'price_view', 'shipment_type', 'status'])) {
                     return false;
-                }),
-                'type',
-                'code'
-            ),
-            fn ($type) => ['type' => match ($type) {
-                'int'      => 'integer',
-                'decimal'  => 'double',
-                'datetime' => 'date',
-                default    => null
-            }]
-        );
+                }
+
+                if (in_array($attribute['type'], ['varchar', 'text', 'gallery', 'static'])) {
+                    // Types best left up to ES to interpret the type.
+                    return false;
+                }
+
+                if (! empty($attribute['source_model'])) {
+                    // Due to the source model value can be mapped to any type, best to let ES interpret them.
+                    return false;
+                }
+
+                if ($attribute['listing'] || $attribute['filter'] || $attribute['search'] || $attribute['sorting']) {
+                    return true;
+                }
+
+                $alwaysInFlat = array_merge(['sku'], Eventy::filter('index.' . static::getModelName() . '.attributes', []));
+                if (in_array($attribute['code'], $alwaysInFlat)) {
+                    return true;
+                }
+
+                return false;
+            })
+        )
+            ->pluck('type', 'code')
+            ->map(fn ($type) => [
+                'type' => match ($type) {
+                    'int'      => 'integer',
+                    'decimal'  => 'double',
+                    'datetime' => 'date',
+                    default    => null
+                }
+            ])
+            ->whereNotNull('type');
 
         return [
             'properties' => [
-                ...Arr::where($attributeTypeMapping, fn ($mapping) => $mapping['type'] !== null),
-                'price' => [
-                    'type' => 'double',
-                ],
-                'special_price' => [
-                    'type' => 'double',
-                ],
+                ...$attributeTypeMapping,
                 'children' => [
                     'type' => 'flattened',
                 ],

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -130,12 +130,12 @@ trait Searchable
                     }
 
                     if (in_array($attribute['type'], ['varchar', 'text', 'gallery', 'static'])) {
-                        // Types best left up to ES to interperet the type.
+                        // Types best left up to ES to interpret the type.
                         return false;
                     }
 
                     if (! empty($attribute['source_model'])) {
-                        // Due to the source model value can be mapped to any type, best to let ES interperet them.
+                        // Due to the source model value can be mapped to any type, best to let ES interpret them.
                         return false;
                     }
 
@@ -157,8 +157,6 @@ trait Searchable
                 'int'      => 'integer',
                 'decimal'  => 'double',
                 'datetime' => 'date',
-                'text'     => 'text',
-                'varchar'  => 'text',
                 default    => 'text'
             }]
         );

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -134,7 +134,7 @@ trait Searchable
                         return false;
                     }
 
-                    if (!empty($attribute['source_model'])) {
+                    if (! empty($attribute['source_model'])) {
                         // Due to the source model value can be mapped to any type, best to let ES interperet them.
                         return false;
                     }
@@ -153,13 +153,13 @@ trait Searchable
                 'type',
                 'code'
             ),
-            fn ($type) => ['type' => match($type) {
-                'int' => 'integer',
-                'decimal' => 'double',
+            fn ($type) => ['type' => match ($type) {
+                'int'      => 'integer',
+                'decimal'  => 'double',
                 'datetime' => 'date',
-                'text' => 'text',
-                'varchar' => 'text',
-                default => 'text'
+                'text'     => 'text',
+                'varchar'  => 'text',
+                default    => 'text'
             }]
         );
 

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -157,13 +157,13 @@ trait Searchable
                 'int'      => 'integer',
                 'decimal'  => 'double',
                 'datetime' => 'date',
-                default    => 'text'
+                default    => null
             }]
         );
 
         return [
             'properties' => [
-                ...$attributeTypeMapping,
+                ...Arr::where($attributeTypeMapping, fn($mapping) => $mapping['type'] !== null),
                 'price' => [
                     'type' => 'double',
                 ],

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -163,7 +163,7 @@ trait Searchable
 
         return [
             'properties' => [
-                ...Arr::where($attributeTypeMapping, fn($mapping) => $mapping['type'] !== null),
+                ...Arr::where($attributeTypeMapping, fn ($mapping) => $mapping['type'] !== null),
                 'price' => [
                     'type' => 'double',
                 ],

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -121,8 +121,51 @@ trait Searchable
 
     protected static function indexMapping(): array
     {
+        $attributeModel = config('rapidez.models.attribute');
+        $attributeTypeMapping = Arr::map(
+            Arr::pluck(
+                $attributeModel::getCachedWhere(function ($attribute) {
+                    if (in_array($attribute['code'], ['msrp_display_actual_price_type', 'price_view', 'shipment_type', 'status'])) {
+                        return false;
+                    }
+
+                    if (in_array($attribute['type'], ['varchar', 'text', 'gallery', 'static'])) {
+                        // Types best left up to ES to interperet the type.
+                        return false;
+                    }
+
+                    if (!empty($attribute['source_model'])) {
+                        // Due to the source model value can be mapped to any type, best to let ES interperet them.
+                        return false;
+                    }
+
+                    if ($attribute['listing'] || $attribute['filter'] || $attribute['search'] || $attribute['sorting']) {
+                        return true;
+                    }
+
+                    $alwaysInFlat = array_merge(['sku'], Eventy::filter('index.' . static::getModelName() . '.attributes', []));
+                    if (in_array($attribute['code'], $alwaysInFlat)) {
+                        return true;
+                    }
+
+                    return false;
+                }),
+                'type',
+                'code'
+            ),
+            fn ($type) => ['type' => match($type) {
+                'int' => 'integer',
+                'decimal' => 'double',
+                'datetime' => 'date',
+                'text' => 'text',
+                'varchar' => 'text',
+                default => 'text'
+            }]
+        );
+
         return [
             'properties' => [
+                ...$attributeTypeMapping,
                 'price' => [
                     'type' => 'double',
                 ],

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -158,7 +158,7 @@ trait Searchable
                     'decimal'  => 'double',
                     'datetime' => 'date',
                     default    => null
-                }
+                },
             ])
             ->whereNotNull('type');
 


### PR DESCRIPTION
This PR basically takes all indexable attributes, tries to determine their type and pass it to elasticsearch.

The biggest usecase for this is custom range sliders which WILL break if the type is set to a textual type.
It's also some data optimisation for Elasticsearch.