### PR TITLE
Use npm workspaces for Rapidez dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
         "vue-turbolinks": "^2.2.2",
         "vue2-teleport": "^1.1.4"
     },
-    "dependencies": {}
+    "dependencies": {},
+    "workspaces": [
+        "vendor/rapidez/*"
+    ]
 }


### PR DESCRIPTION
As this file will be published to `rapidez/rapidez` we also need it here so for example https://github.com/rapidez/account/pull/76 will work