### PR TITLE
Unique autocomplete ids

### DIFF
--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -8,7 +8,6 @@
 >
     <x-rapidez::input
         {{ $attributes->merge([
-            'id' => 'autocomplete-input',
             'type' => 'search',
             'name' => 'q',
             'autocomplete' => 'off',

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -33,7 +33,6 @@
         </ais-instant-search>
         <div v-else class="relative w-full">
             <x-rapidez::autocomplete.input
-                id="autocomplete-facade-input"
                 v-model="$root.autocompleteFacadeQuery"
                 v-on:focus="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"
                 v-on:mouseover="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"

--- a/resources/views/layouts/partials/header/autocomplete.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete.blade.php
@@ -33,6 +33,7 @@
         </ais-instant-search>
         <div v-else class="relative w-full">
             <x-rapidez::autocomplete.input
+                id="autocomplete-facade-input"
                 v-model="$root.autocompleteFacadeQuery"
                 v-on:focus="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"
                 v-on:mouseover="window.document.dispatchEvent(new window.Event('loadAutoComplete'))"

--- a/tests/playwright/search.spec.js
+++ b/tests/playwright/search.spec.js
@@ -12,6 +12,8 @@ test('search page', async ({ page }) => {
 test('autocomplete', async ({ page }) => {
     const product = await new ProductPage(page).goto(process.env.PRODUCT_URL_SIMPLE)
     await page.goto('/')
+    await page.getByTestId('autocomplete-input').click()
+    await page.waitForLoadState('networkidle')
     await page.getByTestId('autocomplete-input').fill(product.name)
     await page.waitForLoadState('networkidle')
     await expect(page.getByTestId('autocomplete-item').first()).toContainText(product.name)


### PR DESCRIPTION
Follow up on https://github.com/rapidez/core/pull/964, it seems we don't need any id's at all.