### PR TITLE
[4.x] Always trim category name

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -72,9 +72,7 @@ class Category extends Model
 
     protected function name(): Attribute
     {
-        return Attribute::get(function (?string $value) {
-            return trim($value ?? '');
-        });
+        return Attribute::get(fn (?string $value) => trim($value ?? ''));
     }
 
     public function subcategories()

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -23,7 +23,7 @@ class Category extends Model
         self::CREATED_AT => 'datetime',
     ];
 
-    protected $appends = ['url'];
+    protected $appends = ['url', 'name'];
 
     protected static function booting()
     {
@@ -68,6 +68,13 @@ class Category extends Model
         return Attribute::make(
             get: fn () => '/' . ($this->url_path ? $this->url_path : 'catalog/category/view/id/' . $this->entity_id)
         );
+    }
+
+    protected function name(): Attribute
+    {
+        return Attribute::get(function (?string $value) {
+            return trim($value ?? '');
+        });
     }
 
     public function subcategories()


### PR DESCRIPTION
#1267 but then for 4.x, as the 5.x patch stopped working after a few commits into the PR.