### PR TITLE
[5.x] Always use score field for autocomplete sorting

### DIFF
--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -134,17 +134,18 @@ export default {
         async getSearchSettings() {
             let config = await InstantSearchMixin.methods.getSearchSettings.bind(this).call()
 
-            config.sorting = {
-                default: {
-                    field: '_score',
-                    key: 'default',
-                    label: 'Default',
-                    order: 'desc',
-                    value: window.config.index.product,
+            return {
+                ...config,
+                sorting: {
+                    default: {
+                        field: '_score',
+                        key: 'default',
+                        label: 'Default',
+                        order: 'desc',
+                        value: window.config.index.product,
+                    },
                 },
             }
-
-            return config
         },
 
         async getInstantSearchClientConfig() {

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -131,6 +131,22 @@ export default {
             return client
         },
 
+        async getSearchSettings() {
+            let config = await InstantSearchMixin.methods.getSearchSettings.bind(this).call()
+
+            config.sorting = {
+                default: {
+                    field: '_score',
+                    key: 'default',
+                    label: 'Default',
+                    order: 'desc',
+                    value: window.config.index.product,
+                }
+            }
+
+            return config
+        },
+
         async getInstantSearchClientConfig() {
             const config = await InstantSearchMixin.methods.getInstantSearchClientConfig.bind(this).call()
 

--- a/resources/js/components/Search/Autocomplete.vue
+++ b/resources/js/components/Search/Autocomplete.vue
@@ -141,7 +141,7 @@ export default {
                     label: 'Default',
                     order: 'desc',
                     value: window.config.index.product,
-                }
+                },
             }
 
             return config


### PR DESCRIPTION
Using a different sorting ended up breaking the autocomplete, because the categories didn't like being sorted by SKU which broke the autocomplete entirely.