### PR TITLE
[4.x] Remove notifyOnError for login function

### DIFF
--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -130,6 +130,9 @@ export const login = async function (email, password) {
             email: email,
             password: password,
         },
+        {
+            notifyOnError: false,
+        },
     ).then(async (response) => {
         await loginByToken(response.data.generateCustomerToken.token)
         return response


### PR DESCRIPTION
The error you get with notifyOnError is not useful, it tells you your session has expired when really you just didn't put in the right credentials.