### PR TITLE
[5.x] Always trim category name

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -55,6 +55,11 @@ class Category extends Model
             : ('catalog/category/view/id/' . $this->entity_id)));
     }
 
+    public function name(): Attribute
+    {
+        return Attribute::get(fn($name) => trim($name));
+    }
+
     public function products(): HasManyThrough
     {
         return $this->hasManyThrough(

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -59,7 +59,7 @@ class Category extends Model
     {
         return Attribute::get(function (?AttributeVarchar $value) {
             $value ??= $this->getCustomAttribute('name');
-            return trim($value);
+            return trim($value?->value ?? '');
         });
     }
 

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -57,7 +57,7 @@ class Category extends Model
 
     public function name(): Attribute
     {
-        return Attribute::get(fn($name) => trim($name));
+        return Attribute::get(fn ($name) => trim($name));
     }
 
     public function products(): HasManyThrough

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -59,6 +59,7 @@ class Category extends Model
     {
         return Attribute::get(function (?AttributeVarchar $value) {
             $value ??= $this->getCustomAttribute('name');
+
             return trim($value);
         });
     }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -23,7 +23,7 @@ class Category extends Model
     protected $primaryKey = 'entity_id';
     protected $entityTypeId = EavAttribute::ENTITY_TYPE_CATALOG_CATEGORY;
 
-    protected $appends = ['url'];
+    protected $appends = ['url', 'name'];
 
     public const STATUS_ACTIVE = 1;
 
@@ -57,7 +57,7 @@ class Category extends Model
 
     public function name(): Attribute
     {
-        return Attribute::get(fn ($name) => trim($name));
+        return Attribute::get(fn () => trim($this->getCustomAttribute('name')));
     }
 
     public function products(): HasManyThrough

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -55,9 +55,12 @@ class Category extends Model
             : ('catalog/category/view/id/' . $this->entity_id)));
     }
 
-    public function name(): Attribute
+    protected function name(): Attribute
     {
-        return Attribute::get(fn () => trim($this->getCustomAttribute('name')));
+        return Attribute::get(function (?AttributeVarchar $value) {
+            $value ??= $this->getCustomAttribute('name');
+            return trim($value);
+        });
     }
 
     public function products(): HasManyThrough


### PR DESCRIPTION
As it turns out, other places also need this trimmed. By fixing that at the root we don't have to trim each location individually.