### PR TITLE
Fixed NaN Prices

### DIFF
--- a/src/Models/AbstractAttribute.php
+++ b/src/Models/AbstractAttribute.php
@@ -55,7 +55,7 @@ class AbstractAttribute extends Model
             return array_key_exists('value', $this->getCasts())
                 ? $this->castAttribute('value', $value)
                 : $value;
-        });
+        })->shouldCache();
     }
 
     protected function value(): Attribute

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -266,6 +266,9 @@ class Product extends Model
     protected function price(): Attribute
     {
         return Attribute::get(function (?AttributeDecimal $value) {
+            /** @var ?AttributeDecimal $value */
+            $value ??= $this->getCustomAttribute('price');
+
             $customerGroupId = auth('magento-customer')
                 ->user()
                 ?->group_id ?: 0;
@@ -279,7 +282,7 @@ class Product extends Model
             }
 
             return $price->price ?: $price->min_price;
-        });
+        })->shouldCache();
     }
 
     // We're not applying the customer group here so
@@ -314,7 +317,7 @@ class Product extends Model
             }
 
             return $specialPrice < $this->price ? $specialPrice : null;
-        });
+        })->shouldCache();
     }
 
     protected function calculatedTierPrices(): Attribute


### PR DESCRIPTION
Running toArray would cause the price to be `null` while `->price` would return the correct price.
This would result in NaN prices for products that are out of stock.

The code causing this is https://github.com/laravel/framework/blob/f374d48bc97144bf2ed6e76b1fa2743e615ad446/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L249
By default they pass `null` as argument to any mutator added to the `$appends`

Which we can fix by getting the value from the underlying store.