### PR TITLE
Allow duplicate graphql calls if variables are different

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -76,6 +76,7 @@ export default {
         mutated: false,
         running: false,
         initialVariables: {},
+        runningVariables: {},
         data: {},
         mutate: () => null,
         redirectUrl: '',
@@ -141,7 +142,7 @@ export default {
 
     methods: {
         async mutateFn() {
-            if (this.running) {
+            if (this.running && JSON.stringify(this.data) === JSON.stringify(this.runningVariables)) {
                 return
             }
 
@@ -157,6 +158,8 @@ export default {
 
                 let variables = this.data,
                     query = this.query
+
+                this.runningVariables = JSON.parse(JSON.stringify(this.data))
 
                 if (this.beforeRequest) {
                     ;[query, variables, options] = await this.beforeRequest(query, variables, options)

--- a/resources/views/checkout/partials/address.blade.php
+++ b/resources/views/checkout/partials/address.blade.php
@@ -142,8 +142,8 @@
                 <x-rapidez::input.select.country
                     name="{{ $type }}_country"
                     v-model="variables.country_code"
-                    v-on:change="$root.$nextTick(() => {
-                        window.$emit('postcode-change', variables);
+                    v-on:change="(event) => $root.$nextTick(() => {
+                        window.$emit('postcode-change', variables, event);
                         variables.region_id = null
                     })"
                     required
@@ -179,7 +179,7 @@
                 <x-rapidez::input
                     name="{{ $type }}_postcode"
                     v-model="variables.postcode"
-                    v-on:change="$root.$nextTick(() => window.$emit('postcode-change', variables))"
+                    v-on:change="(event) => $root.$nextTick(() => window.$emit('postcode-change', variables, event))"
                     required
                 />
             </label>
@@ -191,7 +191,7 @@
                     <x-rapidez::input
                         name="{{ $type }}_housenumber"
                         v-model="variables.street[1]"
-                        v-on:change="$root.$nextTick(() => window.$emit('postcode-change', variables))"
+                        v-on:change="(event) => $root.$nextTick(() => window.$emit('postcode-change', variables, event))"
                         required
                     />
                 </label>


### PR DESCRIPTION
In: https://github.com/rapidez/core/pull/740 this check was introduced.
It fixed accidental double clicks causing duplicate requests.

But it also broke the same graphql component sending a request with different variables, which would now get short circuited without sending a request to update the data. 

This would for instance cause issues with postcode modules updating the address.
As the change event on a postcode field would trigger the mutate for the updated postcode, at the same time the postcode module would update the street and city. 
Attempting to mutate it would result in nothing since the previous mutation has not finished yet.

When this is approved i will roll this change out to the other packages (postcode-change event), as well as the 4.x branch

ref: RAP-1827