### PR TITLE
Fix color for gallery arrows

### DIFF
--- a/resources/views/product/partials/gallery/slider.blade.php
+++ b/resources/views/product/partials/gallery/slider.blade.php
@@ -19,10 +19,10 @@
 
     @if (count($selectedChild->images ?? []) > 1)
         <button v-if="active" v-on:click="change(active-1)" class="z-10 top-1/2 left-3 -translate-y-1/2 absolute" aria-label="@lang('Prev')" v-cloak>
-            <x-heroicon-o-chevron-left class="size-8 text-inactive" />
+            <x-heroicon-o-chevron-left class="size-8 text" />
         </button>
         <button v-if="active != images.length-1" v-on:click="change(active+1)" class="z-10 top-1/2 right-3 -translate-y-1/2 absolute" aria-label="@lang('Next')">
-            <x-heroicon-o-chevron-right class="size-8 text-inactive" />
+            <x-heroicon-o-chevron-right class="size-8 text" />
         </button>
     @endif
 </div>


### PR DESCRIPTION
`text-inactive` doesn't work in Rapidez v4 it should be `text` 
