### PR TITLE
[4.x] Set guest email on change

### DIFF
--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -5,6 +5,7 @@ import { useDebounceFn } from '@vueuse/core'
 
 const debouncePromise = useDebounceFn(async function (self) {
     self.isEmailAvailable = await isEmailAvailable(self.email || '')
+    await self.handleGuest()
 }, 300)
 
 export default {


### PR DESCRIPTION
if you can change the email field, you're a guest and your guest email should be set. However, this did not happen in checkout setups where the login step is combined with something else (e.g. the onestep checkout) which meant your email didn't actually get set until you go to the next step.

By hooking into this function we change that. Maybe we should also check if the email is valid before we go into either of these functions?