### PR TITLE
[4.x] Use slot props in listings to avoid instantsearch doing full re-renders

### DIFF
--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -8,17 +8,17 @@
 <div class="min-h-screen">
     <listing
         {{ $attributes }}
-        v-slot="{ loaded, index, searchClient, rangeAttributes, categoryAttributes, hitsPerPage, filters, sortOptions, withFilters, withSwatches, routing, middlewares }"
+        v-slot="listingSlotProps"
         v-cloak
         v-bind:root-path='@json($rootPath)'
     >
         <div>
             <ais-instant-search
-                v-if="searchClient"
-                :search-client="searchClient"
-                :middlewares="middlewares"
-                :index-name="index"
-                :routing="routing"
+                v-if="listingSlotProps.searchClient"
+                :search-client="listingSlotProps.searchClient"
+                :middlewares="listingSlotProps.middlewares"
+                :index-name="listingSlotProps.index"
+                :routing="listingSlotProps.routing"
             >
                 {{ $before ?? '' }}
 

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -5,15 +5,15 @@
         <listing
             {{ $attributes }}
             v-if="intersected"
-            v-slot="{ loaded, index, searchClient, middlewares }"
+            v-slot="listingSlotProps"
             v-cloak
         >
             <div>
                 <ais-instant-search
-                    v-if="searchClient"
-                    :search-client="searchClient"
-                    :index-name="index"
-                    :middlewares="middlewares"
+                    v-if="listingSlotProps.searchClient"
+                    :search-client="listingSlotProps.searchClient"
+                    :index-name="listingSlotProps.index"
+                    :middlewares="listingSlotProps.middlewares"
                 >
                     <ais-configure :filters="'{{ $field }}:({{ is_array($value)
                         ? implode(' OR ', $value)

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -1,9 +1,9 @@
-<autocomplete v-slot="{ searchClient, middlewares, searchHistory }" :hits-per-page="{{ config('rapidez.frontend.autocomplete.size', 3) }}">
+<autocomplete v-slot="autocompleteSlotProps" :hits-per-page="{{ config('rapidez.frontend.autocomplete.size', 3) }}">
     <div class="relative w-full">
         <ais-instant-search
-            v-if="searchClient"
-            :search-client="searchClient"
-            :middlewares="middlewares"
+            v-if="autocompleteSlotProps.searchClient"
+            :search-client="autocompleteSlotProps.searchClient"
+            :middlewares="autocompleteSlotProps.middlewares"
             :index-name="config.index.product"
             class="contents"
             v-cloak

--- a/resources/views/layouts/partials/header/autocomplete/history.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/history.blade.php
@@ -1,12 +1,12 @@
 <ais-state-results v-slot="{ state: { query: searchQuery } }">
     <div>
-        <div v-if="searchHistory && searchHistory?.filter(([query, metadata]) => query.includes(searchQuery.toLowerCase())).length" class="border-b py-2">
+        <div v-if="autocompleteSlotProps.searchHistory && autocompleteSlotProps.searchHistory?.filter(([query, metadata]) => query.includes(searchQuery.toLowerCase())).length" class="border-b py-2">
             <x-rapidez::autocomplete.title>
                 @lang('Previous Searches')
             </x-rapidez::autocomplete.title>
             <ul class="flex flex-col font-sans">
                 <li
-                    v-for="[query, metadata] in searchHistory
+                    v-for="[query, metadata] in autocompleteSlotProps.searchHistory
                         .filter(([query, metadata]) => query.includes(searchQuery.toLowerCase()))
                         .slice(0, {{ Arr::get($fields, 'size', config('rapidez.frontend.autocomplete.size', 3)) }})"
                     class="flex flex-1 items-center w-full hover:bg-muted"
@@ -22,7 +22,7 @@
             </ul>
             {{-- Add search suggestions to the phone's keyboard --}}
             <datalist id="search-history" v-if="window.matchMedia('(pointer:coarse)').matches">
-                <option v-bind:value="query" v-for="[query, metadata] in searchHistory"></option>
+                <option v-bind:value="query" v-for="[query, metadata] in autocompleteSlotProps.searchHistory"></option>
             </datalist>
         </div>
     </div>

--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -1,5 +1,5 @@
 <ais-hierarchical-menu
-    v-bind:attributes="categoryAttributes"
+    v-bind:attributes="listingSlotProps.categoryAttributes"
     v-bind:sort-by="['count','name']"
     @attributes(['root-path' => $rootPath?->join(' > ')])
     show-more

--- a/resources/views/listing/partials/filter/price.blade.php
+++ b/resources/views/listing/partials/filter/price.blade.php
@@ -1,5 +1,5 @@
 <ais-range-input
-    v-if="rangeAttributes.includes(filter.code)"
+    v-if="listingSlotProps.rangeAttributes.includes(filter.code)"
     :attribute="filter.code"
 >
     <template v-slot="{ currentRefinement, range, canRefine, refine, sendEvent }">

--- a/resources/views/listing/partials/filter/selected.blade.php
+++ b/resources/views/listing/partials/filter/selected.blade.php
@@ -1,4 +1,4 @@
-<ais-clear-refinements v-bind:excluded-attributes="[...categoryAttributes, 'query']">
+<ais-clear-refinements v-bind:excluded-attributes="[...listingSlotProps.categoryAttributes, 'query']">
     <template v-slot="{ canRefine, refine, createURL }">
         <div v-show="canRefine" class="flex flex-wrap items-baseline justify-between gap-2 w-full pb-2.5">
             <div class="text-sm">
@@ -19,10 +19,10 @@
 <ais-current-refinements>
     <template v-slot="{ items, createURL }">
         <ul class="flex gap-x-1.5 gap-y-2 flex-wrap has-[li]:pb-4">
-            <template v-for="item in withFilters(items)">
+            <template v-for="item in listingSlotProps.withFilters(items)">
                 <li
                     class="flex flex-wrap relative"
-                    v-for="refinement in withSwatches(item.refinements, item.filter)"
+                    v-for="refinement in listingSlotProps.ithSwatches(item.refinements, item.filter)"
                     :key="[
                       refinement.attribute,
                       refinement.type,

--- a/resources/views/listing/partials/filter/selected.blade.php
+++ b/resources/views/listing/partials/filter/selected.blade.php
@@ -22,7 +22,7 @@
             <template v-for="item in listingSlotProps.withFilters(items)">
                 <li
                     class="flex flex-wrap relative"
-                    v-for="refinement in listingSlotProps.ithSwatches(item.refinements, item.filter)"
+                    v-for="refinement in listingSlotProps.withSwatches(item.refinements, item.filter)"
                     :key="[
                       refinement.attribute,
                       refinement.type,

--- a/resources/views/listing/partials/filter/swatch.blade.php
+++ b/resources/views/listing/partials/filter/swatch.blade.php
@@ -7,7 +7,7 @@
         <x-rapidez::accordion.filter v-show="items.length" canToggleShowMore>
             <x-slot:content>
                 <ul class="flex flex-wrap gap-x-1.5 gap-y-2 items-center pr-14">
-                    <li v-for="item in withSwatches(items, filter)">
+                    <li v-for="item in listingSlotProps.withSwatches(items, filter)">
                         <label
                             v-if="filter.visual_swatch"
                             class="cursor-pointer flex items-center justify-center p-1 rounded-full ring-inset ring-1 has-[:focus]:ring-emphasis relative"

--- a/resources/views/listing/partials/item.blade.php
+++ b/resources/views/listing/partials/item.blade.php
@@ -1,7 +1,7 @@
 <div v-bind:key="item.entity_id" class="px-5 py-10">
     <add-to-cart v-bind:product="item" v-slot="addToCart" v-cloak>
         <div class="group relative flex flex-1 flex-col rounded bg-white h-full">
-            <a :href="addToCart.productUrl | url" v-on:click="sendEvent('click', item, 'Hit Clicked')" class="block mb-auto">
+            <a :href="addToCart.productUrl | url" v-on:click="listingSlotProps.sendEvent('click', item, 'Hit Clicked')" class="block mb-auto">
                 <img
                     v-if="addToCart.currentThumbnail"
                     :src="'/storage/{{ config('rapidez.store') }}/resizes/200/magento/catalog/product' + addToCart.currentThumbnail + '.webp'"

--- a/resources/views/listing/partials/toolbar/pages.blade.php
+++ b/resources/views/listing/partials/toolbar/pages.blade.php
@@ -1,4 +1,4 @@
-<ais-hits-per-page :items="hitsPerPage">
+<ais-hits-per-page :items="listingSlotProps.hitsPerPage">
     <template v-slot="{ items, refine }">
         <select
             v-bind:value="items.find(item => item.isRefined)?.value"


### PR DESCRIPTION
This is kind of a workaround, as a fix for this exact issue has eluded me.

---

When you have a Vue component around the `ais-instant-search` component, with a v-slot using the `{ a, b, ... }` notation, for example like this:

```blade
<toggler v-slot="{ isOpen, toggle }">
    <div>
        <ais-instant-search>
            [...]
        </ais-instant-search>
    </div>
</toggler>
```

If *any* of the variables that exist within that slot scope change(in a non-deep way)---even just a completely unused boolean going from true to false---the whole instantsearch tree gets refreshed. Adding a key does not resolve this issue.

Something of note here as well is that when this tree gets refreshed, the classname of the instantsearch element changes from:

```html
<div class="Ais-InstantSearch">
```

to:

```html
<div class="[object Object]">
```

I've not been able to figure out how that is even possible, as it appears the functions that control the classname here can only possibly return strings (or throw errors).

---

Because it's only non-deep variable changes, this means we can stick to objects. In this case, using SlotProps variables for the slots instead. This somewhat fixes this issue. We still end up with `[object Object]` as the classname for the ais-instant-search div on the product overview pages, which you can also see happens in the rapidez demo.