### PR TITLE
Allow the product slider to be sorted

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -24,7 +24,7 @@ Examples:
                     :search-client="listingSlotProps.searchClient"
                     :index-name="listingSlotProps.index"
                     :middlewares="listingSlotProps.middlewares"
-                    @if($sorting)
+                    @if ($sorting)
                     :initial-ui-state="{
                         [listingSlotProps.index]: {
                             sortBy: listingSlotProps.index + '_{{ $sorting }}',
@@ -32,7 +32,7 @@ Examples:
                     }"
                     @endif
                 >
-                    @if($sorting)
+                    @if ($sorting)
                         {{-- When sorting by default, instantsearch needs this component even though there are no options --}}
                         <ais-sort-by
                             :items="[]"


### PR DESCRIPTION
In the [Statamic Query Builder](https://github.com/rapidez/statamic-query-builder) we want to be able to sort the product slider based on settings configured in the component. This change allows for the items in the product slider to be sorted.