### PR TITLE
[5.x] Make rewrites store-specific again

### DIFF
--- a/src/Models/Traits/HasAlternatesThroughRewrites.php
+++ b/src/Models/Traits/HasAlternatesThroughRewrites.php
@@ -14,7 +14,6 @@ trait HasAlternatesThroughRewrites
     {
         return $this
             ->hasMany(config('rapidez.models.rewrite'), 'entity_id')
-            ->withoutGlobalScope('store')
             ->where('entity_type', static::getEntityType());
     }
 
@@ -23,6 +22,7 @@ trait HasAlternatesThroughRewrites
         return Attribute::make(
             get: function () {
                 $rewrites = $this->rewrites()
+                    ->withoutGlobalScope('store')
                     ->where('redirect_type', 0)
                     ->whereHas('store', fn ($query) => $query->where('store.group_id', config('rapidez.group')))
                     ->pluck('request_path', 'store_id');


### PR DESCRIPTION
ref: RAP-1902

The way this was implemented caused rewrites to not be store-specific when retrieved on a model. I moved the `->withoutGlobalScope('store')` to the alternates function where it should have been in the first place.