### PR TITLE
[5.x] Make config props defaults lazy

### DIFF
--- a/resources/js/components/Graphql.vue
+++ b/resources/js/components/Graphql.vue
@@ -34,7 +34,7 @@ export default {
         },
         store: {
             type: String,
-            default: window.config.store_code,
+            default: () => window.config.store_code,
         },
     },
 

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -52,7 +52,7 @@ export default {
         },
         store: {
             type: String,
-            default: window.config.store_code,
+            default: () => window.config.store_code,
         },
         beforeRequest: {
             type: Function,

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -22,7 +22,7 @@ export default {
     props: {
         index: {
             type: String,
-            default: window.config.index.product,
+            default: () => window.config.index.product,
         },
         query: {
             type: Function,


### PR DESCRIPTION
In some cases, the prop default would get loaded in _before_ the config gets loaded in. This caused graphql mutations placed in root DOM (such as the one on the registration page) to sometimes not work because the store code wasn't loaded in. I can't say exactly what triggers this bug exactly, and why it does work just fine in most places.

By lazy loading them like this, this issue was fully resolved.