### PR TITLE
Support combined unique per store key

### DIFF
--- a/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
+++ b/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
@@ -35,7 +35,7 @@ class ForCurrentStoreWithoutLimitScope implements Scope
             ->where(fn ($query) => $query
                 // Remove values where we already have values in the current store.
                 ->where(function ($query) use ($scope, $model) {
-                    $columnKey = DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn ($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
+                    $columnKey = count($scope->uniquePerStoreKeys) === 1 ? $query->qualifyColumn($scope->uniquePerStoreKeys[0]) : DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn ($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
 
                     $query
                         ->whereNotIn($columnKey, function ($query) use ($scope, $model, $columnKey) {

--- a/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
+++ b/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
@@ -14,8 +14,7 @@ class ForCurrentStoreWithoutLimitScope implements Scope
 {
     public array $uniquePerStoreKeys;
 
-    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id')
-    {
+    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id') {
         $this->uniquePerStoreKeys = is_array($uniquePerStoreKey) ? $uniquePerStoreKey : [$uniquePerStoreKey];
     }
 
@@ -35,18 +34,16 @@ class ForCurrentStoreWithoutLimitScope implements Scope
             ->where(fn ($query) => $query
                 // Remove values where we already have values in the current store.
                 ->where(function ($query) use ($scope, $model) {
-                    $columnKey = count($scope->uniquePerStoreKeys) === 1 ? $query->qualifyColumn($scope->uniquePerStoreKeys[0]) : DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn ($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
-
                     $query
-                        ->whereNotIn($columnKey, function ($query) use ($scope, $model, $columnKey) {
+                        ->whereNotExists(function ($query) use ($scope, $model) {
                             $query
-                                ->select($columnKey)
-                                ->from($model->getTable())
-                                ->where($model->qualifyColumn($scope->storeIdColumn), config('rapidez.store'));
-                            foreach ($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
-                                $query->whereColumn($model->qualifyColumn($uniquePerStoreKey), $model->qualifyColumn($uniquePerStoreKey));
+                                ->select(DB::raw(1))
+                                ->from($model->getTable() . ' as comparison')
+                                ->where('comparison.'.$this->storeIdColumn, config('rapidez.store'));
+                            foreach($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
+                                $query->whereColumn('comparison.'.$uniquePerStoreKey, $model->qualifyColumn($uniquePerStoreKey));
                             }
-                        });
+                    });
                 })
                 // Unless the value IS the current store.
                 ->orWhere($query->qualifyColumn($this->storeIdColumn), config('rapidez.store'))

--- a/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
+++ b/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
@@ -14,7 +14,8 @@ class ForCurrentStoreWithoutLimitScope implements Scope
 {
     public array $uniquePerStoreKeys;
 
-    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id') {
+    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id')
+    {
         $this->uniquePerStoreKeys = is_array($uniquePerStoreKey) ? $uniquePerStoreKey : [$uniquePerStoreKey];
     }
 
@@ -39,11 +40,11 @@ class ForCurrentStoreWithoutLimitScope implements Scope
                             $query
                                 ->select(DB::raw(1))
                                 ->from($model->getTable() . ' as comparison')
-                                ->where('comparison.'.$this->storeIdColumn, config('rapidez.store'));
-                            foreach($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
-                                $query->whereColumn('comparison.'.$uniquePerStoreKey, $model->qualifyColumn($uniquePerStoreKey));
+                                ->where('comparison.' . $this->storeIdColumn, config('rapidez.store'));
+                            foreach ($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
+                                $query->whereColumn('comparison.' . $uniquePerStoreKey, $model->qualifyColumn($uniquePerStoreKey));
                             }
-                    });
+                        });
                 })
                 // Unless the value IS the current store.
                 ->orWhere($query->qualifyColumn($this->storeIdColumn), config('rapidez.store'))

--- a/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
+++ b/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
@@ -14,7 +14,8 @@ class ForCurrentStoreWithoutLimitScope implements Scope
 {
     public array $uniquePerStoreKeys;
 
-    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id') {
+    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id')
+    {
         $this->uniquePerStoreKeys = is_array($uniquePerStoreKey) ? $uniquePerStoreKey : [$uniquePerStoreKey];
     }
 
@@ -34,7 +35,7 @@ class ForCurrentStoreWithoutLimitScope implements Scope
             ->where(fn ($query) => $query
                 // Remove values where we already have values in the current store.
                 ->where(function ($query) use ($scope, $model) {
-                    $columnKey = DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
+                    $columnKey = DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn ($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
 
                     $query
                         ->whereNotIn($columnKey, function ($query) use ($scope, $model, $columnKey) {
@@ -42,10 +43,10 @@ class ForCurrentStoreWithoutLimitScope implements Scope
                                 ->select($columnKey)
                                 ->from($model->getTable())
                                 ->where($model->qualifyColumn($scope->storeIdColumn), config('rapidez.store'));
-                            foreach($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
+                            foreach ($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
                                 $query->whereColumn($model->qualifyColumn($uniquePerStoreKey), $model->qualifyColumn($uniquePerStoreKey));
                             }
-                    });
+                        });
                 })
                 // Unless the value IS the current store.
                 ->orWhere($query->qualifyColumn($this->storeIdColumn), config('rapidez.store'))

--- a/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
+++ b/src/Models/Scopes/ForCurrentStoreWithoutLimitScope.php
@@ -5,13 +5,18 @@ namespace Rapidez\Core\Models\Scopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Remove results from the default store when store view specific is found.
  */
 class ForCurrentStoreWithoutLimitScope implements Scope
 {
-    public function __construct(public $uniquePerStoreKey, public $storeIdColumn = 'store_id') {}
+    public array $uniquePerStoreKeys;
+
+    public function __construct(string|array $uniquePerStoreKey, public $storeIdColumn = 'store_id') {
+        $this->uniquePerStoreKeys = is_array($uniquePerStoreKey) ? $uniquePerStoreKey : [$uniquePerStoreKey];
+    }
 
     public function apply(Builder $query, Model $model)
     {
@@ -20,18 +25,28 @@ class ForCurrentStoreWithoutLimitScope implements Scope
                 ->where($query->qualifyColumn($this->storeIdColumn), 0);
         }
 
+        $scope = $this;
+
         return $query
             // Pre-filter results to be default and current store only.
             ->whereIn($query->qualifyColumn($this->storeIdColumn), [0, config('rapidez.store')])
             // Remove values from the default store where values for the current store exist.
             ->where(fn ($query) => $query
                 // Remove values where we already have values in the current store.
-                ->whereNotIn($query->qualifyColumn($this->uniquePerStoreKey), fn ($query) => $query
-                    ->select($model->qualifyColumn($this->uniquePerStoreKey))
-                    ->from($model->getTable())
-                    ->whereColumn($model->qualifyColumn($this->uniquePerStoreKey), $model->qualifyColumn($this->uniquePerStoreKey))
-                    ->where($model->qualifyColumn($this->storeIdColumn), config('rapidez.store'))
-                )
+                ->where(function ($query) use ($scope, $model) {
+                    $columnKey = DB::Raw('CONCAT(' . collect($scope->uniquePerStoreKeys)->map(fn($key) => $query->qualifyColumn($key))->implode(",'-',") . ')');
+
+                    $query
+                        ->whereNotIn($columnKey, function ($query) use ($scope, $model, $columnKey) {
+                            $query
+                                ->select($columnKey)
+                                ->from($model->getTable())
+                                ->where($model->qualifyColumn($scope->storeIdColumn), config('rapidez.store'));
+                            foreach($scope->uniquePerStoreKeys as $uniquePerStoreKey) {
+                                $query->whereColumn($model->qualifyColumn($uniquePerStoreKey), $model->qualifyColumn($uniquePerStoreKey));
+                            }
+                    });
+                })
                 // Unless the value IS the current store.
                 ->orWhere($query->qualifyColumn($this->storeIdColumn), config('rapidez.store'))
             );


### PR DESCRIPTION
This PR adds support for a combined `uniquePerStoreKey`
Not every database table has a single field which is duplicate with multiple stores, but unique otherwise.

An example of what this could work with before is the `catalog_product_entity_media_gallery_value`
`value_id` is completely unique except for `store_id` where it can have the same `value_id`

An example where this wouldn't work before is the `catalog_product_entity_varchar` table.
Where an entry is unique per store only when `attribute_id` and `entity_id` are combined. Since an `attribute` can have values attached and a product can also have multiple values attached, but a product cannot have multiple values of the same attribute attached.

An example of it's usage in that case would be:
```php
new ForCurrentStoreWithoutLimitScope(['entity_id', 'attribute_id'], 'store_id')
```