### PR TITLE
Fixed images in subfolder webshop

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -127,7 +127,7 @@ function init() {
                     let url = new URL(imagePath)
                     url = url.pathname.replace('/media', '')
 
-                    return `/storage/${store}/resizes/${size}/magento${url}`
+                    return window.url(`/storage/${store}/resizes/${size}/magento${url}`)
                 },
 
                 categoryPositions(categoryId) {


### PR DESCRIPTION
Pass the image path into the url filter.
This turns 

`/storage/...` into `https://example.com/storage/...`
But more importantly would turn `/storage/...` (which would already resolve to `https://example.com/storage/...`)
into `https://example.com/nl/storage/...` if that is the base url of the shop.