### PR TITLE
[4.x] Check email availability if it's prefilled

### DIFF
--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -34,6 +34,12 @@ export default {
         return this.$scopedSlots.default(this)
     },
 
+    mounted() {
+        if (!user.value.is_logged_in && this.email) {
+            this.checkEmailAvailability()
+        }
+    },
+
     methods: {
         async go() {
             if (user.value.is_logged_in) {


### PR DESCRIPTION
If your email was pre-filled (due to already being written into the cart) it didn't get re-checked for availability. This meant that the password field would not appear if you entered an existing email, and you'd have to change it to something else and change it back to log in.

This PR checks email availability once on mount if it's filled and you're not logged in.