### PR TITLE
[2.x] Add region_code to optional attributes

### DIFF
--- a/resources/js/components/Checkout/Checkout.vue
+++ b/resources/js/components/Checkout/Checkout.vue
@@ -170,7 +170,7 @@ export default {
                 ),
             )
             Object.entries(this.checkout.shipping_address).forEach(([key, val]) => {
-                if (!val && !['region_id', 'customer_address_id', 'same_as_billing'].concat(optionalFields).includes(key)) {
+                if (!val && !['region_id', 'region_code', 'customer_address_id', 'same_as_billing'].concat(optionalFields).includes(key)) {
                     Notify(key + ' cannot be empty', 'warning')
                     validated = false
                 }


### PR DESCRIPTION
`region_id` and `region_code` can be used interchangeably in the checkout. Only one was currently optional, so here I've added the other.