### PR TITLE
Trim category name before indexing it

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -152,6 +152,7 @@ trait Searchable
                     ->take($i)
                     ->map(fn ($id) => $categories[$id]->name ?? null)
                     ->whereNotNull()
+                    ->map(fn ($name) => trim($name))
                     ->join(' > ');
 
                 $data['category_lvl' . $i][] = $pathCategories;


### PR DESCRIPTION
ref: GT-2536

Subcategories that ended with a space did not work properly when used as a category filter, then refreshed. This caused some category pages to return empty when refreshing or using browser back/forward.

I initially wanted to use `->map(trim(...))` but this doesn't work, as it'll try to inject the array key into the second argument of the trim function.