### PR TITLE
[5.x] Make sure combining queries don't read the same stream multiple times

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -170,7 +170,10 @@ export default {
                         throw error
                     }
 
-                    const errorResponse = await error.response.json()
+                    if (!error._responseData && !error.response.bodyUsed) {
+                        error._responseData = error.response.json()
+                    }
+                    const errorResponse = error._responseData ? await error._responseData : {}
                     if (this.errorCallback) {
                         await this.errorCallback(this.data, errorResponse)
                     }


### PR DESCRIPTION
ref: GT-2543

In our Sentry logging we noticed that sometimes, graphql queries would have their error body already seemingly read. This was puzzling at first, because there's no obvious way to have this happen.

However, in the `submitPartials` code, it turns out that when `combiningGraphQL` gets used, it will send the same error object to all of the graphql components that got combined. While I wasn't able to verify this was actually happening, the code seemed pretty clear cut and dry to me in this instance.

Because I didn't want to change anything about how the fetch function sends a responseClone instead of just the actual response data (I'm sure there's a reason, but I didn't dig for it), I instead reworked this part to work to work with concurrency by using a shared responseData object in the error object. Note that the naive way to do this would run into race conditions, so instead I store the awaitable part once, and then await it after.