### PR TITLE
Playwright run on branch fix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Get commit hash and tag of the core
         working-directory: ./rapidez/core
         run: |
-          echo "CORE_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "CORE_HASH=$(git rev-parse --abbrev-ref HEAD  | sed 's|/|_|g')" >> $GITHUB_ENV
           echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Composer require the local rapidez/core


### PR DESCRIPTION
To fix errors like:
```
Problem 1
    - Root composer.json requires rapidez/core dev-34ce4933[31](https://github.com/rapidez/core/actions/runs/16472486228/job/46565053147#step:10:32)45dc88199418cccbb9e749e3e597e6 as 4.2.0, found rapidez/core[dev-master] but it does not match the constraint.
```