### PR TITLE
[4.x] Fix category positions script & add category fallback

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -165,7 +165,7 @@ export default {
             let data = uiState[this.index]
 
             // Remove the root path from the category if it's in there
-            let category = data.hierarchicalMenu?.category_lvl1
+            let category = data.hierarchicalMenu?.category_lvl1 ?? []
             for (let i = 0; i < this.rootPath?.length && category?.length && category[0] == this.rootPath[i]; i++) {
                 category.splice(0, 1)
             }

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -135,7 +135,7 @@ function init() {
                         function_score: {
                             script_score: {
                                 script: {
-                                    source: `Integer.parseInt(doc['positions.${categoryId}'].empty ? '0' : doc['positions.${categoryId}'].value)`,
+                                    source: `doc.containsKey('positions.${categoryId}') ? (Integer.parseInt(doc['positions.${categoryId}'].empty ? '0' : doc['positions.${categoryId}'].value)) : 0`,
                                 },
                             },
                         },


### PR DESCRIPTION
The category positions script broke if used on something that didn't have this attribute, as it didn't actually check for existence of this attribute. Because we put the query on by default in the listing that means that everything that only uses `ais-index` also gets this attached. For example, the category listing on the `no-products` view and every non-product list in the autocomplete.

I've added a check to fix it.

Also added a fallback on the category in the Listing. This doesn't fully fix a weird bug I've run across, but it's a symptom of it.