### PR TITLE
Fixed incorrect coupon clearing cart

### DIFF
--- a/resources/js/callbacks.js
+++ b/resources/js/callbacks.js
@@ -61,7 +61,7 @@ document.addEventListener('vue:loaded', function (event) {
                     error.extensions?.category === 'graphql-no-such-entity' &&
                     // Untested, but something like this is maybe a better idea as
                     // we're using a lot of different mutations in the checkout.
-                    error.path.some((path) => path.toLowerCase().includes('cart')),
+                    error.path.some((path) => path.toLowerCase().includes('cart') && !path.toLowerCase().includes('applycoupon')),
             )
         ) {
             Notify(window.config.translations.errors.cart_expired, 'error')


### PR DESCRIPTION
The endpoint to add a coupon to cart is `applyCouponToCart` and a non-existant coupon code results in a `graphql-no-such-entity` error.

This combination causes the cart to be seen as expired while this is not the case.