### PR TITLE
[4.x] Sort super attributes correctly

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -177,16 +177,11 @@ export default {
         getOptions: function (superAttributeCode) {
             if (window.config.swatches.hasOwnProperty(superAttributeCode)) {
                 let swatchOptions = window.config.swatches[superAttributeCode].options
-                let values = {}
 
-                Object.entries(this.product['super_' + superAttributeCode]).forEach(([key, val]) => {
-                    let swatch = Object.values(swatchOptions).find((swatch) => swatch.value === val)
-                    if (swatch) {
-                        values[val] = swatch
-                    }
-                })
-
-                return values
+                return Object.values(this.product['super_' + superAttributeCode])
+                    .map((value) => Object.values(swatchOptions).find((swatch) => swatch.value === value))
+                    .sort((a, b) => a.label.localeCompare(b.label))
+                    .sort((a, b) => a.sort_order - b.sort_order)
             }
 
             return {}

--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -180,6 +180,7 @@ export default {
 
                 return Object.values(this.product['super_' + superAttributeCode])
                     .map((value) => Object.values(swatchOptions).find((swatch) => swatch.value === value))
+                    .filter(Boolean)
                     .sort((a, b) => a.label.localeCompare(b.label))
                     .sort((a, b) => a.sort_order - b.sort_order)
             }

--- a/resources/views/product/partials/super_attributes.blade.php
+++ b/resources/views/product/partials/super_attributes.blade.php
@@ -14,7 +14,7 @@
                 @lang('Select') {{ strtolower($superAttribute->label) }}
             </option>
             <option
-                v-for="option in Object.values(config.product.super_{{ $superAttribute->code }}).sort((a, b) => a.sort_order - b.sort_order)"
+                v-for="option in Object.values(config.product.super_{{ $superAttribute->code }}).sort((a, b) => a.label.localeCompare(b.label)).sort((a, b) => a.sort_order - b.sort_order)"
                 v-text="option.label"
                 :value="option.value"
                 :disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes(option.value)"


### PR DESCRIPTION
This fixes two issues:

- Super attributes didn't get sorted at all in product listings, causing them to always be sorted by value.
- Super attributes got sorted by `sort_order`, however when there are duplicate `sort_order` values the tiebreaker should be alphabetical based on label.

I've also lightly cleaned up the `getOptions` code here.