### PR TITLE
Fixed Turbo bfcache on vue unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         "vue": "^3.5.23",
         "vue-cookies": "^1.8.2",
         "vue-instantsearch": "^4.19.13",
-        "vue-turbolinks": "^2.2.2",
         "vue3-click-away": "^1.2.4"
     },
     "dependencies": {},

--- a/resources/js/vue-components.js
+++ b/resources/js/vue-components.js
@@ -1,4 +1,4 @@
-import TurbolinksAdapter from 'vue-turbolinks'
+import TurbolinksAdapter from './vue-turbolinks'
 import toggler from './components/Elements/Toggler.vue'
 import addToCart from './components/Product/AddToCart.vue'
 import user from './components/User/User.vue'

--- a/resources/js/vue-turbolinks.js
+++ b/resources/js/vue-turbolinks.js
@@ -1,0 +1,45 @@
+function handleVueDestruction(instance) {
+  const event = instance.$options.destroyEvent || defaultEvent();
+
+  document.addEventListener(event, function teardown() {
+    const cachedHTML = instance._.type.template;
+    const el = instance.$el;
+    const parent = el ? el.parentNode : null;
+
+    instance.$.appContext.app.unmount();
+
+    // Vue 3's unmount() removes DOM nodes, so restore cached HTML into the parent manually
+    if (parent && cachedHTML && parent.innerHTML === '') {
+      parent.innerHTML = cachedHTML;
+    }
+
+    document.removeEventListener(event, teardown);
+  });
+}
+
+const Mixin = {
+  beforeMount() {
+    if (this !== this.$root) {
+        // We only wish to unmount the root component.
+        return;
+    }
+
+    handleVueDestruction(this);
+  }
+};
+
+function plugin(app, options) {
+  // Install a global mixin
+  app.mixin(Mixin);
+}
+
+function defaultEvent() {
+  if (typeof Turbo !== 'undefined') {
+    return 'turbo:visit';
+  }
+
+  return 'turbolinks:visit';
+}
+
+export { Mixin as turbolinksAdapterMixin };
+export default plugin;

--- a/resources/js/vue-turbolinks.js
+++ b/resources/js/vue-turbolinks.js
@@ -1,45 +1,45 @@
 function handleVueDestruction(instance) {
-  const event = instance.$options.destroyEvent || defaultEvent();
+    const event = instance.$options.destroyEvent || defaultEvent()
 
-  document.addEventListener(event, function teardown() {
-    const cachedHTML = instance._.type.template;
-    const el = instance.$el;
-    const parent = el ? el.parentNode : null;
+    document.addEventListener(event, function teardown() {
+        const cachedHTML = instance._.type.template
+        const el = instance.$el
+        const parent = el ? el.parentNode : null
 
-    instance.$.appContext.app.unmount();
+        instance.$.appContext.app.unmount()
 
-    // Vue 3's unmount() removes DOM nodes, so restore cached HTML into the parent manually
-    if (parent && cachedHTML && parent.innerHTML === '') {
-      parent.innerHTML = cachedHTML;
-    }
+        // Vue 3's unmount() removes DOM nodes, so restore cached HTML into the parent manually
+        if (parent && cachedHTML && parent.innerHTML === '') {
+            parent.innerHTML = cachedHTML
+        }
 
-    document.removeEventListener(event, teardown);
-  });
+        document.removeEventListener(event, teardown)
+    })
 }
 
 const Mixin = {
-  beforeMount() {
-    if (this !== this.$root) {
-        // We only wish to unmount the root component.
-        return;
-    }
+    beforeMount() {
+        if (this !== this.$root) {
+            // We only wish to unmount the root component.
+            return
+        }
 
-    handleVueDestruction(this);
-  }
-};
+        handleVueDestruction(this)
+    },
+}
 
 function plugin(app, options) {
-  // Install a global mixin
-  app.mixin(Mixin);
+    // Install a global mixin
+    app.mixin(Mixin)
 }
 
 function defaultEvent() {
-  if (typeof Turbo !== 'undefined') {
-    return 'turbo:visit';
-  }
+    if (typeof Turbo !== 'undefined') {
+        return 'turbo:visit'
+    }
 
-  return 'turbolinks:visit';
+    return 'turbolinks:visit'
 }
 
-export { Mixin as turbolinksAdapterMixin };
-export default plugin;
+export { Mixin as turbolinksAdapterMixin }
+export default plugin


### PR DESCRIPTION
The Vue turbolinks package does not actually support Vue 3, meaning most of the back/forward navigations were pure luck that they were stored in cache correctly so vue could boot the page.

One place you could notice it was navigating to a category page, opening a product. Using the browser button to navigate back. And attempting to filter, which would no longer function.

This change unmounts the global Vue instance, replaces the content with the cached template (which vue 3 does for us now) so the full html without Vue html replacing is cached.