### PR TITLE
[4.x] Rename autocomplete facade input to avoid same id errors

### DIFF
--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -1,3 +1,5 @@
+@props(['id' => 'autocomplete-input'])
+
 <form
     id="autocomplete-form"
     method="get"
@@ -8,7 +10,7 @@
 >
     <x-rapidez::input
         {{ $attributes->merge([
-            'id' => 'autocomplete-input',
+            'id' => $id,
             'type' => 'search',
             'name' => 'q',
             'autocomplete' => 'off',

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -33,6 +33,7 @@
         </ais-instant-search>
         <div v-else class="relative w-full">
             <x-rapidez::autocomplete.input
+                id="autocomplete-facade-input"
                 v-model="$root.autocompleteFacadeQuery"
                 v-on:focus="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"
                 v-on:mouseover="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"

--- a/tests/playwright/search.spec.js
+++ b/tests/playwright/search.spec.js
@@ -12,7 +12,7 @@ test('search page', async ({ page }) => {
 test('autocomplete', async ({ page }) => {
     const product = await new ProductPage(page).goto(process.env.PRODUCT_URL_SIMPLE)
     await page.goto('/')
-    await page.getByTestId('autocomplete-input').fill(product.name)
+    await page.getByTestId('autocomplete-facade-input').fill(product.name)
     await page.waitForLoadState('networkidle')
     await expect(page.getByTestId('autocomplete-item').first()).toContainText(product.name)
     await expect(page).toHaveScreenshot()

--- a/tests/playwright/search.spec.js
+++ b/tests/playwright/search.spec.js
@@ -12,7 +12,7 @@ test('search page', async ({ page }) => {
 test('autocomplete', async ({ page }) => {
     const product = await new ProductPage(page).goto(process.env.PRODUCT_URL_SIMPLE)
     await page.goto('/')
-    await page.getByTestId('autocomplete-facade-input').fill(product.name)
+    await page.getByTestId('autocomplete-input').fill(product.name)
     await page.waitForLoadState('networkidle')
     await expect(page.getByTestId('autocomplete-item').first()).toContainText(product.name)
     await expect(page).toHaveScreenshot()


### PR DESCRIPTION
Relevant warning being `[DOM] Found 2 elements with non-unique id #autocomplete-input`. I've left the testid alone because that one is important for the playwright tests to work nicely.