### PR TITLE
[4.x] Fix select types mapping

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -139,6 +139,11 @@ trait Searchable
                     return false;
                 }
 
+                if ($attribute['input'] === 'select') {
+                    // Select means that while the type may be an int, the data won't be an int.
+                    return false;
+                }
+
                 if ($attribute['listing'] || $attribute['filter'] || $attribute['search'] || $attribute['sorting']) {
                     return true;
                 }


### PR DESCRIPTION
Somehow hadn't run into this before. Mapping on `int` types was incorrect because it was a select on the frontend, which allows it to be non-int types (as the int will just become the option id).