### PR TITLE
Fix quantity steps being thrown off by min_sales_qty

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -210,7 +210,7 @@ class Product extends Model
 
     public function getMinSaleQtyAttribute(int $minSalesQty): int
     {
-        if (!$this->qty_increments) {
+        if (! $this->qty_increments) {
             return $minSalesQty;
         }
         $remainder = $minSalesQty % $this->qty_increments;


### PR DESCRIPTION
the `step` counts from `min`
If step size is 10 magento will expect 10, 20, 30, etc. to be sent.
When a `min_sale_qty` of 1 is given, it will set the `min` to 1, so step sizes will go 11, 21, 31, etc. instead.

This attribute getter will lock to the next qty_increment step to ensure the steps are correct. e.g.

With a step size of 10
`min_sale_qty` of 1-10 will result in 10
`min_sale_qty` of 11-20 will result in 20
and so on...