### PR TITLE
Remove render blocking 404 download

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           URL: http://localhost:1234/
           FLAT_TABLES: true
-          CUSTOM_ENTRYPOINT_COMMAND: "php bin/magento encryption:key:change -k 5AM3SD5SkwT8iwIxL6L1q8XQhzK3wk51; magerun2 config:store:set system/smtp/disable 1; magerun2 config:store:set checkout/options/enable_guest_checkout_login 1"
+          CUSTOM_ENTRYPOINT_COMMAND: "php bin/magento encryption:key:change -k 5AM3SD5SkwT8iwIxL6L1q8XQhzK3wk51; magerun2 config:store:set system/smtp/disable 1; magerun2 config:store:set checkout/options/enable_guest_checkout_login 1; magerun2 config:store:delete design/head/includes"
         ports:
           - 3307:3306
           - 1234:80

--- a/tests/playwright/pages/BasePage.js
+++ b/tests/playwright/pages/BasePage.js
@@ -73,7 +73,7 @@ export class BasePage {
             thresholds: {
                 performance: 90,
                 accessibility: 100,
-                'best-practices': 96, // TODO: Check why this one isn't 100 in CI
+                'best-practices': 100,
                 seo: 100,
             },
             reports: {


### PR DESCRIPTION
This should raise the speed score as it no longer tries a render blocking 404 css download which is in the Magento demo by default with `<link rel="stylesheet" type="text/css"  media="all" href="{{MEDIA_URL}}styles.css" />`