### PR TITLE
Added loader for buttons

### DIFF
--- a/resources/views/cart/sidebar.blade.php
+++ b/resources/views/cart/sidebar.blade.php
@@ -47,6 +47,7 @@
         href="{{ route('checkout') }}"
         class="w-full text-center"
         v-bind:class="{ 'pointer-events-none': !canOrder }"
+        loader
     >
         @lang('Checkout')
     </x-rapidez::button.conversion>

--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -33,7 +33,7 @@
                             @include('rapidez::checkout.steps.shipping_method')
                         </template>
 
-                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start">
+                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start" loader>
                             @lang('Next')
                         </x-rapidez::button.conversion>
                     </form>

--- a/resources/views/checkout/pages/login.blade.php
+++ b/resources/views/checkout/pages/login.blade.php
@@ -20,7 +20,7 @@
         >
             @include('rapidez::checkout.steps.login')
 
-            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3">
+            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader>
                 @lang('Next')
             </x-rapidez::button.conversion>
         </form>

--- a/resources/views/checkout/steps/place_order.blade.php
+++ b/resources/views/checkout/steps/place_order.blade.php
@@ -8,7 +8,7 @@
     v-slot="{ mutate, variables }"
 >
     <fieldset>
-        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3">
+        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader>
             @lang('Place order')
         </x-rapidez::button.conversion>
     </fieldset>

--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -30,9 +30,9 @@
         <x-heroicon-s-x-mark class="size-7" />
     </button>
     <x-rapidez::button
-        class="absolute right-0 top-0 bg-opacity-0 hover:bg-opacity-0 border-none *:peer-placeholder-shown:bg-muted *:peer-placeholder-shown:text"
+        class="absolute right-0 top-0 bg-opacity-0 hover:bg-opacity-0 border-none [&>span>div]:peer-placeholder-shown:bg-muted [&>span>div]:peer-placeholder-shown:text"
         type="submit"
-        title="@lang('Search')"
+        :title="__('Search')"
     >
         <x-rapidez::autocomplete.magnifying-glass />
     </x-rapidez::button>

--- a/resources/views/components/button/base.blade.php
+++ b/resources/views/components/button/base.blade.php
@@ -1,14 +1,3 @@
-@props(['tag' => 'button', 'disableWhenLoading' => true])
-
-@php
-    $tag = $attributes->hasAny('href', ':href', 'v-bind:href') ? 'a' : $tag;
-    $tag = $attributes->has('for') ? 'label' : $tag;
-@endphp
-
-<x-rapidez::tag
-    is="{{ $tag }}"
-    {{ $attributes->merge([
-        ':disabled' => $attributes->has('href') || $attributes->has(':href') || !$disableWhenLoading ? null : '$root.loading']) }}
->
+<x-rapidez::button.tag {{ $attributes->twMerge('relative inline-flex items-center justify-center transition font-medium text-base rounded min-h-12 py-1.5 px-5 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer gap-x-1.5') }}>
     {{ $slot }}
-</x-rapidez::tag>
+</x-rapidez::button.tag>

--- a/resources/views/components/button/tag.blade.php
+++ b/resources/views/components/button/tag.blade.php
@@ -1,0 +1,27 @@
+@props(['tag' => 'button', 'disableWhenLoading' => true, 'loader' => false])
+
+@php
+    $tag = $attributes->hasAny('href', ':href', 'v-bind:href') ? 'a' : $tag;
+    $tag = $attributes->has('for') ? 'label' : $tag;
+
+    if ($loader) {
+        $attributes['v-bind:disabled'] = 'loading';
+    }
+@endphp
+
+<x-rapidez::tag
+    is="{{ $tag }}"
+    {{ $attributes->merge([
+        ':disabled' => $attributes->has('href') || $attributes->has(':href') || !$disableWhenLoading ? null : '$root.loading',
+    ]) }}
+>
+    <span class="contents" @if ($loader) v-bind:class="{'invisible': loading}" @endif>
+        {{ $slot }}
+    </span>
+
+    @if ($loader)
+        <div v-if="loading" class="absolute right-1/2 bottom-1/2 translate-x-1/2 translate-y-1/2" v-cloak>
+            <x-heroicon-o-arrow-path class="animate-spin size-5"/>
+        </div>
+    @endif
+</x-rapidez::tag>


### PR DESCRIPTION
This will add a loader on a button when we are waiting for request for example inside the checkout. When you add `loader` on a button it will get a loader:
<img width="269" height="122" alt="Scherm­afbeelding 2025-08-08 om 10 51 02" src="https://github.com/user-attachments/assets/6a49728f-e430-4209-8410-a8e3419cae48" />
