### PR TITLE
[4.x] Disable setting guest email when guest checkout is disabled

### DIFF
--- a/config/rapidez/magento-defaults.php
+++ b/config/rapidez/magento-defaults.php
@@ -12,6 +12,7 @@ return [
     'cataloginventory/item_options/backorders'            => '0',
     'cataloginventory/options/show_out_of_stock'          => '0',
     'checkout/cart/redirect_to_cart'                      => '0',
+    'checkout/options/guest_checkout'                     => '1',
     'currency/options/default'                            => 'USD',
     'customer/address/company_show'                       => 'opt',
     'customer/address/fax_show'                           => '',
@@ -24,6 +25,8 @@ return [
     'customer/address/taxvat_show'                        => '',
     'customer/address/telephone_show'                     => 'req',
     'customer/create_account/vat_frontend_visibility'     => '0',
+    'customer/password/minimum_password_length'           => '8',
+    'customer/password/required_character_classes_number' => '3',
     'design/search_engine_robots/default_robots'          => 'INDEX,FOLLOW',
     'general/country/default'                             => 'US',
     'general/locale/code'                                 => 'en_US',
@@ -38,6 +41,4 @@ return [
     'trans_email/ident_general/email'                     => 'owner@example.com',
     'web/secure/base_url'                                 => '{{unsecure_base_url}}',
     'web/url/catalog_media_url_format'                    => 'hash',
-    'customer/password/required_character_classes_number' => '3',
-    'customer/password/minimum_password_length'           => '8',
 ];

--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -98,7 +98,7 @@ export default {
             if (!this.allowGuest) {
                 return false
             }
-            
+
             await setGuestEmailOnCart(this.email)
 
             return true

--- a/resources/js/components/Checkout/CheckoutLogin.vue
+++ b/resources/js/components/Checkout/CheckoutLogin.vue
@@ -18,6 +18,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        allowGuest: {
+            type: Boolean,
+            default: true,
+        },
     },
 
     data: () => ({
@@ -91,6 +95,10 @@ export default {
         },
 
         async handleGuest() {
+            if (!this.allowGuest) {
+                return false
+            }
+            
             await setGuestEmailOnCart(this.email)
 
             return true

--- a/resources/views/checkout/steps/login.blade.php
+++ b/resources/views/checkout/steps/login.blade.php
@@ -1,4 +1,8 @@
-<checkout-login v-slot="checkoutLogin" v-bind:allow-passwordless="Boolean({{ (int)(config('rapidez.frontend.allow_guest_on_existing_account')) }})">
+<checkout-login
+    v-slot="checkoutLogin"
+    v-bind:allow-passwordless="Boolean({{ (int)(config('rapidez.frontend.allow_guest_on_existing_account')) }})"
+    v-bind:allow-guest="Boolean({{ (int)(Rapidez::config('checkout/options/guest_checkout')) }})"
+>
     <fieldset partial-submit="go" class="flex flex-col gap-3" v-cloak>
         <label>
             <x-rapidez::label>@lang('Email')</x-rapidez::label>


### PR DESCRIPTION
When this option is set to `no`, the Rapidez checkout will break any time you put anything into the email box. You will get a `graphql-authorization` error because it will try to set the guest email, when that's illegal with this option disabled.