### PR TITLE
Prevent split on category_lvl1 reference

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -165,7 +165,7 @@ export default {
             let data = uiState[this.index]
 
             // Remove the root path from the category if it's in there
-            let category = data.hierarchicalMenu?.category_lvl1 ?? []
+            let category = [...(data.hierarchicalMenu?.category_lvl1 ?? [])]
             for (let i = 0; i < this.rootPath?.length && category?.length && category[0] == this.rootPath[i]; i++) {
                 category.splice(0, 1)
             }


### PR DESCRIPTION
This PR aims to fix the issue that occurs when you're searching in a category until no results are found, you then remove your search query and it can still not find anything.

The reason this change works is because in JS Arrays and Objects are references.
So the splice call is not being executed on `let category`, instead on `data.hierarchicalMenu.category_lvl1` causing any information there to get lost.

Using the spread operator we make a clone instead, thus having no side-effects on the data in `category_lvl1`