### PR TITLE
[2.x] Support negative product option prices

### DIFF
--- a/src/Models/ProductOption.php
+++ b/src/Models/ProductOption.php
@@ -54,11 +54,13 @@ class ProductOption extends Model
                     return;
                 }
 
+                $prefix = $this->price->price >= 0 ? '+ ' : '- ';
+
                 if ($this->price->price_type == 'percent') {
-                    return '+ ' . floatval($this->price->price) . '%';
+                    return $prefix . floatval($this->price->price) . '%';
                 }
 
-                return '+ ' . price($this->price->price);
+                return $prefix . price($this->price->price);
             },
         )->shouldCache();
     }

--- a/src/Models/ProductOptionTypeValue.php
+++ b/src/Models/ProductOptionTypeValue.php
@@ -50,11 +50,13 @@ class ProductOptionTypeValue extends Model
                     return;
                 }
 
+                $prefix = $this->price->price >= 0 ? '+ ' : '- ';
+
                 if ($this->price->price_type == 'percent') {
-                    return '+ ' . floatval($this->price->price) . '%';
+                    return $prefix . floatval($this->price->price) . '%';
                 }
 
-                return '+ ' . price($this->price->price);
+                return $prefix . price($this->price->price);
             },
         )->shouldCache();
     }


### PR DESCRIPTION
This PR will make it possible to show lowered prices in product options (e.g. trading something in, or a default feature included in the default price that can be disabled)