### PR TITLE
[4.x] Fix off-by-one error

### DIFF
--- a/resources/views/components/slider.blade.php
+++ b/resources/views/components/slider.blade.php
@@ -32,9 +32,9 @@
             <div v-if="slidesTotal > 1" class="flex flex-row justify-center w-full mt-9">
                 <div
                     v-for="index in slidesTotal"
-                    v-on:click="navigate(index)"
+                    v-on:click="navigate(index + 1)"
                     class="relative bg rounded-full border size-4 mx-1 cursor-pointer"
-                    :class="{ 'bg-active border-active': index === currentSlide }">
+                    :class="{ 'bg-active border-active': index + 1 === currentSlide }">
                 </div>
             </div>
         @endslotdefault

--- a/resources/views/components/slider.blade.php
+++ b/resources/views/components/slider.blade.php
@@ -32,9 +32,9 @@
             <div v-if="slidesTotal > 1" class="flex flex-row justify-center w-full mt-9">
                 <div
                     v-for="index in slidesTotal"
-                    v-on:click="navigate(index + 1)"
+                    v-on:click="navigate(index - 1)"
                     class="relative bg rounded-full border size-4 mx-1 cursor-pointer"
-                    :class="{ 'bg-active border-active': index + 1 === currentSlide }">
+                    :class="{ 'bg-active border-active': index - 1 === currentSlide }">
                 </div>
             </div>
         @endslotdefault


### PR DESCRIPTION
This bit of code caused the selected index on the slider to be off by one. Fixed by subtracting one.