### PR TITLE
Added error handling for config.js

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -52,8 +52,8 @@ async function init() {
     booting = true
 
     for (let i = 0; i < 20; i++) {
-        // Wait until config is available, for a max of 1s
-        if (window.config.store) {
+        // Wait until config is available, or has thrown an error, for a max of 1s
+        if (window.config.store || window.configError) {
             break
         }
         await new Promise((resolve) => setTimeout(resolve, 50))
@@ -66,7 +66,7 @@ async function init() {
 
     // Check if the localstorage needs a flush.
     let cachekey = useLocalStorage('cachekey')
-    if (cachekey.value !== window.config.cachekey) {
+    if (window.config.cachekey && cachekey.value !== window.config.cachekey) {
         window.config.flushable_localstorage_keys.forEach((key) => {
             useLocalStorage(key).value = null
         })
@@ -109,6 +109,7 @@ async function init() {
                 mask: useMask(),
                 showTax: window.config.show_tax,
                 scrollLock: useScrollLock(document.body),
+                configError: false,
             },
             methods: {
                 search(value) {
@@ -178,8 +179,16 @@ async function init() {
                 loadingCount: function (count) {
                     window.app.$data.loading = count > 0
                 },
+
+                configError: function (newValue) {
+                    if (newValue === true) {
+                        throw new Error('Config.js failed to load due to an error.')
+                    }
+                }
             },
             mounted() {
+                this.configError = window.configError ?? false;
+
                 setTimeout(() => {
                     const event = new CustomEvent('vue:mounted', { detail: { vue: window.app } })
                     document.dispatchEvent(event)

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -184,10 +184,10 @@ async function init() {
                     if (newValue === true) {
                         throw new Error('Config.js failed to load due to an error.')
                     }
-                }
+                },
             },
             mounted() {
-                this.configError = window.configError ?? false;
+                this.configError = window.configError ?? false
 
                 setTimeout(() => {
                     const event = new CustomEvent('vue:mounted', { detail: { vue: window.app } })

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,7 +23,7 @@
 
     @php($configPath = route('config') . '?v=' . Cache::rememberForever('cachekey', fn () => md5(Str::random())) . '&s=' . config('rapidez.store'))
     <link href="{{ $configPath }}" rel="preload" as="script">
-    <script defer src="{{ $configPath }}"></script>
+    <script defer src="{{ $configPath }}" onerror="window.app?.configError === false ? window.app.configError = true : window.configError = true"></script>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @stack('head')
@@ -32,6 +32,8 @@
 <body class="text antialiased has-[.prevent-scroll:checked]:overflow-clip">
     <div id="app" class="flex flex-col min-h-dvh">
         @include('rapidez::layouts.partials.global-slideover')
+
+        @includeWhen(config('app.debug'), 'rapidez::layouts.partials.debug')
         @includeWhen(!request()->routeIs('checkout'), 'rapidez::layouts.partials.header')
         @includeWhen(request()->routeIs('checkout'), 'rapidez::layouts.checkout.header')
         <main>

--- a/resources/views/layouts/partials/debug.blade.php
+++ b/resources/views/layouts/partials/debug.blade.php
@@ -1,0 +1,7 @@
+<div
+    v-cloak
+    v-if="$root.configError"
+    class="w-full bg-danger text-center text-white font-bold"
+>
+    Config.js failed to load due to an error.
+</div>


### PR DESCRIPTION
ref: RAP-1856

This PR adds some error handling for when config.js does not load in. It will throw an error that Sentry can catch, and when the app is in debug mode it will also show a nice obvious red bar at the top of the page.