### PR TITLE
[2.x] Fix login & option to allow checkout without login

### DIFF
--- a/config/rapidez/frontend.php
+++ b/config/rapidez/frontend.php
@@ -29,6 +29,9 @@ return [
         'default' => ['cart', 'login', 'credentials', 'payment', 'success'],
     ],
 
+    // If set to true, you will not be required to log in when attempting to check out with an existing email address
+    'allow_guest_on_existing_account' => false,
+
     'autocomplete' => [
         // Attach additional indexes to the autocomplete
         // Uses the views in rapidez::layouts.partials.header.autocomplete

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -52,24 +52,24 @@ export default {
                 })
             } else if (this.email) {
                 await this.checkEmailAvailability()
+
+                if (this.emailAvailable) {
+                    this.$root.guestEmail = this.email
+                    this.$root.checkout.step = this.nextStep
+                } else {
+                    this.$nextTick(function () {
+                        this.$scopedSlots.default()[0].context.$refs.password.focus()
+                    })
+                }
             } else {
                 Notify(window.config.translations.account.email, 'error')
             }
         },
 
         async checkEmailAvailability() {
-            let responseData = await window.magentoAPI('post', 'customers/isEmailAvailable', {
+            this.emailAvailable = await window.magentoAPI('post', 'customers/isEmailAvailable', {
                 customerEmail: this.email,
             })
-
-            if ((this.emailAvailable = responseData)) {
-                this.$root.guestEmail = this.email
-                this.$root.checkout.step = this.nextStep
-            } else {
-                this.$nextTick(function () {
-                    this.$scopedSlots.default()[0].context.$refs.password.focus()
-                })
-            }
         },
 
         loginInputChange(e) {

--- a/resources/js/components/Checkout/Login.vue
+++ b/resources/js/components/Checkout/Login.vue
@@ -33,6 +33,8 @@ export default {
     mounted() {
         if (this.$root.loggedIn) {
             this.successfulLogin()
+        } else if (this.email) {
+            this.checkEmailAvailability()
         }
     },
 

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -21,7 +21,7 @@
                 placeholder="Password"
                 ref="password"
                 v-on:input="loginInputChange"
-                @unless (config('rapidez.frontend.allow_guest_on_existing_account')) required @endunless
+                :required="!config('rapidez.frontend.allow_guest_on_existing_account'))"
             />
 
             <x-rapidez::button type="submit" class="w-full mt-5" dusk="continue">

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -21,7 +21,7 @@
                 placeholder="Password"
                 ref="password"
                 v-on:input="loginInputChange"
-                required
+                @unless (config('rapidez.frontend.allow_guest_on_existing_account')) required @endunless
             />
 
             <x-rapidez::button type="submit" class="w-full mt-5" dusk="continue">

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -21,7 +21,7 @@
                 placeholder="Password"
                 ref="password"
                 v-on:input="loginInputChange"
-                :required="!config('rapidez.frontend.allow_guest_on_existing_account'))"
+                :required="!config('rapidez.frontend.allow_guest_on_existing_account')"
             />
 
             <x-rapidez::button type="submit" class="w-full mt-5" dusk="continue">


### PR DESCRIPTION
Contains a small fix for when a user refreshes making the password field not show up but the email field continues to be filled. This is (as far as I'm aware) only relevant for 2.x.

---

Magento does not actually have an option to require logging in when trying to check out with an existing email address. So, it is weird that Rapidez works the other way around right now.

In principle this config value should default to `true` but I don't want to break backwards compatibility here so I've kept it as `false`.

Note that this will also have to be done in checkout theme, confira, 3.x and 4.x.