### PR TITLE
Fix null check for auth

### DIFF
--- a/src/Http/Middleware/AuthenticateHealthCheck.php
+++ b/src/Http/Middleware/AuthenticateHealthCheck.php
@@ -16,7 +16,10 @@ class AuthenticateHealthCheck
      */
     public function handle($request, $next)
     {
-        $auth = config('rapidez.healthcheck.auth', [static::class, 'auth']);
+        $auth = config('rapidez.healthcheck.auth');
+        if ($auth === null) {
+            $auth = [self::class, 'auth'];
+        }
         abort_unless($auth($request), 403);
 
         return $next($request);


### PR DESCRIPTION
It seems at some point the `config` function changed it's logic to return null if the config value is explicitly `null` which makes sense but makes us need to change the check to explicitly state null