### PR TITLE
[4.x] Add has_options to elastic data

### DIFF
--- a/config/rapidez/searchkit.php
+++ b/config/rapidez/searchkit.php
@@ -28,6 +28,7 @@ return [
         'images',
         'url',
         'thumbnail',
+        'has_options',
         'in_stock',
         'children',
         'super_*',

--- a/src/Models/Scopes/Product/WithProductAttributesScope.php
+++ b/src/Models/Scopes/Product/WithProductAttributesScope.php
@@ -15,6 +15,7 @@ class WithProductAttributesScope implements Scope
             $model->qualifyColumn('sku'),
             $model->qualifyColumn('visibility'),
             $model->qualifyColumn('type_id'),
+            $model->qualifyColumn('has_options'),
             $model->getQualifiedCreatedAtColumn(),
             $model->getQualifiedUpdatedAtColumn(),
         ]);


### PR DESCRIPTION
We use this column to determine whether or not to redirect when you click on the add to cart button in the listing. However, this was not selected nor added to the searchkit result attributes. As a result, this functionality didn't work.