### PR TITLE
Implement custom elasticsearch engine to support opensearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "laravel/scout": "^10.14",
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.0|^5.3",
-        "matchish/laravel-scout-elasticsearch": "^7.11",
+        "rapidez/laravel-scout-elasticsearch": "<1.0.0",
         "rapidez/blade-components": "^1.10",
         "rapidez/blade-directives": "^1.1",
         "rapidez/laravel-multi-cache": "^2.0",
@@ -64,7 +64,7 @@
         "laravel": {
             "providers": [
                 "Rapidez\\Core\\RapidezServiceProvider",
-                "Matchish\\ScoutElasticSearch\\ElasticSearchServiceProvider"
+                "Rapidez\\ScoutElasticSearch\\ElasticSearchServiceProvider"
             ],
             "aliases": {
                 "Rapidez": "Rapidez\\Core\\Facades\\Rapidez"

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -230,7 +230,7 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function bootScout(): self
     {
-        config()->set('scout.driver', 'Matchish\\ScoutElasticSearch\\Engines\\ElasticSearchEngine');
+        config()->set('scout.driver', 'Rapidez\\ScoutElasticSearch\\Engines\\ElasticSearchEngine');
 
         return $this;
     }


### PR DESCRIPTION
This PR adds the opensearch engine compatibility by adding
```env
SCOUT_SEARCH_BACKEND=opensearch
```
to your .env

There will also be some mapping done to support the flattened type.
https://github.com/rapidez/laravel-scout-elasticsearch/commit/11c978986b1f52744370a1891100b175d4857024

docs: https://github.com/rapidez/docs/pull/100