### PR TITLE
[3.x] Add backorder & fixed product taxes

### DIFF
--- a/resources/views/cart/queries/fragments/cart.graphql
+++ b/resources/views/cart/queries/fragments/cart.graphql
@@ -5,6 +5,9 @@ fragment cart on Cart {
     items {
         id
         quantity
+        @if (Rapidez::checkCompadreVersion('0.0.2'))
+            qty_backordered
+        @endif
         product {
             ...product
         }
@@ -20,6 +23,12 @@ fragment cart on Cart {
             }
             row_total_including_tax {
                 value
+            }
+            fixed_product_taxes {
+                amount {
+                    value
+                }
+                label
             }
         }
         ... on SimpleCartItem {


### PR DESCRIPTION
These were present in the old query, but seem to have been forgotten in the update to the fragment.