### PR TITLE
[2.x] Fix checkout navigation history with Turbo

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -277,11 +277,7 @@ export default {
                 this.checkout.step = this.steps.indexOf(window.location.hash.substring(1))
             })
 
-            history.replaceState(
-                { turbo: { restorationIdentifier: Turbo.session.restorationIdentifier } },
-                null,
-                '#' + this.steps[this.checkout.step],
-            )
+            history.replaceState(history.state, null, '#' + this.steps[this.checkout.step])
         },
     },
 
@@ -336,11 +332,7 @@ export default {
         'checkout.step': function () {
             if (this.backEvent) {
                 this.backEvent = false
-                history.replaceState(
-                    { turbo: { restorationIdentifier: Turbo.session.restorationIdentifier } },
-                    null,
-                    '#' + this.steps[this.checkout.step],
-                )
+                history.replaceState(history.state, null, '#' + this.steps[this.checkout.step])
                 return
             }
 


### PR DESCRIPTION
Note: This issue only occurs in 2.x

When navigating to the checkout and then back to the homepage (by clicking the logo or similar), the back button will not send you back to the checkout anymore. This is because Turbo gets confused when you replace the current state without adding the `restorationIdentifier`.

I've used the current `history.state` variable for simplicity. If you wanted to be extremely specific about only adding the `restorationIdentifier`, you'd want to use this object:
```
{ turbo: { restorationIdentifier: Turbo.session.restorationIdentifier } }
```