### PR TITLE
[5.x] Fix track events being duplicated

### DIFF
--- a/resources/views/product/partials/track.blade.php
+++ b/resources/views/product/partials/track.blade.php
@@ -1,5 +1,7 @@
 <script async>
-document.addEventListener('vue:loaded', function() {
-    window.rapidezAPI('POST', '/track/product/' + window.config.product.entity_id)
-})
+if (! document.documentElement.hasAttribute('data-turbo-preview')) {
+    document.addEventListener('vue:loaded', function() {
+        window.rapidezAPI('POST', '/track/product/' + window.config.product.entity_id)
+    }, { once: true })
+}
 </script>


### PR DESCRIPTION
ref: RAP-1878

Two issues at play here. Firstly, this eventlistener never gets removed, which caused it to re-run on every new Turbo navigation. The requests actually piled up the more products you visited, causing things to eventually break.

Secondarily, as it turns out turbo actually loads the page twice. Once a stale "preview" version from cache, then another once the page actually loads. This is great for pagespeed, but it also means this script got executed twice on cached pages.

Luckily, we can easily check whether the page is cached by checking if `data-turbo-preview` is set on the documentElement.

This does beg the question... do we need to wrap anything else with this kind of check?