### PR TITLE
[5.x] Remove unnecessary disallow with parameters

### DIFF
--- a/resources/views/robots.blade.php
+++ b/resources/views/robots.blade.php
@@ -3,7 +3,6 @@ Crawl-delay: 1
 Allow: /*.js?
 Allow: /*.css?
 Allow: /*?page=
-Disallow: /*?
 Disallow: /account$
 Disallow: /account/*
 Disallow: /cart$


### PR DESCRIPTION
ref: RAP-1905

Google apparently didn't like this as it adds its own GTM parameters to everything it indexes and then chooses to disallow itself.