### PR TITLE
Updated healthcheck to check opensearch as well

### DIFF
--- a/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
@@ -53,8 +53,7 @@ class ElasticsearchHealthcheck extends Base
             return $response;
         }
 
-        if (! property_exists($data->version, 'distribution')
-            && $data->version->build_flavor !== 'oss'
+        if ($data->version->build_flavor !== 'oss'
             && ! version_compare($data->version->number, $this->esVersion, '>=')
         ) {
             $response['healthy'] = false;

--- a/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
@@ -53,7 +53,7 @@ class ElasticsearchHealthcheck extends Base
             return $response;
         }
 
-        if (!property_exists($data->version, 'distribution')
+        if (! property_exists($data->version, 'distribution')
             && $data->version->build_flavor !== 'oss'
             && ! version_compare($data->version->number, $this->esVersion, '>=')
         ) {

--- a/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/ElasticsearchHealthcheck.php
@@ -2,6 +2,9 @@
 
 namespace Rapidez\Core\Listeners\Healthcheck;
 
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
 class ElasticsearchHealthcheck extends Base
 {
     protected $esVersion = '7.6';
@@ -13,9 +16,44 @@ class ElasticsearchHealthcheck extends Base
             'messages' => [],
         ];
 
-        $data = json_decode(@file_get_contents(config('rapidez.es_url')));
-        if (is_object($data)
-            && property_exists($data, 'version')
+        if (config('elasticsearch.backend_type') !== 'elasticsearch') {
+            return $response;
+        }
+
+        try {
+            $data = Http::withBasicAuth(
+                config('elasticsearch.user'),
+                config('elasticsearch.password')
+            )
+                ->get(config('rapidez.es_url'))
+                ->object();
+        } catch (ConnectionException $e) {
+            $data = null;
+        }
+
+        if (! is_object($data) || ! property_exists($data, 'version')) {
+            $response['healthy'] = false;
+            $response['messages'][] = [
+                'type'  => 'error',
+                'value' => __('Elasticsearch is not reachable at: :url', ['url' => config('rapidez.es_url')]),
+            ];
+
+            return $response;
+        }
+
+        if (property_exists($data->version, 'distribution')
+            && $data->version->distribution === 'opensearch'
+        ) {
+            $response['healthy'] = false;
+            $response['messages'][] = [
+                'type'  => 'error',
+                'value' => __('SCOUT_SEARCH_BACKEND is set to elasticsearch, but the given ELASTICSEARCH_URL seems to be opensearch!'),
+            ];
+
+            return $response;
+        }
+
+        if (!property_exists($data->version, 'distribution')
             && $data->version->build_flavor !== 'oss'
             && ! version_compare($data->version->number, $this->esVersion, '>=')
         ) {
@@ -25,12 +63,6 @@ class ElasticsearchHealthcheck extends Base
                 'value' => __('Your Elasticsearch version is too low!') . PHP_EOL .
                     __('Your version: :version (:build_flavour)', ['version' => $data->version->number, 'build_flavour' => $data->version->build_flavor]) . PHP_EOL .
                     __('You need at least: :version basic/default (non OSS version)', ['version' => $this->esVersion]),
-            ];
-        } elseif (! is_object($data) || ! property_exists($data, 'version')) {
-            $response['healthy'] = false;
-            $response['messages'][] = [
-                'type'  => 'error',
-                'value' => __('Elasticsearch is not reachable at: :url', ['url' => config('rapidez.es_url')]),
             ];
         }
 

--- a/src/Listeners/Healthcheck/OpensearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/OpensearchHealthcheck.php
@@ -39,7 +39,7 @@ class OpensearchHealthcheck extends Base
             return $response;
         }
 
-        if (!property_exists($data->version, 'distribution')
+        if (! property_exists($data->version, 'distribution')
             || $data->version->distribution !== 'opensearch'
         ) {
             $response['healthy'] = false;

--- a/src/Listeners/Healthcheck/OpensearchHealthcheck.php
+++ b/src/Listeners/Healthcheck/OpensearchHealthcheck.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rapidez\Core\Listeners\Healthcheck;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+class OpensearchHealthcheck extends Base
+{
+    public function handle()
+    {
+        $response = [
+            'healthy'  => true,
+            'messages' => [],
+        ];
+
+        if (config('elasticsearch.backend_type') !== 'opensearch') {
+            return $response;
+        }
+
+        try {
+            $data = Http::withBasicAuth(
+                config('elasticsearch.user'),
+                config('elasticsearch.password')
+            )
+                ->get(config('rapidez.es_url'))
+                ->object();
+        } catch (ConnectionException $e) {
+            $data = null;
+        }
+
+        if (! is_object($data) || ! property_exists($data, 'version')) {
+            $response['healthy'] = false;
+            $response['messages'][] = [
+                'type'  => 'error',
+                'value' => __('Opensearch is not reachable at: :url', ['url' => config('rapidez.es_url')]),
+            ];
+
+            return $response;
+        }
+
+        if (!property_exists($data->version, 'distribution')
+            || $data->version->distribution !== 'opensearch'
+        ) {
+            $response['healthy'] = false;
+            $response['messages'][] = [
+                'type'  => 'error',
+                'value' => __('SCOUT_SEARCH_BACKEND is set to opensearch, but the given ELASTICSEARCH_URL does not seem to be opensearch!'),
+            ];
+        }
+
+        return $response;
+    }
+}

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -35,6 +35,7 @@ use Rapidez\Core\Http\Middleware\DetermineAndSetShop;
 use Rapidez\Core\Listeners\Healthcheck\ElasticsearchHealthcheck;
 use Rapidez\Core\Listeners\Healthcheck\MagentoSettingsHealthcheck;
 use Rapidez\Core\Listeners\Healthcheck\ModelsHealthcheck;
+use Rapidez\Core\Listeners\Healthcheck\OpensearchHealthcheck;
 use Rapidez\Core\Listeners\ReportProductView;
 use Rapidez\Core\Listeners\UpdateLatestIndexDate;
 use Rapidez\Core\ViewComponents\PlaceholderComponent;
@@ -249,6 +250,7 @@ class RapidezServiceProvider extends ServiceProvider
         ModelsHealthcheck::register();
         MagentoSettingsHealthcheck::register();
         ElasticsearchHealthcheck::register();
+        OpensearchHealthcheck::register();
         UpdateLatestIndexDate::register();
 
         return $this;


### PR DESCRIPTION
Fixes: rapidez/rapidez#99

This PR adds an additional health check to check opensearch reachability.
Now also utilising Laravels http facade in order to use admin credentials so the web user does not need access to the Elastic/opensearch servers status and version.