### PR TITLE
Increase notification open time depending on words

### DIFF
--- a/resources/js/components/Notifications/Notification.vue
+++ b/resources/js/components/Notifications/Notification.vue
@@ -21,9 +21,12 @@ export default {
         this.link = this.notification.link
     },
     mounted() {
-        setTimeout(() => {
-            this.close()
-        }, Math.max(this.duration, this.message.split(' ').length / 3 * 1000))
+        setTimeout(
+            () => {
+                this.close()
+            },
+            Math.max(this.duration, (this.message.split(' ').length / 3) * 1000),
+        )
     },
     data: () => ({
         message: null,

--- a/resources/js/components/Notifications/Notification.vue
+++ b/resources/js/components/Notifications/Notification.vue
@@ -23,7 +23,7 @@ export default {
     mounted() {
         setTimeout(() => {
             this.close()
-        }, this.duration)
+        }, Math.max(this.duration, this.message.split(' ').length / 3 * 1000))
     },
     data: () => ({
         message: null,


### PR DESCRIPTION
In some cases notifications can contain quite a lot of text where the 5s duration might not be enough.

This change uses the lower end of the average reading speed of ~3 words per second to calculate and use the higher timeout if it would exceed the regular duration.