### PR TITLE
[4.x] Use Attribute casts instead of getXxxAttribute

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,4 +10,5 @@ parameters:
         - '#^Result of static method TorMorten\\Eventy\\Events::#'
         - "#Access to an undefined property#"
         - "#::waitUntilIdle#"
+    checkModelAppends: false
     level: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,4 @@ parameters:
         - '#^Result of static method TorMorten\\Eventy\\Events::#'
         - "#Access to an undefined property#"
         - "#::waitUntilIdle#"
-    checkModelAppends: false
     level: 1

--- a/resources/views/listing/partials/item/super_attributes.blade.php
+++ b/resources/views/listing/partials/item/super_attributes.blade.php
@@ -12,10 +12,10 @@
             @lang('Select') @{{ superAttribute.label.toLowerCase() }}
         </option>
         <option
-            v-for="(option, optionId) in addToCart.getOptions(superAttribute.code)"
+            v-for="option in addToCart.getOptions(superAttribute.code)"
             v-text="option.label"
-            :value="optionId"
-            :disabled="addToCart.disabledOptions['super_'+superAttribute.code].includes(optionId)"
+            :value="option.value"
+            :disabled="addToCart.disabledOptions['super_'+superAttribute.code].includes(option.value)"
         />
     </x-rapidez::input.select>
 </label>

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -109,7 +109,7 @@ class Category extends Model
                     ->orderByRaw('FIELD(' . $this->getQualifiedKeyName() . ',' . implode(',', $categoryIds) . ')')
                     ->get();
             }
-        );
+        )->shouldCache();
     }
 
     /**

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -63,7 +63,7 @@ class Category extends Model
         return 'catalog_category_flat_store_' . config('rapidez.store');
     }
 
-    public function url(): Attribute
+    protected function url(): Attribute
     {
         return Attribute::make(
             get: fn () => '/' . ($this->url_path ? $this->url_path : 'catalog/category/view/id/' . $this->entity_id)
@@ -98,7 +98,7 @@ class Category extends Model
             ->where('entity_type', 'category');
     }
 
-    public function parentcategories(): Attribute
+    protected function parentcategories(): Attribute
     {
         return Attribute::make(
             get: function () {

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -244,27 +244,32 @@ class Product extends Model
     {
         return Attribute::make(
             get: fn (): array => $this->gallery->sortBy('productImageValue.position')->pluck('value')->toArray()
-        );
+        )->shouldCache();
+    }
+
+    private function getImageFrom(?string $image): ?string
+    {
+        return $image !== 'no_selection' ? $image : null;
     }
 
     public function image(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $image): ?string => $image !== 'no_selection' ? $image : null
+            get: $this->getImageFrom(...)
         );
     }
 
     public function smallImage(): Attribute
     {
         return Attribute::make(
-            get: fn (): ?string => $this->image
+            get: $this->getImageFrom(...)
         );
     }
 
     public function thumbnail(): Attribute
     {
         return Attribute::make(
-            get: fn (): ?string => $this->image
+            get: $this->getImageFrom(...)
         );
     }
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -221,14 +221,18 @@ class Product extends Model
         return $minSalesQty - $remainder + $this->qty_increments;
     }
 
-    public function getUrlAttribute(): string
+    public function url(): Attribute
     {
-        return '/' . ($this->url_key ? $this->url_key . Rapidez::config('catalog/seo/product_url_suffix') : 'catalog/product/view/id/' . $this->entity_id);
+        return Attribute::make(
+            get: fn() => '/' . ($this->url_key ? $this->url_key . Rapidez::config('catalog/seo/product_url_suffix') : 'catalog/product/view/id/' . $this->entity_id)
+        );
     }
 
-    public function getImagesAttribute(): array
+    public function images(): Attribute
     {
-        return $this->gallery->sortBy('productImageValue.position')->pluck('value')->toArray();
+        return Attribute::make(
+            get: fn() => $this->gallery->sortBy('productImageValue.position')->pluck('value')->toArray()
+        );
     }
 
     public function getImageAttribute($image): ?string

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -167,7 +167,7 @@ class Product extends Model
     public function price(): Attribute
     {
         return Attribute::make(
-            get: function(?float $price): ?float {
+            get: function (?float $price): ?float {
                 if ($this->type_id == 'configurable') {
                     return collect($this->children)->min->price;
                 }
@@ -184,7 +184,7 @@ class Product extends Model
     public function specialPrice(): Attribute
     {
         return Attribute::make(
-            get: function(?float $specialPrice): ?float {
+            get: function (?float $specialPrice): ?float {
                 if (! in_array($this->type_id, ['configurable', 'grouped'])) {
                     if ($this->special_from_date && $this->special_from_date > now()->toDateTimeString()) {
                         return null;
@@ -219,7 +219,7 @@ class Product extends Model
     public function minSaleQty(): Attribute
     {
         return Attribute::make(
-            get: function(?int $minSaleQty): ?int {
+            get: function (?int $minSaleQty): ?int {
                 if (! $this->qty_increments) {
                     return $minSaleQty;
                 }

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -164,7 +164,7 @@ class Product extends Model
         return $query->whereIn($this->getQualifiedKeyName(), $productIds);
     }
 
-    public function price(): Attribute
+    protected function price(): Attribute
     {
         return Attribute::make(
             get: function (?float $price): ?float {
@@ -181,7 +181,7 @@ class Product extends Model
         );
     }
 
-    public function specialPrice(): Attribute
+    protected function specialPrice(): Attribute
     {
         return Attribute::make(
             get: function (?float $specialPrice): ?float {
@@ -216,7 +216,7 @@ class Product extends Model
         );
     }
 
-    public function minSaleQty(): Attribute
+    protected function minSaleQty(): Attribute
     {
         return Attribute::make(
             get: function (?int $minSaleQty): ?int {
@@ -233,14 +233,14 @@ class Product extends Model
         );
     }
 
-    public function url(): Attribute
+    protected function url(): Attribute
     {
         return Attribute::make(
             get: fn (): string => '/' . ($this->url_key ? $this->url_key . Rapidez::config('catalog/seo/product_url_suffix') : 'catalog/product/view/id/' . $this->entity_id)
         );
     }
 
-    public function images(): Attribute
+    protected function images(): Attribute
     {
         return Attribute::make(
             get: fn (): array => $this->gallery->sortBy('productImageValue.position')->pluck('value')->toArray()
@@ -252,21 +252,21 @@ class Product extends Model
         return $image !== 'no_selection' ? $image : null;
     }
 
-    public function image(): Attribute
+    protected function image(): Attribute
     {
         return Attribute::make(
             get: $this->getImageFrom(...)
         );
     }
 
-    public function smallImage(): Attribute
+    protected function smallImage(): Attribute
     {
         return Attribute::make(
             get: $this->getImageFrom(...)
         );
     }
 
-    public function thumbnail(): Attribute
+    protected function thumbnail(): Attribute
     {
         return Attribute::make(
             get: $this->getImageFrom(...)


### PR DESCRIPTION
We still used the old `getXxxAttribute()` functionality in a few places. This PR replaces all of those with the Attribute cast.