### PR TITLE
[2.x] Fix search overview header not showing properly on page load

### DIFF
--- a/resources/views/search/overview.blade.php
+++ b/resources/views/search/overview.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
     <div class="container">
-        <h1 class="font-bold text-3xl">@lang('Search for'): @{{ $root.queryParams.get('q') }}</h1>
+        <h1 class="font-bold text-3xl">@lang('Search for'): <span v-text="$root.queryParams.get('q')">{{ request()->get('q') }}</span></h1>
         <x-rapidez::listing query="{
             bool: {
                 must: [


### PR DESCRIPTION
This would show `Search for: {{ $root.queryParams.get('q') }}` for a split second before turning into the correct text, because vue hadn't loaded in yet. This could be fixed with a v-cloak, but I think this is neater.