### PR TITLE
[5.x] Mage-os compatibility

### DIFF
--- a/resources/views/checkout/queries/placeOrder.graphql
+++ b/resources/views/checkout/queries/placeOrder.graphql
@@ -10,10 +10,6 @@ mutation placeOrder (
         orderV2 {
             ...orderV2
         }
-        errors {
-            code
-            message
-        }
     }
 }
 


### PR DESCRIPTION
Draft PR for now that contains whatever changes are needed to make mage-os work. For now that is:

- Removing the `errors` field from `PlaceOrderOutput`.