### PR TITLE
Include simpleProduct in cart-add event

### DIFF
--- a/resources/js/components/Product/AddToCart.vue
+++ b/resources/js/components/Product/AddToCart.vue
@@ -140,7 +140,7 @@ export default {
                     await this.callback(this.product, this.qty)
                 }
 
-                window.$emit('cart-add', { product: this.product, qty: this.qty })
+                window.$emit('cart-add', { product: this.product, simpleProduct: this.simpleProduct, qty: this.qty })
 
                 if (this.notifySuccess) {
                     Notify(this.product.name + ' ' + window.config.translations.cart.add, 'success', [], window.url('/cart'))


### PR DESCRIPTION
For analytics it will be useful to see the simple product added to the cart in case you're adding a configurable product.