### PR TITLE
[4.x] Don't add .keyword to the productlist fieldname

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -1,4 +1,4 @@
-@props(['value', 'title' => false, 'field' => 'sku.keyword'])
+@props(['value', 'title' => false, 'field' => 'sku'])
 
 @if ($value)
     <lazy v-slot="{ intersected }">

--- a/resources/views/widget/productlist.blade.php
+++ b/resources/views/widget/productlist.blade.php
@@ -1,1 +1,1 @@
-<x-rapidez::productlist :title="$options->title ?? false" field="{{ $condition->attribute }}.keyword" :value="array_map('trim', explode(',', $condition->value))"/>
+<x-rapidez::productlist :title="$options->title ?? false" field="{{ $condition->attribute }}" :value="array_map('trim', explode(',', $condition->value))"/>


### PR DESCRIPTION
Searchkit/instantsearch don't expect the keyword to be added by us. This causes an error on productlists that use the default `sku.keyword` field value, which we didn't notice only because there are none of those within the core right now.