### PR TITLE
Make use of vue:loaded

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -201,7 +201,7 @@ export default {
                 if (this.redirect) {
                     if (this.notify.message) {
                         document.addEventListener(
-                            'turbo:load',
+                            'vue:loaded',
                             () => {
                                 Notify(this.notify.message, this.notify.type ?? 'success')
                             },


### PR DESCRIPTION
This wasn't working with `turbo:load` when do a `<graphql-mutation` with an redirect and a notification message. 
Example: 
```
<graphql-mutation
    v-cloak
    query="mutation reset($email: String!, $token: String!, $password: String!) { resetPassword ( email: $email, resetPasswordToken: $token, newPassword: $password ) }"
    :variables="{ token: '{{ request()->token }}' }"
    :clear="true"
    :notify="{ message: '@lang('Your password has been changed, please login.')' }"
    redirect="{{ route('account.login') }}"
>
```
So instead of `turbo:load` it should be `vue:loaded` 