### PR TITLE
[5.x] Add heartbeat to keep CSRF tokens alive

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -94,9 +94,12 @@ async function init() {
 
     // Heartbeat every 15 minutes to keep CSRF alive
     if (!window.heartbeat) {
-        window.heartbeat = setInterval(() => {
-            rapidezFetch('/heartbeat')
-        }, 1000 * 60 * 15)
+        window.heartbeat = setInterval(
+            () => {
+                rapidezFetch('/heartbeat')
+            },
+            1000 * 60 * 15,
+        )
     }
 
     requestAnimationFrame(() => {

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -92,6 +92,13 @@ async function init() {
         custom_attributes: [],
     }
 
+    // Heartbeat every 15 minutes to keep CSRF alive
+    if (!window.heartbeat) {
+        window.heartbeat = setInterval(() => {
+            rapidezFetch('/heartbeat')
+        }, 1000 * 60 * 15)
+    }
+
     requestAnimationFrame(() => {
         window.app = createApp({
             el: '#app',
@@ -151,6 +158,7 @@ async function init() {
             // If we have view transitions, we need to make sure we destroy after render.
             destroyEvent: !!document.startViewTransition ? 'turbo:before-cache-timeout' : 'turbo:before-cache',
         })
+
         // https://vuejs.org/api/application.html#app-config-performance
         window.app.config.performance = import.meta.env.VITE_PERFORMANCE == 'true'
         window.app.config.globalProperties = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,4 +26,6 @@ Route::middleware('web')->group(function () {
 
     Route::get('search', config('rapidez.routing.controllers.search'))->name('search');
     Route::fallback(config('rapidez.routing.controllers.fallback'));
+
+    Route::get('heartbeat', fn() => response()->json(['alive' => true]));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,5 +27,5 @@ Route::middleware('web')->group(function () {
     Route::get('search', config('rapidez.routing.controllers.search'))->name('search');
     Route::fallback(config('rapidez.routing.controllers.fallback'));
 
-    Route::get('heartbeat', fn() => response()->json(['alive' => true]));
+    Route::get('heartbeat', fn () => response()->json(['alive' => true]));
 });


### PR DESCRIPTION
ref: RAP-1888

This PR adds an empty route under the `web` middleware to keep the CSRF token alive, which it then calls every 15 minutes. This should significantly reduce the issue where people are doing requests with invalid CSRF tokens.