### PR TITLE
Playwright only update screenshots on the last failed

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -140,7 +140,7 @@ jobs:
       # Screenshots
       - name: Update screenshots
         if: failure() && matrix.screenshots == true && github.event_name != 'schedule' && !(github.event_name == 'push' && (github.ref_name == 'master' || endsWith(github.ref_name, '.x')))
-        run: yarn playwright test --update-snapshots --reporter=list
+        run: yarn playwright test --update-snapshots --last-failed --reporter=list
 
       - name: Move the screenshots
         if: failure() && matrix.screenshots == true && github.event_name != 'schedule' && !(github.event_name == 'push' && (github.ref_name == 'master' || endsWith(github.ref_name, '.x')))


### PR DESCRIPTION
As the tests ran in the test step, within the update screenshots step we only need to update those to speed things up