### PR TITLE
[5.x] Return null on no values instead of empty array

### DIFF
--- a/src/Models/AbstractAttribute.php
+++ b/src/Models/AbstractAttribute.php
@@ -70,7 +70,8 @@ class AbstractAttribute extends Model
                 return e(htmlspecialchars_decode($val), false);
             }, Arr::wrap($value));
 
-            if (count($value) === 1) {
+            // NOTE: doing it this way properly returns null when there are no values
+            if (count($value) <= 1) {
                 return Arr::first($value);
             }
 


### PR DESCRIPTION
Ran into this bug when going to a category overview page where the category had no description value. It ended up returning an empty array.

`Arr::first([])` returns `null`, so changing this check like I've done here works correctly.