### PR TITLE
Credentials form fixes

### DIFF
--- a/resources/views/checkout/partials/address.blade.php
+++ b/resources/views/checkout/partials/address.blade.php
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-12 gap-3">
+<div class="grid grid-cols-12 gap-5">
     <div class="col-span-12" v-if="$root.loggedIn">
         <graphql query="{ customer { addresses { id firstname lastname street city postcode country_code } } }">
             <div v-if="data" slot-scope="{ data }">
@@ -17,6 +17,35 @@
     </div>
 
     <div class="contents" v-if="!$root.loggedIn || !variables.customer_address_id">
+        @if ((Rapidez::config('customer/address/company_show')) || (Rapidez::config('customer/address/taxvat_show')))
+            <div class="grid col-span-12 grid-cols-12 gap-5">
+                @if (Rapidez::config('customer/address/company_show'))
+                    <div class="col-span-12 sm:col-span-6">
+                        <label>
+                            <x-rapidez::label>@lang('Company')</x-rapidez::label>
+                            <x-rapidez::input
+                                name="{{ $type }}_company"
+                                v-model="variables.company"
+                                :required="Rapidez::config('customer/address/company_show') == 'req'"
+                            />
+                        </label>
+                    </div>
+                @endif
+                @if (Rapidez::config('customer/address/taxvat_show'))
+                    <div class="col-span-12 sm:col-span-6">
+                        <label>
+                            <x-rapidez::label>@lang('Tax ID')</x-rapidez::label>
+                            <x-rapidez::input
+                                name="{{ $type }}_vat_id"
+                                v-model="variables.vat_id"
+                                v-on:change="window.app.$emit('vat-change', $event)"
+                                :required="Rapidez::config('customer/address/taxvat_show') == 'req'"
+                            />
+                        </label>
+                    </div>
+                @endif
+            </div>
+        @endif
         @if (Rapidez::config('customer/address/prefix_show') && strlen(Rapidez::config('customer/address/prefix_options')))
             <div class="col-span-12">
                 <label>
@@ -90,62 +119,7 @@
                 </label>
             </div>
         @endif
-        <div class="col-span-6 sm:col-span-3">
-            <label>
-                <x-rapidez::label>@lang('Postcode')</x-rapidez::label>
-                <x-rapidez::input
-                    name="{{ $type }}_postcode"
-                    v-model="variables.postcode"
-                    v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', variables))"
-                    required
-                />
-            </label>
-        </div>
-        @if (Rapidez::config('customer/address/street_lines') >= 2)
-            <div class="col-span-6 sm:col-span-3">
-                <label>
-                    <x-rapidez::label>@lang('Housenumber')</x-rapidez::label>
-                    <x-rapidez::input
-                        name="{{ $type }}_housenumber"
-                        v-model="variables.street[1]"
-                        v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', variables))"
-                        required
-                    />
-                </label>
-            </div>
-        @endif
-        @if (Rapidez::config('customer/address/street_lines') >= 3)
-            <div class="col-span-6 sm:col-span-3">
-                <label>
-                    <x-rapidez::label>@lang('Addition')</x-rapidez::label>
-                    <x-rapidez::input
-                        name="{{ $type }}_addition"
-                        v-model="variables.street[2]"
-                    />
-                </label>
-            </div>
-        @endif
-        <div class="col-span-6 sm:col-span-3">
-            <label>
-                <x-rapidez::label>@lang('Street')</x-rapidez::label>
-                <x-rapidez::input
-                    name="{{ $type }}_street"
-                    v-model="variables.street[0]"
-                    required
-                />
-            </label>
-        </div>
-        <div class="col-span-12 sm:col-span-6 sm:col-start-1">
-            <label>
-                <x-rapidez::label>@lang('City')</x-rapidez::label>
-                <x-rapidez::input
-                    name="{{ $type }}_city"
-                    v-model="variables.city"
-                    required
-                />
-            </label>
-        </div>
-        <div class="col-span-12 sm:col-span-6 sm:col-start-1">
+        <div class="col-span-12 sm:has-[+*_.region.exists]:col-span-3 sm:col-span-6">
             <label>
                 <x-rapidez::label>@lang('Country')</x-rapidez::label>
                 <x-rapidez::input.select.country
@@ -160,11 +134,11 @@
                 />
             </label>
         </div>
-        <div class="col-span-12 sm:col-span-6 has-[.exists]:block hidden">
+        <div class="col-span-12 sm:col-span-3 has-[.region.exists]:block hidden">
             <label>
                 <x-rapidez::label>@lang('Region')</x-rapidez::label>
                 <x-rapidez::input.select.region
-                    class="exists"
+                    class="region exists"
                     name="{{ $type }}_region"
                     dusk="{{ $type }}_region"
                     country="variables.country_code"
@@ -173,7 +147,7 @@
             </label>
         </div>
         @if (Rapidez::config('customer/address/telephone_show'))
-            <div class="col-span-12 sm:col-span-6 sm:col-start-1">
+            <div class="col-span-12 sm:col-span-6">
                 <label>
                     <x-rapidez::label>@lang('Telephone')</x-rapidez::label>
                     <x-rapidez::input
@@ -184,6 +158,61 @@
                 </label>
             </div>
         @endif
+        <div class="col-span-12 {{ Rapidez::config('customer/address/street_lines') >= 3 ? 'sm:col-span-4' : 'sm:col-span-6' }}">
+            <label>
+                <x-rapidez::label>@lang('Postcode')</x-rapidez::label>
+                <x-rapidez::input
+                    name="{{ $type }}_postcode"
+                    v-model="variables.postcode"
+                    v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', variables))"
+                    required
+                />
+            </label>
+        </div>
+        @if (Rapidez::config('customer/address/street_lines') >= 2)
+            <div class="{{ Rapidez::config('customer/address/street_lines') >= 3 ? 'col-span-6 sm:col-span-4' : 'col-span-12 sm:col-span-6' }}">
+                <label>
+                    <x-rapidez::label>@lang('Housenumber')</x-rapidez::label>
+                    <x-rapidez::input
+                        name="{{ $type }}_housenumber"
+                        v-model="variables.street[1]"
+                        v-on:change="$root.$nextTick(() => window.app.$emit('postcode-change', variables))"
+                        required
+                    />
+                </label>
+            </div>
+        @endif
+        @if (Rapidez::config('customer/address/street_lines') >= 3)
+            <div class="col-span-6 sm:col-span-4">
+                <label>
+                    <x-rapidez::label>@lang('Addition')</x-rapidez::label>
+                    <x-rapidez::input
+                        name="{{ $type }}_addition"
+                        v-model="variables.street[2]"
+                    />
+                </label>
+            </div>
+        @endif
+        <div class="col-span-12 sm:col-span-6">
+            <label>
+                <x-rapidez::label>@lang('Street')</x-rapidez::label>
+                <x-rapidez::input
+                    name="{{ $type }}_street"
+                    v-model="variables.street[0]"
+                    required
+                />
+            </label>
+        </div>
+        <div class="col-span-12 sm:col-span-6">
+            <label>
+                <x-rapidez::label>@lang('City')</x-rapidez::label>
+                <x-rapidez::input
+                    name="{{ $type }}_city"
+                    v-model="variables.city"
+                    required
+                />
+            </label>
+        </div>
         @if (Rapidez::config('customer/address/fax_show'))
             <div class="col-span-12 sm:col-span-6">
                 <label>
@@ -192,31 +221,6 @@
                         name="{{ $type }}_fax"
                         v-model="variables.fax"
                         :required="Rapidez::config('customer/address/fax_show') === 'req'"
-                    />
-                </label>
-            </div>
-        @endif
-        @if (Rapidez::config('customer/address/company_show'))
-            <div class="col-span-12 sm:col-span-6 sm:col-start-1">
-                <label>
-                    <x-rapidez::label>@lang('Company')</x-rapidez::label>
-                    <x-rapidez::input
-                        name="{{ $type }}_company"
-                        v-model="variables.company"
-                        :required="Rapidez::config('customer/address/company_show') == 'req'"
-                    />
-                </label>
-            </div>
-        @endif
-        @if (Rapidez::config('customer/address/taxvat_show'))
-            <div class="col-span-12 sm:col-span-6">
-                <label>
-                    <x-rapidez::label>@lang('Tax ID')</x-rapidez::label>
-                    <x-rapidez::input
-                        name="{{ $type }}_vat_id"
-                        v-model="variables.vat_id"
-                        v-on:change="window.app.$emit('vat-change', $event)"
-                        :required="Rapidez::config('customer/address/taxvat_show') == 'req'"
                     />
                 </label>
             </div>


### PR DESCRIPTION
Fixes for the credentials form: 
**Before multistep:**
<img width="1121" alt="Scherm­afbeelding 2025-06-25 om 10 10 10" src="https://github.com/user-attachments/assets/6bb12d02-70c7-45be-b775-d6f509cae8ba" />
**Before one step:**
<img width="1098" alt="Scherm­afbeelding 2025-06-25 om 10 10 20" src="https://github.com/user-attachments/assets/1a6f21a9-d457-4453-81f0-6a6d1f2d9ffe" />
**After multistep:**
<img width="1138" alt="Scherm­afbeelding 2025-06-25 om 10 09 27" src="https://github.com/user-attachments/assets/0d4a6e42-f1f1-4434-aac1-d1445c065f62" />
**After onestep:**
<img width="1111" alt="Scherm­afbeelding 2025-06-25 om 10 10 03" src="https://github.com/user-attachments/assets/b5e2a98b-b367-43c9-8117-548537e56d9b" />

_There are some conditional fields for example `region field` that will shown when selecting Italy_
<img width="1101" alt="Scherm­afbeelding 2025-06-25 om 10 14 53" src="https://github.com/user-attachments/assets/5b604a04-fc0b-4ba3-a363-0600978a7097" />
_Also added checks in the styling when the `Addition` is shown or not_

Internal ref (RAP-1404) show a  toggle to switch between Consumer and Business

_Made also the gap a little big bigger between the fields._
