### PR TITLE
[4.x] Fix visual swatches that aren't defined as super attributes not being shown

### DIFF
--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -172,7 +172,7 @@ class ConfigController
         // Get the filterable attributes and category levels
         $filterableAttributes = collect($this->getFilterableAttributes())
             ->map(function ($attribute) {
-                $isNumeric = $attribute['super'] || in_array($attribute['input'], ['boolean', 'price']);
+                $isNumeric = $attribute['super'] || $attribute['visual_swatch'] || in_array($attribute['input'], ['boolean', 'price']);
 
                 return [
                     'attribute' => $attribute['code'],


### PR DESCRIPTION
Usually, color attributes would become a super attribute (e.g. in the Rapidez demo) which means this check passed without issues.

However, if you add custom data or otherwise only visual swatch data that's not a super attribute, this didn't work because it tried to fetch the data as if it were a string with a keyword field. This fixes that.