### PR TITLE
Add min-h-screen to default slot to keep description at the bottom

### DIFF
--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -23,7 +23,7 @@
                 {{ $before ?? '' }}
 
                 @slotdefault('slot')
-                    <div class="flex gap-x-20 gap-y-5 max-lg:flex-col">
+                    <div class="flex gap-x-20 gap-y-5 max-lg:flex-col min-h-screen">
                         <div class="lg:w-80 shrink-0" data-testid="listing-filters">
                             @include('rapidez::listing.filters')
                         </div>


### PR DESCRIPTION
There is already a min-h-screen around the listing in case that isn't loaded yet.
This change ensures the before and after slot have the min-h element between them to ensure the description doesn't cause layout shifts.