### PR TITLE
[4.x] Use array.from instead of toArray on entries

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -290,7 +290,7 @@ export default {
             await this.setOptionsFromValues(Object.fromEntries(options))
         },
         async setOptionsFromUrlParams() {
-            let options = new URLSearchParams(window.location.search).entries().toArray()
+            let options = Array.from(new URLSearchParams(window.location.search).entries())
             await this.setOptionsFromValues(this.optionsFromNamedOptions(options))
         },
         optionsFromNamedOptions(values) {


### PR DESCRIPTION
ref: GT-2543

Older browsers don't support `toArray()` on these entries yet. As this is a very simple fix, this was worth updating here.