### PR TITLE
[5.x] Add robots.txt from blade

### DIFF
--- a/resources/views/robots.blade.php
+++ b/resources/views/robots.blade.php
@@ -1,0 +1,22 @@
+User-agent: *
+Crawl-delay: 1
+Allow: /*.js?
+Allow: /*.css?
+Allow: /*?page=
+Disallow: /*?
+Disallow: /account$
+Disallow: /account/*
+Disallow: /cart$
+Disallow: /cart/*
+Disallow: /checkout$
+Disallow: /checkout/*
+Disallow: /search$
+Disallow: /search/*
+
+{{--
+    Includes the Magento robots.txt instructions.
+    NOTE: Make sure to clean these instructions up, or to not include them at all.
+--}}
+{{ Rapidez::config('design/search_engine_robots/custom_instructions') }}
+
+Sitemap: {{ url('sitemap.xml') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,13 @@ Route::middleware('cache.headers:public;max_age=3600;s_maxage=3600;stale_while_r
     Route::get('config.js', ConfigController::class)->name('config');
 });
 
+Route::middleware('cache.headers:public;max_age=86400;s_maxage=86400')->group(function (): void {
+    Route::get('robots.txt', function () {
+        return response()->view('robots')
+            ->header('Content-Type', 'text/plain; charset=utf-8');
+    });
+});
+
 Route::middleware('web')->group(function () {
     Route::view('cart', 'rapidez::cart.overview')->name('cart');
 


### PR DESCRIPTION
ref: RAP-1889

This fixes the sitemap issue where it uses a relative URL (where the absolute URL is vastly preferred).

Overrides [the `robots.txt` file from rapidez/rapidez](https://github.com/rapidez/rapidez/blob/master/public/robots.txt). We should probably remove it from that repo in the next major release.