### PR TITLE
[4.x] Fix swatches having content shift on pageload

### DIFF
--- a/resources/views/components/input/swatch/visual.blade.php
+++ b/resources/views/components/input/swatch/visual.blade.php
@@ -1,7 +1,13 @@
-@props(['color' => '\'none\''])
+@props(['color' => '\'none\'', 'staticColor' => false])
 
 <label class="group/swatch cursor-pointer flex items-center justify-center p-1 rounded-full ring-inset relative ring-default ring-1 hover:ring-emphasis has-[:checked]:ring-active has-[:checked]:ring-2 has-[:checked]:hover:ring-active group">
-    <span class="size-5 block border border-black/15 rounded-full m-px" v-bind:style="{ background: {{ $color }} }"></span>
+    <span class="size-5 block border border-black/15 rounded-full m-px"
+        @if($staticColor)
+            style="background:{{ $color }}"
+        @else
+            v-bind:style="{ background: {{ $color }} }"
+        @endif
+    ></span>
     <input {{ $attributes->class('opacity-0 size-0 absolute') }}>
     @if ($slot->isNotEmpty())
         <span class="pointer-events-none absolute left-0 bottom-full mb-1 rounded px-1.5 py-0.5 bg-active text-white opacity-0 group-hover/swatch:opacity-100 transition-opacity">

--- a/resources/views/components/input/swatch/visual.blade.php
+++ b/resources/views/components/input/swatch/visual.blade.php
@@ -2,7 +2,7 @@
 
 <label class="group/swatch cursor-pointer flex items-center justify-center p-1 rounded-full ring-inset relative ring-default ring-1 hover:ring-emphasis has-[:checked]:ring-active has-[:checked]:ring-2 has-[:checked]:hover:ring-active group">
     <span class="size-5 block border border-black/15 rounded-full m-px"
-        @if($staticColor)
+        @if ($staticColor)
             style="background:{{ $color }}"
         @else
             v-bind:style="{ background: {{ $color }} }"

--- a/resources/views/product/partials/super-attributes/drop_down.blade.php
+++ b/resources/views/product/partials/super-attributes/drop_down.blade.php
@@ -12,7 +12,7 @@
         <option disabled selected hidden :value="undefined">
             @lang('Select') {{ strtolower($superAttribute->label) }}
         </option>
-        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+        @foreach ($product->{'super_' . $superAttribute->code} as $optionId => $option)
             <option
                 value="{{ $option->value }}"
                 :disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes({{ $option->value }})"

--- a/resources/views/product/partials/super-attributes/drop_down.blade.php
+++ b/resources/views/product/partials/super-attributes/drop_down.blade.php
@@ -12,11 +12,13 @@
         <option disabled selected hidden :value="undefined">
             @lang('Select') {{ strtolower($superAttribute->label) }}
         </option>
-        <option
-            v-for="option in Object.values(config.product.super_{{ $superAttribute->code }}).sort((a, b) => a.label.localeCompare(b.label)).sort((a, b) => a.sort_order - b.sort_order)"
-            v-text="option.label"
-            :value="option.value"
-            :disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes(option.value)"
-        />
+        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+            <option
+                value="{{ $option->value }}"
+                :disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes({{ $option->value }})"
+            >
+                {{ $option->label }}
+            </option>
+        @endforeach
     </x-rapidez::input.select>
 </label>

--- a/resources/views/product/partials/super-attributes/text_swatch.blade.php
+++ b/resources/views/product/partials/super-attributes/text_swatch.blade.php
@@ -4,7 +4,7 @@
     </x-rapidez::label>
 
     <ul class="flex flex-wrap gap-x-1.5 gap-y-2 items-center pr-14">
-        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+        @foreach ($product->{'super_' . $superAttribute->code} as $optionId => $option)
             <li>
                 <x-rapidez::input.swatch.text
                     type="radio"

--- a/resources/views/product/partials/super-attributes/text_swatch.blade.php
+++ b/resources/views/product/partials/super-attributes/text_swatch.blade.php
@@ -4,19 +4,21 @@
     </x-rapidez::label>
 
     <ul class="flex flex-wrap gap-x-1.5 gap-y-2 items-center pr-14">
-        <li v-for="option in Object.values(config.product.super_{{ $superAttribute->code }}).sort((a, b) => a.label.localeCompare(b.label)).sort((a, b) => a.sort_order - b.sort_order)">
-            <x-rapidez::input.swatch.text
-                type="radio"
-                name="{{ $superAttribute->code }}"
-                v-model="addToCart.options[{{ $superAttributeId }}]"
-                v-bind:value="option.value"
-                v-bind:disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes(option.value)"
-                v-bind:aria-label="option.label"
-                v-bind:id="option.label"
-                required
-            >
-                @{{ option.label }}
-            </x-rapidez::input.swatch.text>
-        </li>
+        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+            <li>
+                <x-rapidez::input.swatch.text
+                    type="radio"
+                    name="{{ $superAttribute->code }}"
+                    v-model="addToCart.options[{{ $superAttributeId }}]"
+                    v-bind:disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes({{ $option->value }})"
+                    :value="$option->value"
+                    :aria-label="$option->label"
+                    :id="$option->label"
+                    required
+                >
+                    {{ $option->label }}
+                </x-rapidez::input.swatch.text>
+            </li>
+        @endforeach
     </ul>
 </div>

--- a/resources/views/product/partials/super-attributes/visual_swatch.blade.php
+++ b/resources/views/product/partials/super-attributes/visual_swatch.blade.php
@@ -4,7 +4,7 @@
     </x-rapidez::label>
 
     <ul class="flex flex-wrap gap-x-1.5 gap-y-2 items-center pr-14">
-        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+        @foreach ($product->{'super_' . $superAttribute->code} as $optionId => $option)
             <li>
                 <x-rapidez::input.swatch.visual
                     type="radio"

--- a/resources/views/product/partials/super-attributes/visual_swatch.blade.php
+++ b/resources/views/product/partials/super-attributes/visual_swatch.blade.php
@@ -4,20 +4,23 @@
     </x-rapidez::label>
 
     <ul class="flex flex-wrap gap-x-1.5 gap-y-2 items-center pr-14">
-        <li v-for="option in Object.values(config.product.super_{{ $superAttribute->code }}).sort((a, b) => a.label.localeCompare(b.label)).sort((a, b) => a.sort_order - b.sort_order)">
-            <x-rapidez::input.swatch.visual
-                type="radio"
-                name="{{ $superAttribute->code }}"
-                v-model="addToCart.options[{{ $superAttributeId }}]"
-                v-bind:value="option.value"
-                v-bind:disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes(option.value)"
-                v-bind:aria-label="option.label"
-                v-bind:id="option.label"
-                color="window.config.swatches['{{ $superAttribute->code }}']?.options?.[option.value]?.swatch ?? 'none'"
-                required
-            >
-                @{{ option.label }}
-            </x-rapidez::input.swatch.visual>
-        </li>
+        @foreach($product->{'super_' . $superAttribute->code} as $optionId => $option)
+            <li>
+                <x-rapidez::input.swatch.visual
+                    type="radio"
+                    name="{{ $superAttribute->code }}"
+                    v-model="addToCart.options[{{ $superAttributeId }}]"
+                    v-bind:disabled="addToCart.disabledOptions.super_{{ $superAttribute->code }}.includes({{ $option->value }})"
+                    :value="$option->value"
+                    :aria-label="$option->label"
+                    :id="$option->label"
+                    :color="config('rapidez.models.option_swatch')::getCachedSwatchValue($superAttribute->code, $option->value)['swatch'] ?? 'none'"
+                    static-color
+                    required
+                >
+                    {{ $option->label }}
+                </x-rapidez::input.swatch.visual>
+            </li>
+        @endforeach
     </ul>
 </div>

--- a/src/Models/OptionSwatch.php
+++ b/src/Models/OptionSwatch.php
@@ -58,7 +58,7 @@ class OptionSwatch extends Model
                 ->toArray();
         });
     }
-    
+
     public static function getCachedSwatchValue($code, $option)
     {
         return static::getCachedSwatchValues()[$code]['options'][$option] ?? null;

--- a/src/Models/OptionSwatch.php
+++ b/src/Models/OptionSwatch.php
@@ -58,4 +58,9 @@ class OptionSwatch extends Model
                 ->toArray();
         });
     }
+    
+    public static function getCachedSwatchValue($code, $option)
+    {
+        return static::getCachedSwatchValues()[$code]['options'][$option] ?? null;
+    }
 }

--- a/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductSuperAttributesScope.php
@@ -53,6 +53,7 @@ class WithProductSuperAttributesScope implements Scope
                     ->where('catalog_product_super_attribute_label.store_id', config('rapidez.store'));
             })
             ->whereColumn('product_id', $model->getTable() . '.entity_id')
+            ->orderBy('frontend_label')
             ->orderBy('catalog_product_super_attribute.position');
 
         $builder->selectSub($query, 'super_attributes');


### PR DESCRIPTION
The swatches on the PDP were placed on the page with Vue. This meant that there was a content flicker on page load before Vue was fully loaded in.

As it turns out, we can just get all this data directly out of PHP. Because of that we can show the swatches instantly upon page load.

There is still a tiny jump if you go to the page with one of the swatches pre-selected (e.g. `/beaumont-summit-kit.html?color=58`), however this is only the selected state and is barely noticeable.