### PR TITLE
Implement StatefulGuard to workaround error

### DIFF
--- a/src/Auth/MagentoCartTokenGuard.php
+++ b/src/Auth/MagentoCartTokenGuard.php
@@ -3,11 +3,11 @@
 namespace Rapidez\Core\Auth;
 
 use Illuminate\Auth\Middleware\Authenticate;
-use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 
-class MagentoCartTokenGuard extends MagentoCustomerTokenGuard implements Guard
+class MagentoCartTokenGuard extends MagentoCustomerTokenGuard implements StatefulGuard
 {
     public static function register()
     {

--- a/src/Auth/MagentoCustomerTokenGuard.php
+++ b/src/Auth/MagentoCustomerTokenGuard.php
@@ -3,12 +3,12 @@
 namespace Rapidez\Core\Auth;
 
 use Illuminate\Auth\TokenGuard;
-use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Http\Request;
 
-class MagentoCustomerTokenGuard extends TokenGuard implements Guard
+class MagentoCustomerTokenGuard extends TokenGuard implements StatefulGuard
 {
     public static function register()
     {
@@ -80,5 +80,43 @@ class MagentoCustomerTokenGuard extends TokenGuard implements Guard
     protected function retrieveByToken($token)
     {
         return config('rapidez.models.customer')::whereToken($token)->first();
+    }
+
+    // The following methods are not implemented for token-based authentication.
+    // @see: https://github.com/laravel/framework/pull/56785
+
+    public function attempt(array $credentials = [], $remember = false)
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function once(array $credentials = [])
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function login(Authenticatable $user, $remember = false)
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function loginUsingId($id, $remember = false)
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function onceUsingId($id)
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function viaRemember()
+    {
+        throw new \BadMethodCallException('Method not implemented.');
+    }
+
+    public function logout()
+    {
+        throw new \BadMethodCallException('Method not implemented.');
     }
 }

--- a/src/Auth/MagentoCustomerTokenGuard.php
+++ b/src/Auth/MagentoCustomerTokenGuard.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Core\Auth;
 
+use BadMethodCallException;
 use Illuminate\Auth\TokenGuard;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\StatefulGuard;
@@ -87,36 +88,36 @@ class MagentoCustomerTokenGuard extends TokenGuard implements StatefulGuard
 
     public function attempt(array $credentials = [], $remember = false)
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function once(array $credentials = [])
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function login(Authenticatable $user, $remember = false)
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function loginUsingId($id, $remember = false)
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function onceUsingId($id)
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function viaRemember()
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 
     public function logout()
     {
-        throw new \BadMethodCallException('Method not implemented.');
+        throw new BadMethodCallException('Method not implemented.');
     }
 }


### PR DESCRIPTION
This is the workaround fix for the errors caused by: https://github.com/laravel/framework/commit/6d5dfad051e6b7f1c51fb113189b52be3fd36170#diff-6a2323fa8736e9d453a642748f40d503d69e17a5b9ea944a57e45b271870be75R174

The preferred fix is created in a PR here: https://github.com/laravel/framework/pull/56785