### PR TITLE
[4.x] Delay watch functions to avoid loading race condition

### DIFF
--- a/resources/js/stores/useCart.js
+++ b/resources/js/stores/useCart.js
@@ -271,7 +271,7 @@ export const taxTotal = (cart) => {
     return cart.prices.applied_taxes.reduce((sum, tax) => sum + tax.amount.value, 0)
 }
 
-watch(mask, refresh)
+window.setTimeout(() => watch(mask, refresh))
 if (cartStorage.value?.id && !mask.value) {
     clear()
 }

--- a/resources/js/stores/useUser.js
+++ b/resources/js/stores/useUser.js
@@ -194,7 +194,7 @@ export const user = computed({
 })
 
 // If token gets changed or emptied we should update the user.
-watch(token, refresh)
+window.setTimeout(() => watch(token, refresh))
 if (userStorage.value?.email && !token.value) {
     token.value = ''
     userStorage.value = {}


### PR DESCRIPTION
Depending on what order the code gets loaded in, these watch functions may be called before the variable exists. For example, on a vanilla Rapidez installation this can happen with the `useCart` watch if you don't install `rapidez/account`. Possibly something to do with how `useMask` imports it---it's not entirely clear how the imports end up getting resolved under different circumstances.

Because we don't have exact control over when and how things get loaded in, the best solution I could find is to make the watch get executed later. This still works exactly as it should, but makes sure everything is loaded in before.

The one in `useUser` is probably unnecessary, but I've added it anyway to be safe.