### PR TITLE
[4.x] Make shipping address also a clone so reactivity doesn't do weird things

### DIFF
--- a/resources/views/checkout/steps/shipping_address.blade.php
+++ b/resources/views/checkout/steps/shipping_address.blade.php
@@ -1,12 +1,12 @@
 <graphql-mutation
     :query="config.queries.setNewShippingAddressesOnCart"
-    :variables="{
+    :variables="JSON.parse(JSON.stringify({
         cart_id: mask,
         ...window.address_defaults,
         ...cart.shipping_addresses[0],
         country_code: cart.shipping_addresses[0]?.country.code || window.address_defaults.country_code,
         region_id: cart.shipping_addresses[0]?.region.region_id || window.address_defaults.region_id,
-    }"
+    }))"
     group="shipping"
     :before-request="(query, variables, options) => [variables.customer_address_id ? config.queries.setExistingShippingAddressesOnCart : query, variables, options]"
     :callback="updateCart"


### PR DESCRIPTION
There are certain scenarios where this being inherently reactive breaks the checkout. For example, we use a Magento package sometimes that (kind of as a side effect) sets a default empty shipping address, which then ends up being partially reactive with the street variables because this is an array, and as such gets passed as a reference in here. This makes the address form quite buggy.

We already did this on the billing address, but for whatever reason (that I could not figure out) not on the shipping address.