### PR TITLE
[5.x] Listen to default_sort_by from magento

### DIFF
--- a/config/rapidez/magento-defaults.php
+++ b/config/rapidez/magento-defaults.php
@@ -1,9 +1,10 @@
 <?php
 
 return [
+    'catalog/frontend/default_sort_by'                    => 'position',
     'catalog/frontend/flat_catalog_category'              => '0',
-    'catalog/frontend/grid_per_page_values'               => '12,24,36',
     'catalog/frontend/flat_catalog_product'               => '0',
+    'catalog/frontend/grid_per_page_values'               => '12,24,36',
     'catalog/frontend/grid_per_page'                      => '12',
     'catalog/frontend/show_swatches_in_product_list'      => '1',
     'catalog/recently_products/viewed_count'              => '5',

--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -270,7 +270,7 @@ class ConfigController
         // Set default sort by
         $defaultSortBy = Rapidez::config('catalog/frontend/default_sort_by');
         $sortableAttributes = $sortableAttributes
-            ->sortBy(fn($attribute) => $attribute['code'] == $defaultSortBy ? 0 : 1)
+            ->sortBy(fn ($attribute) => $attribute['code'] == $defaultSortBy ? 0 : 1)
             ->values()
             ->toArray();
 

--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -250,21 +250,34 @@ class ConfigController
                     "rapidez::frontend.sorting.{$attribute['code']}.{$direction}",
                     trans_fallback("rapidez::frontend.{$attribute['code']}", ucfirst($attribute['code'])) . ' ' . trans_fallback("rapidez::frontend.{$direction}", $direction),
                 ),
+                'code'  => $attribute['code'],
                 'field' => $attribute['code'] . (Attribute::hasKeyword($attribute['code']) ? '.keyword' : ''),
                 'order' => $direction,
                 'value' => "{$index}_{$attribute['code']}_{$direction}",
                 'key'   => "_{$attribute['code']}_{$direction}",
             ]));
 
-        // Add default relevance sort
+        // Add relevance sort
         $sortableAttributes->prepend([
             'label' => __('Relevance'),
+            'code'  => 'position',
             'field' => '_score',
             'order' => 'desc',
-            'value' => $index,
-            'key'   => 'default',
+            'value' => "{$index}_score_desc",
+            'key'   => '_score_desc',
         ]);
 
-        return $sortableAttributes->keyBy('key')->toArray();
+        // Set default sort by
+        $defaultSortBy = Rapidez::config('catalog/frontend/default_sort_by');
+        $sortableAttributes = $sortableAttributes
+            ->sortBy(fn($attribute) => $attribute['code'] == $defaultSortBy ? 0 : 1)
+            ->values()
+            ->toArray();
+
+        // Change value and key of default sort
+        $sortableAttributes[0]['value'] = $index;
+        $sortableAttributes[0]['key'] = 'default';
+
+        return Arr::keyBy($sortableAttributes, 'key');
     }
 }


### PR DESCRIPTION
ref: GT-2556

The `default_sort_by` option can be set in Magento, but we don't listen to it. It has one special case `position` which is the same as our `relevance` sort. Everything else that this value is generated from all the actual attributes that are sortable in Magento.

The way this code is structured means that if nothing matches, it will fall back to the relevance sort regardless.