### PR TITLE
Add vue-turbo-frame component

### DIFF
--- a/resources/js/components/VueTurboFrame.vue
+++ b/resources/js/components/VueTurboFrame.vue
@@ -1,41 +1,35 @@
 <template>
-  <turbo-frame
-    :src="src"
-    :id="id"
-    @turbo:before-frame-render="handleBeforeRender"
-    loading="lazy"
-    target="_top"
-  >
-    <component :is="fetchedComponent"></component>
-  </turbo-frame>
+    <turbo-frame :src="src" :id="id" @turbo:before-frame-render="handleBeforeRender" loading="lazy" target="_top">
+        <component :is="fetchedComponent"></component>
+    </turbo-frame>
 </template>
 
 <script>
 export default {
-  name: 'VueTurboFrame',
-  props: {
-    src: String,
-    id: String,
-  },
-  data() {
-    return {
-      html: '<div></div>',
-    }
-  },
-  computed: {
-    fetchedComponent() {
-      return {
-        template: this.html || '',
-      }
+    name: 'VueTurboFrame',
+    props: {
+        src: String,
+        id: String,
     },
-  },
-  methods: {
-    handleBeforeRender(event) {
-      // override default render function
-      event.detail.render = (_currentElement, newElement) => {
-        this.html = newElement.innerHTML
-      }
+    data() {
+        return {
+            html: '<div></div>',
+        }
     },
-  },
+    computed: {
+        fetchedComponent() {
+            return {
+                template: this.html || '',
+            }
+        },
+    },
+    methods: {
+        handleBeforeRender(event) {
+            // override default render function
+            event.detail.render = (_currentElement, newElement) => {
+                this.html = newElement.innerHTML
+            }
+        },
+    },
 }
 </script>

--- a/resources/js/components/VueTurboFrame.vue
+++ b/resources/js/components/VueTurboFrame.vue
@@ -1,0 +1,41 @@
+<template>
+  <turbo-frame
+    :src="src"
+    :id="id"
+    @turbo:before-frame-render="handleBeforeRender"
+    loading="lazy"
+    target="_top"
+  >
+    <component :is="fetchedComponent"></component>
+  </turbo-frame>
+</template>
+
+<script>
+export default {
+  name: 'VueTurboFrame',
+  props: {
+    src: String,
+    id: String,
+  },
+  data() {
+    return {
+      html: '<div></div>',
+    }
+  },
+  computed: {
+    fetchedComponent() {
+      return {
+        template: this.html || '',
+      }
+    },
+  },
+  methods: {
+    handleBeforeRender(event) {
+      // override default render function
+      event.detail.render = (_currentElement, newElement) => {
+        this.html = newElement.innerHTML
+      }
+    },
+  },
+}
+</script>

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -31,6 +31,9 @@ Vue.component('global-slideover', globalSlideover)
 import globalSlideoverInstance from './components/GlobalSlideoverInstance.vue'
 Vue.component('global-slideover-instance', globalSlideoverInstance)
 
+import VueTurboFrame from './components/VueTurboFrame.vue'
+Vue.component('vue-turbo-frame', VueTurboFrame)
+
 import images from './components/Product/Images.vue'
 Vue.component('images', images)
 


### PR DESCRIPTION
Heavily inspired by https://github.com/ElMassimo/vite_ruby/discussions/369#discussioncomment-9743096

The `vue-turbo-frame` component lets you load Vue components right inside Turbo Frames. Before this, Vue components generally wouldn't load or render correctly when content came in via a Turbo Frame.

Usage is pretty much the same as a normal `turbo-frame`, but I've pre-configured a couple of useful props that we usually want on there anyway.

Here's how you'd use it in your main Blade template:

```html
<vue-turbo-frame src="/path-to-your-content" id="my-frame">
    <!-- This is the content you'd see before the frame actually loads -->
    <div>Loading cool stuff...</div>
</vue-turbo-frame>
```

And then, the Blade file that `/path-to-your-content` serves would look something like this, containing your actual `turbo-frame` and Vue component:

```blade
<turbo-frame id="my-frame">
    <my-vue-component>
        <!-- This is the content you'd see after the frame loads -->
        This works now, yippie! 🚀
    </my-vue-component>
</turbo-frame>
```

The props I've added by default **to** the component are:

*   `loading="lazy"`: This means the content only loads when it scrolls into your browser's view.
*   `target="_top"`: This fixes links, so they navigate the whole page (e.g., `a href="/test"` works as expected) instead of just within the frame.

Of course, you'd also want to have the web route pointing to the view you want to load.