### PR TITLE
Fixed await in GraphqlMutation

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -93,7 +93,7 @@ export default {
         this.data = this.variables
 
         if (this.debounce) {
-            this.mutate = useDebounceFn(this.mutateFn, this.debounce)
+            this.mutate = useDebounceFn(async () => await this.mutateFn, this.debounce)
         } else {
             this.mutate = this.mutateFn
         }
@@ -145,9 +145,10 @@ export default {
                     ;[query, variables, options] = await this.beforeRequest(query, variables, options)
                 }
 
-                let response = await (
-                    this.group ? combiningGraphQL(query, variables, options, this.group) : magentoGraphQL(query, variables, options)
-                ).catch(async (error) => {
+                const graphqlPromise = this.group
+                    ? combiningGraphQL(query, variables, options, this.group)
+                    : magentoGraphQL(query, variables, options)
+                let response = await graphqlPromise.catch(async (error) => {
                     if (!GraphQLError.prototype.isPrototypeOf(error)) {
                         throw error
                     }


### PR DESCRIPTION
Before, due to handling of the ternary operator the await didn't always function as expected. 
By saving the promise in a variable we can ensure it's the resulting promise that's always await-ed