### PR TITLE
Recently viewed widget sorting

### DIFF
--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -33,6 +33,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        transformItems: {
+            type: Function,
+            default: (items) => items,
+        },
     },
 
     data: () => ({

--- a/resources/js/components/RecentlyViewed.vue
+++ b/resources/js/components/RecentlyViewed.vue
@@ -39,10 +39,8 @@ export default {
         },
 
         sort(items) {
-            return items.sort(
-                (a, b) => this.products.indexOf(b.entity_id) - this.products.indexOf(a.entity_id)
-            )
-        }
+            return items.sort((a, b) => this.products.indexOf(b.entity_id) - this.products.indexOf(a.entity_id))
+        },
     },
 
     computed: {

--- a/resources/js/components/RecentlyViewed.vue
+++ b/resources/js/components/RecentlyViewed.vue
@@ -37,6 +37,12 @@ export default {
                 this.storage.products = this.storage.products.slice(-this.max)
             }
         },
+
+        sort(items) {
+            return items.sort(
+                (a, b) => this.products.indexOf(b.entity_id) - this.products.indexOf(a.entity_id)
+            )
+        }
     },
 
     computed: {

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -33,7 +33,7 @@ Examples:
                         @endif
                     @endslotdefault
 
-                    <ais-hits v-slot="{ items, sendEvent }">
+                    <ais-hits v-slot="{ items, sendEvent }" v-bind:transform-items="listingSlotProps.transformItems">
                         <div v-if="items.length" class="flex flex-col gap-5">
                             @if ($title)
                                 <strong class="font-bold text-2xl">

--- a/resources/views/listing/products.blade.php
+++ b/resources/views/listing/products.blade.php
@@ -16,7 +16,7 @@
     <div class="pb-4 border-b">
         @include('rapidez::listing.partials.toolbar')
     </div>
-    <ais-hits>
+    <ais-hits :transform-items="listingSlotProps.transformItems">
         <template v-slot="{ items, sendEvent }">
             <div v-if="items && items.length" class="overflow-hidden">
                 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 -mx-5 -mb-px *:border-b">

--- a/resources/views/widget/recently-viewed.blade.php
+++ b/resources/views/widget/recently-viewed.blade.php
@@ -1,7 +1,8 @@
-<recently-viewed :max="{{ $options->page_size ?? $max ?? Rapidez::config('catalog/recently_products/viewed_count') }}" v-slot="{ products }">
+<recently-viewed :max="{{ $options->page_size ?? $max ?? Rapidez::config('catalog/recently_products/viewed_count') }}" v-slot="{ products, sort }">
     <x-rapidez::productlist
         title="Recently viewed"
         field="entity_id"
         value="products"
+        v-bind:transform-items="sort"
     />
 </recently-viewed>


### PR DESCRIPTION
So the products in the widget are sorted in order of visits instead of by the default; score.

- We could sort directly in the DSL query with a custom script but this feels cleaner and it is better readable
- As `transform-items` is the only prop on the [ais-hits component ](https://www.algolia.com/doc/api-reference/widgets/hits/vue/) we could use I added it on the listing component to passthrough. This way we can just set in on the productlist component (as all attributes will be set on the listing Vue component) without the need of a Blade component prop with all possible variants (with and without v-bind, etc)