### PR TITLE
Fix autocomplete focus on mobile

### DIFF
--- a/resources/views/components/autocomplete/input.blade.php
+++ b/resources/views/components/autocomplete/input.blade.php
@@ -17,6 +17,7 @@
             'placeholder' => __('What are you looking for?'),
             'class' => 'text-base h-12 peer',
             'data-testid' => 'autocomplete-input',
+            'id' => 'autocomplete-input',
         ]) }}
     />
     <button


### PR DESCRIPTION
Due to the missing id the autocomplete facade no longer matched to the real autocomplete and automatically focussed.
After this change that works again so the facade change is invisible again