### PR TITLE
[2.x] Added possibility for custom query in productlist component

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -1,19 +1,22 @@
-@props(['value', 'title' => false, 'field' => 'sku.keyword'])
-
-@if ($value)
+@props(['value' => null, 'dslQuery' => null, 'limit' => 999, 'title' => false, 'field' => 'sku.keyword'])
+@if ($value || $dslQuery)
     <lazy v-slot="{ intersected }">
         <listing v-if="intersected">
             <x-rapidez::reactive-base>
                 <reactive-list
-                    component-id="{{ md5(serialize($value)) }}"
+                    component-id="{{ md5(serialize($value ?? $dslQuery)) }}"
                     data-field="{{ $field }}"
-                    :size="999"
+                    :size="{{ $limit }}"
                     :infinite-scroll="false"
-                    :default-query="function () { return { query: { terms: { '{{ $field }}': {!!
-                        is_array($value)
-                            ? "['".implode("','", $value)."']"
-                            : $value
-                    !!} } } } }"
+                    @if ($dslQuery)
+                        :default-query="function () { return { query: {{ $dslQuery }} } }"
+                    @else
+                        :default-query="function () { return { query: { terms: { '{{ $field }}': {!!
+                            is_array($value)
+                                ? "['".implode("','", $value)."']"
+                                : $value
+                        !!} } } } }"
+                    @endif
                 >
                     @if ($title)
                         <strong class="font-bold text-2xl mt-5" slot="renderResultStats">


### PR DESCRIPTION
This is the 2.x variant for https://github.com/rapidez/core/pull/914.
As the title states i added a possibility to add a custom query in the productlist component.
This addition is wanted from https://github.com/rapidez/statamic-query-builder/pull/5#discussion_r2171080072.
Nothing will change for this component when the dslQuery has not been set.