### PR TITLE
[5.x] Use enums for constant values

### DIFF
--- a/resources/views/product/partials/addtocart.blade.php
+++ b/resources/views/product/partials/addtocart.blade.php
@@ -5,7 +5,7 @@
 >
     <form v-on:submit.prevent="addToCart.add" class="flex flex-col gap-5">
         <h1 class="text-3xl font-bold" itemprop="name">{{ $product->name }}</h1>
-        @if (!$product->stock->is_in_stock && $product->stock->backorders === 0)
+        @if (!$product->stock->is_in_stock && $product->stock->backorders === Rapidez\Core\Enums\Backorders::No->value)
             <p class="text-red-600">@lang('Sorry! This product is currently out of stock.')</p>
         @else
             @include('rapidez::product.partials.super-attributes')
@@ -13,7 +13,7 @@
 
             @includeWhen($product->tierPrices->count(), 'rapidez::product.partials.tier-prices')
 
-            @if ($product->qty <= 0 && $product->stock->backorders === 2)
+            @if ($product->qty <= 0 && $product->stock->backorders === Rapidez\Core\Enums\Backorders::Notify->value)
                 <div class="flex gap-2">
                     <x-heroicon-o-exclamation-circle class="mt-px w-5" />
                     <span>@lang('This product will be backordered')</span>

--- a/src/Enums/Backorders.php
+++ b/src/Enums/Backorders.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum Backorders: int
+{
+    case No = 0;
+    case Yes = 1;
+    case Notify = 2;
+}

--- a/src/Enums/CategoryStatus.php
+++ b/src/Enums/CategoryStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum CategoryStatus: int
+{
+    case Inactive = 0;
+    case Active = 1;
+}

--- a/src/Enums/EntityType.php
+++ b/src/Enums/EntityType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum EntityType: int
+{
+    case Customer = 1;
+    case Address = 2;
+    case Category = 3;
+    case Product = 4;
+}

--- a/src/Enums/ProductStatus.php
+++ b/src/Enums/ProductStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum ProductStatus: int
+{
+    case Disabled = 1;
+    case Enabled = 2;
+}

--- a/src/Enums/ProductStatus.php
+++ b/src/Enums/ProductStatus.php
@@ -4,6 +4,6 @@ namespace Rapidez\Core\Enums;
 
 enum ProductStatus: int
 {
-    case Disabled = 1;
-    case Enabled = 2;
+    case Enabled = 1;
+    case Disabled = 2;
 }

--- a/src/Enums/ReviewEntityType.php
+++ b/src/Enums/ReviewEntityType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum ReviewEntityType: int
+{
+    case Product = 1;
+    case Customer = 2;
+    case Category = 3;
+}

--- a/src/Enums/Visibility.php
+++ b/src/Enums/Visibility.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\Core\Enums;
+
+enum Visibility: int
+{
+    case None = 1;
+    case Catalog = 2;
+    case Search = 3;
+    case Both = 4;
+}

--- a/src/Http/Controllers/ProductController.php
+++ b/src/Http/Controllers/ProductController.php
@@ -5,9 +5,9 @@ namespace Rapidez\Core\Http\Controllers;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
+use Rapidez\Core\Enums\Visibility;
 use Rapidez\Core\Events\ProductViewEvent;
 use Rapidez\Core\Facades\Rapidez;
-use Rapidez\Core\Models\Product;
 use TorMorten\Eventy\Facades\Eventy;
 
 class ProductController
@@ -21,8 +21,8 @@ class ProductController
             ->withEventyGlobalScopes('productpage.scopes')
             ->with(['tierPrices'])
             ->whereInAttribute('visibility', [
-                Product::VISIBILITY_IN_CATALOG,
-                Product::VISIBILITY_BOTH,
+                Visibility::Catalog->value,
+                Visibility::Both->value,
             ])
             ->findOrFail($productId);
 

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Rapidez\Core\Enums\EntityType;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Scopes\Category\IsActiveScope;
 use Rapidez\Core\Models\Traits\HasAlternatesThroughRewrites;
@@ -21,11 +22,9 @@ class Category extends Model
 
     protected $table = 'catalog_category_entity';
     protected $primaryKey = 'entity_id';
-    protected $entityTypeId = EavAttribute::ENTITY_TYPE_CATALOG_CATEGORY;
+    protected $entityTypeId = EntityType::Category->value;
 
     protected $appends = ['url', 'name'];
-
-    public const STATUS_ACTIVE = 1;
 
     protected static function booted(): void
     {

--- a/src/Models/EavAttribute.php
+++ b/src/Models/EavAttribute.php
@@ -4,14 +4,10 @@ namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\Cache;
+use Rapidez\Core\Enums\EntityType;
 
 class EavAttribute extends Model
 {
-    public const ENTITY_TYPE_CUSTOMER = 1;
-    public const ENTITY_TYPE_CUSTOMER_ADDRESS = 2;
-    public const ENTITY_TYPE_CATALOG_CATEGORY = 3;
-    public const ENTITY_TYPE_CATALOG_PRODUCT = 4;
-
     protected $table = 'eav_attribute';
 
     protected $primaryKey = 'attribute_id';
@@ -34,7 +30,7 @@ class EavAttribute extends Model
             return EavAttribute::query()
                 ->select('*')
                 ->leftJoin('catalog_eav_attribute', 'catalog_eav_attribute.attribute_id', '=', 'eav_attribute.attribute_id')
-                ->where('entity_type_id', self::ENTITY_TYPE_CATALOG_PRODUCT)
+                ->where('entity_type_id', EntityType::Product->value)
                 ->orderBy('position')
                 ->orderBy('eav_attribute.attribute_id')
                 ->get();
@@ -47,7 +43,7 @@ class EavAttribute extends Model
             return EavAttribute::query()
                 ->select('*')
                 ->leftJoin('customer_eav_attribute', 'customer_eav_attribute.attribute_id', '=', 'eav_attribute.attribute_id')
-                ->where('entity_type_id', self::ENTITY_TYPE_CUSTOMER)
+                ->where('entity_type_id', EntityType::Customer->value)
                 ->orderBy('sort_order')
                 ->orderBy('eav_attribute.attribute_id')
                 ->get();

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Rapidez\Core\Enums\EntityType;
+use Rapidez\Core\Enums\ReviewEntityType;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Scopes\Product\EnabledScope;
 use Rapidez\Core\Models\Scopes\Product\ForCurrentWebsiteScope;
@@ -28,17 +30,9 @@ class Product extends Model
     use HasSuperAttributes;
     use Searchable;
 
-    public const VISIBILITY_NOT_VISIBLE = 1;
-    public const VISIBILITY_IN_CATALOG = 2;
-    public const VISIBILITY_IN_SEARCH = 3;
-    public const VISIBILITY_BOTH = 4;
-
-    public const STATUS_ENABLED = 1;
-    public const STATUS_DISABLED = 2;
-
     protected $table = 'catalog_product_entity';
     protected $primaryKey = 'entity_id';
-    protected $entityTypeId = EavAttribute::ENTITY_TYPE_CATALOG_PRODUCT;
+    protected $entityTypeId = EntityType::Product->value;
 
     protected $with = [
         'stock',
@@ -189,7 +183,7 @@ class Product extends Model
             config('rapidez.models.review', Review::class), 'review',
             'entity_pk_value', 'review_id',
             'entity_id', 'review_id',
-        )->where('review.entity_id', Review::REVIEW_ENTITY_PRODUCT);
+        )->where('review.entity_id', ReviewEntityType::Product->value);
     }
 
     public function views(): HasMany

--- a/src/Models/Review.php
+++ b/src/Models/Review.php
@@ -4,10 +4,6 @@ namespace Rapidez\Core\Models;
 
 class Review extends Model
 {
-    public const REVIEW_ENTITY_PRODUCT = 1;
-    public const REVIEW_ENTITY_CUSTOMER = 2;
-    public const REVIEW_ENTITY_CATEGORY = 3;
-
     protected $table = 'review_detail';
 
     protected $primaryKey = 'detail_id';

--- a/src/Models/Scopes/Attribute/OnlyProductAttributesScope.php
+++ b/src/Models/Scopes/Attribute/OnlyProductAttributesScope.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\DB;
+use Rapidez\Core\Enums\EntityType;
 
 class OnlyProductAttributesScope implements Scope
 {
@@ -53,6 +54,6 @@ class OnlyProductAttributesScope implements Scope
                     ->where('table_name', $productTable)
                     ->where('table_schema', $databaseName);
             })
-            ->where($model->qualifyColumn('entity_type_id'), 4); // catalog_product
+            ->where($model->qualifyColumn('entity_type_id'), EntityType::Product->value);
     }
 }

--- a/src/Models/Scopes/Category/IsActiveScope.php
+++ b/src/Models/Scopes/Category/IsActiveScope.php
@@ -5,12 +5,12 @@ namespace Rapidez\Core\Models\Scopes\Category;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Rapidez\Core\Models\Category;
+use Rapidez\Core\Enums\CategoryStatus;
 
 class IsActiveScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereAttribute('is_active', Category::STATUS_ACTIVE);
+        $builder->whereAttribute('is_active', CategoryStatus::Active->value);
     }
 }

--- a/src/Models/Scopes/Product/EnabledScope.php
+++ b/src/Models/Scopes/Product/EnabledScope.php
@@ -5,12 +5,12 @@ namespace Rapidez\Core\Models\Scopes\Product;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
-use Rapidez\Core\Models\Product;
+use Rapidez\Core\Enums\ProductStatus;
 
 class EnabledScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        $builder->whereAttribute('status', Product::STATUS_ENABLED);
+        $builder->whereAttribute('status', ProductStatus::Enabled->value);
     }
 }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -6,11 +6,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Rapidez\Core\Enums\Visibility;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Category;
 use Rapidez\Core\Models\CategoryProduct;
 use Rapidez\Core\Models\EavAttribute;
-use Rapidez\Core\Models\Product;
 use Rapidez\Core\Models\SuperAttribute;
 use Rapidez\Core\Models\Traits\Searchable as ParentSearchable;
 use TorMorten\Eventy\Facades\Eventy;
@@ -27,9 +27,9 @@ trait Searchable
         return $query
             ->with(['reviewSummary', 'children'])
             ->whereInAttribute('visibility', [
-                Product::VISIBILITY_IN_CATALOG,
-                Product::VISIBILITY_IN_SEARCH,
-                Product::VISIBILITY_BOTH,
+                Visibility::Catalog->value,
+                Visibility::Search->value,
+                Visibility::Both->value,
             ])
             ->when(
                 ! Rapidez::config('cataloginventory/options/show_out_of_stock', 0),


### PR DESCRIPTION
ref: RAP-1900

This PR replaces a bunch of `const`s and a few hardcoded values with backed enums. This is a breaking change, as it removes a bunch of consts that may be used in projects using Rapidez. These are:

- `Category::STATUS_*` -> `CategoryStatus::*`
- `EavAttribute::ENTITY_TYPE_*` -> `EntityType::*`
- `Product::STATUS_*` -> `ProductStatus::*`
- `Product::VISIBILITY_*` -> `Visibility::*`
- `Review::REVIEW_ENTITY_*` -> `ReviewEntity::*`

It's very possible that I've missed some use cases. We can always update those when we come across them.