### PR TITLE
Cart and checkout visual summary improvements

### DIFF
--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -1,6 +1,6 @@
 <table class="w-full border-b">
     <tbody class="divide-y">
-        <tr v-for="(item, index) in cart.items" class="flex-wrap max-md:flex *:p-2 md:*:p-4">
+        <tr v-for="(item, index) in cart.items" class="flex-wrap max-md:flex *:first:pt-0 *:p-2 md:*:p-4">
             <td class="w-24">
                 <a :href="item.product.url_key + item.product.url_suffix | url">
                     <img
@@ -19,26 +19,29 @@
                     />
                 </a>
             </td>
-            <td class="items-center max-md:flex flex-1">
+            <td class="max-md:flex flex-1">
                 <div class="flex flex-col items-start">
-                    <a :href="item.product.url_key + item.product.url_suffix | url" class="font-bold" dusk="cart-item-name">
+                    <a :href="item.product.url_key + item.product.url_suffix | url" class="font-medium" dusk="cart-item-name">
                         @{{ item.product.name }}
                         <div class="text-red-600" v-if="!item.is_available">
                             @lang('This product is out of stock, remove it to continue your order.')
                         </div>
                     </a>
-                    <div v-for="option in item.configurable_options">
-                        @{{ option.option_label }}: @{{ option.value_label }}
+                    <div class="*:border-r last:*:border-r-0 *:px-2 *:mb-1.5 *:leading-3 -mx-2 flex flex-wrap text-sm mb-1.5 text-muted mt-1.5">
+                        <div v-for="option in item.configurable_options">
+                            @{{ option.option_label }}: @{{ option.value_label }}
+                        </div>
+                        <div v-for="option in item.customizable_options">
+                            @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
+                        </div>
+                        <div v-for="option in config.cart_attributes">
+                            <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
+                                @{{ $root.attributeLabel(option) }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+                            </template>
+                        </div>
+                        @include('rapidez::cart.item.remove')
                     </div>
-                    <div v-for="option in item.customizable_options">
-                        @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
-                    </div>
-                    <div v-for="option in config.cart_attributes">
-                        <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
-                            @{{ $root.attributeLabel(option) }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
-                        </template>
-                    </div>
-                    @include('rapidez::cart.item.remove')
+                    
                     <div v-if="item.qty_backordered" class="flex gap-2">
                         <x-heroicon-o-exclamation-circle class="mt-px w-5" />
                         <span>

--- a/resources/views/cart/item.blade.php
+++ b/resources/views/cart/item.blade.php
@@ -41,7 +41,7 @@
                         </div>
                         @include('rapidez::cart.item.remove')
                     </div>
-                    
+
                     <div v-if="item.qty_backordered" class="flex gap-2">
                         <x-heroicon-o-exclamation-circle class="mt-px w-5" />
                         <span>

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -16,7 +16,7 @@
         >
         </graphql>
         <div v-if="hasCart" v-cloak>
-            <div class="flex gap-x-10 mb-8 max-lg:flex-col">
+            <div class="flex gap-x-14 mb-8 max-lg:flex-col">
                 <div class="flex w-full flex-col" dusk="cart-content">
                     @include('rapidez::cart.item')
 

--- a/resources/views/cart/sidebar.blade.php
+++ b/resources/views/cart/sidebar.blade.php
@@ -1,4 +1,4 @@
-<dl class="mb-5 flex w-full flex-col rounded-lg border *:flex *:flex-wrap *:justify-between *:p-3 *:border-b last:*:border-none">
+<x-rapidez::summary>
     <div>
         <dt>@lang('Subtotal')</dt>
         <dd v-if="showTax">@{{ cart.prices.subtotal_including_tax.value | price }}</dd>
@@ -7,10 +7,12 @@
 
     <template v-if="cart.shipping_addresses?.length">
         <div v-for="address in cart.shipping_addresses" v-if="address.selected_shipping_method">
-            <dt>@lang('Shipping')</dt>
+            <dt>
+                @lang('Shipping')
+                <small class="text-muted">@{{ address.selected_shipping_method.carrier_title }} - @{{ address.selected_shipping_method.method_title }}</small>
+            </dt>
             <dd v-if="showTax">@{{ address.selected_shipping_method.price_incl_tax.value | price }}</dd>
             <dd v-else>@{{ address.selected_shipping_method.price_excl_tax.value | price }}</dd>
-            <small>@{{ address.selected_shipping_method.carrier_title }} - @{{ address.selected_shipping_method.method_title }}</small>
         </div>
     </template>
 
@@ -35,14 +37,14 @@
         </div>
     </template>
 
-    <div>
+    <div class="border-t pt-3 mt-3 font-bold">
         <dt>@lang('Total')</dt>
         <dd v-if="showTax">@{{ cart.prices.grand_total.value | price }}</dd>
         <dd v-else>@{{ cart.prices.grand_total.value - cart.taxTotal.value | price }}</dd>
     </div>
-</dl>
+</x-rapidez::summary>
 
-<div class="w-full" :class="{ 'cursor-not-allowed': !canOrder }">
+<div class="mt-5 w-full" :class="{ 'cursor-not-allowed': !canOrder }">
     <x-rapidez::button.conversion
         href="{{ route('checkout') }}"
         class="w-full text-center"

--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         @include('rapidez::checkout.partials.progressbar')
         <div v-if="hasCart" v-cloak>
-            <div class="flex gap-5 max-xl:flex-col">
+            <div class="flex gap-14 max-xl:flex-col">
                 <div class="w-full rounded bg p-4 xl:p-8 xl:w-3/4">
                     <form
                         v-on:submit.prevent="(e) => {

--- a/resources/views/checkout/pages/onestep.blade.php
+++ b/resources/views/checkout/pages/onestep.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div class="container">
-        <div v-if="hasCart" class="flex gap-5 max-xl:flex-col" v-cloak>
+        <div v-if="hasCart" class="flex gap-14 max-xl:flex-col" v-cloak>
             <div class="w-full bg rounded p-4 xl:p-8 xl:w-3/4">
                 <form class="grid gap-5 lg:grid-cols-2" v-on:submit.prevent="(e) => {
                     submitPartials(e.target?.form ?? e.target)

--- a/resources/views/checkout/pages/payment.blade.php
+++ b/resources/views/checkout/pages/payment.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         @include('rapidez::checkout.partials.progressbar')
         <div v-if="hasCart" v-cloak>
-            <div class="flex gap-5 max-xl:flex-col">
+            <div class="flex gap-10 max-xl:flex-col">
                 <form class="w-full rounded bg h-fit p-4 xl:p-8 xl:w-3/4" v-on:submit.prevent="(e) => {
                         submitPartials(e.target?.form ?? e.target)
                             .then((result) =>

--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -49,7 +49,7 @@
             <dd class="text-right">@{{ item.prices.row_total.value | price }}</dd>
         </div>
     </x-rapidez::summary>
-    
+
     <x-rapidez::summary class="border-t pt-4 mt-5 mb-5">
         <div>
             <dt>

--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -1,17 +1,60 @@
-<div class="flex flex-col gap-5">
-    <div class="rounded border p-3">
-        <div class="flex w-full flex-col">
-            <div v-for="item in cart.items" class="flex gap-x-1 border-b last:border-b-0 py-3">
-                <div class="w-7/12">@{{ item.product.name }}</div>
-                <div class="w-2/12 px-4 text-right">@{{ item.quantity }}</div>
-                <div class="w-3/12 text-right">@{{ item.prices.row_total.value | price }}</div>
-            </div>
+<div class="flex flex-col">
+    <x-rapidez::summary class="gap-y-4">
+        <div v-for="item in cart.items">
+            <dt>
+                <div class="flex">
+                    <div class="flex shrink-0 size-10 mr-2">
+                        <img
+                            v-if="item.configured_variant?.image"
+                            class="w-10 h-auto object-contain"
+                            :alt="item.product.name"
+                            :src="resizedPath(item.configured_variant.image.url + '.webp', '80x80')"
+                            loading="lazy"
+                            width="80"
+                            height="80"
+                        />
+                        <img
+                            v-else-if="item.product.image"
+                            class="w-10 h-auto object-contain"
+                            :alt="item.product.name"
+                            :src="resizedPath(item.product.image.url + '.webp', '80x80')"
+                            loading="lazy"
+                            width="80"
+                            height="80"
+                        />
+                    </div>
+                    <div class="flex-1">
+                        <div class="mb-1">@{{ item.product.name }}</div>
+                        <div class="last:*:pr-0 *:pr-2 flex flex-wrap gap-x-2 text-xs text-muted">
+                            <div class="*:border-r last:*:border-r-0 *:px-2 *:mb-1.5 *:leading-3 -mx-2 flex flex-wrap text-xs -mb-1.5">
+                                <div>
+                                    @{{ item.quantity }}x
+                                </div>
+                                <div v-for="option in item.configurable_options">
+                                    @{{ option.option_label }}: @{{ option.value_label }}
+                                </div>
+                                <div v-for="option in item.customizable_options">
+                                    @{{ option.label }}: @{{ option.values[0].label || option.values[0].value }}
+                                </div>
+                                <div v-for="option in config.cart_attributes">
+                                    <template v-if="item.product.attribute_values?.[option] && typeof item.product.attribute_values[option] === 'object'">
+                                        @{{ window.attributeLabel(option) }}: <span v-html="item.product.attribute_values[option]?.join(', ')"></span>
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </dt>
+            <dd class="text-right">@{{ item.prices.row_total.value | price }}</dd>
         </div>
-    </div>
-
-    <dl class="flex w-full flex-col rounded border *:flex *:flex-wrap *:justify-between *:p-3 *:border-b last:*:border-none">
+    </x-rapidez::summary>
+    
+    <x-rapidez::summary class="border-t pt-4 mt-5 mb-5">
         <div>
-            <dt>@lang('Subtotal')</dt>
+            <dt>
+                @lang('Subtotal')
+            </dt>
             <dd>@{{ cart.prices.subtotal_including_tax.value | price }}</dd>
         </div>
         <div v-if="cart.prices.applied_taxes.length">
@@ -21,21 +64,21 @@
         <div v-if="cart.shipping_addresses.length && cart.shipping_addresses[0]?.selected_shipping_method">
             <dt>
                 @lang('Shipping')<br>
-                <small>@{{ cart.shipping_addresses[0]?.selected_shipping_method.carrier_title }} - @{{ cart.shipping_addresses[0]?.selected_shipping_method.method_title }}</small>
+                <small class="text-muted">@{{ cart.shipping_addresses[0]?.selected_shipping_method.carrier_title }} - @{{ cart.shipping_addresses[0]?.selected_shipping_method.method_title }}</small>
             </dt>
             <dd>@{{ cart.shipping_addresses[0]?.selected_shipping_method.amount.value | price }}</dd>
         </div>
-        <div v-for="discount in cart.prices.discounts">
+        <div v-for="discount in cart.prices.discounts" class="border-t pt-3 mt-3">
             <dt>@{{ discount.label }}</dt>
-            <dd>-@{{ discount.amount.value | price }}</dd>
+            <dd class="text-green-700 font-medium">-@{{ discount.amount.value | price }}</dd>
         </div>
         <div class="font-bold">
             <dt>@lang('Total')</dt>
             <dd>@{{ cart.prices.grand_total.value | price }}</dd>
         </div>
-    </dl>
+    </x-rapidez::summary>
 
-    <div v-if="cart.shipping_addresses[0]" class="flex w-full flex-col gap-x-1 border p-3 rounded">
+    <div v-if="cart.shipping_addresses[0]" class="flex w-full flex-col gap-x-1 bg px-5 py-4 rounded">
         <p class="font-lg mb-2 font-bold">
             <template v-if="cart.billing_address?.same_as_shipping">@lang('Shipping & billing address')</template>
             <template v-else>@lang('Shipping address')</template>

--- a/resources/views/components/summary.blade.php
+++ b/resources/views/components/summary.blade.php
@@ -1,0 +1,3 @@
+<dl {{ $attributes->twMerge('flex flex-col gap-y-1.5 w-full *:flex *:gap-1 *:flex-wrap first:*:*:flex-1 *:*:flex *:*:flex-col *:*:gap-0.5') }}>
+    {{ $slot }}
+</dl>


### PR DESCRIPTION
Follow up of this [PR](https://github.com/rapidez/core/pull/856/files). That PR was over engineered with too many components. A good way to implement the summary but not within the core. My proposal just adds 1 component for the <dl.

<img width="1793" height="1125" alt="image" src="https://github.com/user-attachments/assets/c2b32cdc-a901-4dd1-ad2c-d891cadcd552" />
<img width="1680" height="969" alt="image" src="https://github.com/user-attachments/assets/d7084df6-3f88-4c22-af4b-61a544eeffd9" />
