### PR TITLE
[5.x] Add fallback to error.path

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -161,7 +161,7 @@ export const magentoGraphQL = (window.magentoGraphQL = async (
             errors.forEach((error) => {
                 if (
                     !['graphql-authorization', 'graphql-authentication'].includes(error?.extensions?.category) ||
-                    error.path.includes('generateCustomerToken')
+                    error.path?.includes('generateCustomerToken')
                 ) {
                     return
                 }


### PR DESCRIPTION
This `path` is not always defined. Adding the `?` here makes sure this doesn't just error out.