### PR TITLE
[5.x] Add roundCurrency helper to round correctly for any currency

### DIFF
--- a/resources/js/helpers.js
+++ b/resources/js/helpers.js
@@ -31,13 +31,13 @@ window.productSpecialPrice = function (product) {
     return window.productPrice(product) > specialPrice ? specialPrice : null
 }
 
-window.roundCurrency = function (price) {
-    const formatter = new Intl.NumberFormat([(config.locale ?? 'default').replace('_', '-'), 'default'], {
-        style: 'currency',
-        currency: config.currency ?? 'eur',
-    })
-    const digits = formatter.resolvedOptions().maximumFractionDigits
+const formatter = new Intl.NumberFormat([(config.locale ?? 'default').replace('_', '-'), 'default'], {
+    style: 'currency',
+    currency: config.currency ?? 'eur',
+})
+const digits = formatter.resolvedOptions().maximumFractionDigits
 
+window.roundCurrency = function (price) {
     return Number.parseFloat(price).toFixed(digits)
 }
 

--- a/resources/js/helpers.js
+++ b/resources/js/helpers.js
@@ -31,8 +31,18 @@ window.productSpecialPrice = function (product) {
     return window.productPrice(product) > specialPrice ? specialPrice : null
 }
 
+window.roundCurrency = function (price) {
+    const formatter = new Intl.NumberFormat([(config.locale ?? 'default').replace('_', '-'), 'default'], {
+        style: 'currency',
+        currency: config.currency ?? 'eur',
+    })
+    const digits = formatter.resolvedOptions().maximumFractionDigits
+
+    return Number.parseFloat(price).toFixed(digits)
+}
+
 window.sumPrices = function (price1, price2) {
-    return Math.round((parseFloat(price1) + parseFloat(price2)) * 100) / 100
+    return window.roundCurrency(parseFloat(price1) + parseFloat(price2))
 }
 
 window.url = function (path = '') {


### PR DESCRIPTION
Ref: none

The `sumPrices` function relied on the fact that most currencies have 2 decimals. This will work, until you run into a currency like Yen (0 decimals) or Dinar (3 decimals)[^1]

By using `Intl.NumberFormat` and getting the `maximumFractionDigits` from that, we can round properly. I've made a helper function for this and applied it to the `sumPrices` function.

[^1]: https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes