### PR TITLE
[4.x] Use option instead of argument for index call

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -27,7 +27,7 @@ Route::middleware('api')->prefix('api')->group(function () {
         Route::match(['get', 'post'], 'index/products', function (Request $request) {
             fastcgi_finish_request();
             Artisan::call('rapidez:index', [
-                'store' => $request->store ?: false,
+                '--store' => $request->store ?: false,
             ]);
         });
 


### PR DESCRIPTION
The 4.x update turned the store parameter from an argument into an option. This means we have to change the signature here as well to reflect that, but we forgot about it.