### PR TITLE
[5.x] Use loading.value

### DIFF
--- a/resources/views/cart/coupon/add.blade.php
+++ b/resources/views/cart/coupon/add.blade.php
@@ -12,7 +12,7 @@
             name="couponCode"
             placeholder="Coupon code"
             v-model="variables.coupon_code"
-            v-bind:disabled="loading"
+            v-bind:disabled="loading.value"
             required
         />
         <x-rapidez::button.outline type="submit" class="sm:text-sm" data-testid="apply-coupon">

--- a/resources/views/cart/item/remove.blade.php
+++ b/resources/views/cart/item/remove.blade.php
@@ -10,7 +10,7 @@
         v-on:click="mutate"
         title="@lang('Remove')"
         class="hover:underline text-red-700"
-        :disabled="$root.loading"
+        :disabled="loading.value"
         data-testid="cart-item-remove"
     >
         @lang('Remove')

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -37,7 +37,7 @@
             />
         </div>
 
-        <div v-if="!hasCart && !loading" v-cloak>@lang('You don\'t have anything in your cart.')</div>
-        <div v-if="loading">@lang('Loading')...</div>
+        <div v-if="!hasCart && !loading.value" v-cloak>@lang('You don\'t have anything in your cart.')</div>
+        <div v-if="loading.value">@lang('Loading')...</div>
     </div>
 @endsection

--- a/resources/views/cart/overview.blade.php
+++ b/resources/views/cart/overview.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         <h1 class="mb-5 text-4xl font-bold">@lang('Cart')</h1>
         <graphql
-            v-if="mask"
+            v-if="mask?.value"
             :query="'query getCart($cart_id: String!) { cart (cart_id: $cart_id) { ...cart } } ' + config.fragments.cart"
             :variables="{ cart_id: mask.value }"
             :callback="updateCart"

--- a/resources/views/components/button/tag.blade.php
+++ b/resources/views/components/button/tag.blade.php
@@ -7,9 +7,9 @@
 
 <x-rapidez::tag
     is="{{ $tag }}"
-    :v-bind:class="$loader ? '{ \'button-loading\': $root.loading }' : ''"
+    :v-bind:class="$loader ? '{ \'button-loading\': loading.value }' : ''"
     {{ $attributes->merge([
-        ':disabled' => $attributes->has('href') || $attributes->has(':href') || !$disableWhenLoading ? null : '$root.loading',
+        ':disabled' => $attributes->has('href') || $attributes->has(':href') || !$disableWhenLoading ? null : 'loading.value',
     ]) }}
 >
     {{ $slot }}

--- a/resources/views/components/input/input.blade.php
+++ b/resources/views/components/input/input.blade.php
@@ -1,1 +1,1 @@
-<x-rapidez::input v-bind:disabled="$root.loading" />
+<x-rapidez::input v-bind:disabled="loading.value" />

--- a/resources/views/layouts/partials/debug.blade.php
+++ b/resources/views/layouts/partials/debug.blade.php
@@ -1,7 +1,7 @@
 <div
     v-cloak
-    v-if="$root.configError"
-    class="w-full bg-danger text-center text-white font-bold"
+    v-if="$root.configError.value"
+    class="w-full bg-red-500 text-center text-white font-bold"
 >
     Config.js failed to load due to an error.
 </div>

--- a/tests/playwright/cart.spec.js-snapshots/add-product-simple-1-webkit-linux.png
+++ b/tests/playwright/cart.spec.js-snapshots/add-product-simple-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eaed5e0ee8e503f6d7f044e4f93c1dd41ca89730923c95db63a5b2a99184a05f
-size 176274
+oid sha256:d6eb3fdca3e386bfe44d43d50f04c34675c563aaadbf03e35c2d561d680025d1
+size 176298

--- a/tests/playwright/general.spec.js-snapshots/cookie-1-Mobile-Safari-linux.png
+++ b/tests/playwright/general.spec.js-snapshots/cookie-1-Mobile-Safari-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77c6740d1d2a4f869c70035432e820aefa4c4b2963e0a1235da9f83aef4df7e8
-size 177647
+oid sha256:cd49ed8951bba62b07e243f42e88a7f3fab51e1a54f4410c388eef1fa66a55c1
+size 177357

--- a/tests/playwright/general.spec.js-snapshots/cookie-1-webkit-linux.png
+++ b/tests/playwright/general.spec.js-snapshots/cookie-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eefa18828c9e1589d3b65a08b1ab1abbda75d179d252dff038691b4548e0edc9
-size 470321
+oid sha256:1e3e711d2ab998de4c7c409976e93e4a6825566a5738079468e5c081264cfa94
+size 470032

--- a/tests/playwright/product.spec.js-snapshots/product-grouped-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-grouped-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4231e184bda5b55ca9ed9f774098e71b544f796742264f0ba6cc05c76077d99
-size 239338
+oid sha256:dff6fdca9b3eed42e5611a8fdaa9e5c624934ea2471e12dd08fab2164f6b3daa
+size 239140

--- a/tests/playwright/product.spec.js-snapshots/product-grouped-1-Mobile-Safari-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-grouped-1-Mobile-Safari-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3cde1b1ce7331b79436f2967be77905a6a230f445a7dabb120907d26c7e8a801
-size 260522
+oid sha256:e97feb9f1868e1604fcb633b1f36facd959534a9cb8077b788f56942c5c3b440
+size 260442

--- a/tests/playwright/product.spec.js-snapshots/product-grouped-1-chromium-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-grouped-1-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f5110f50a83b6a698540f86ffa5a26bd45dc33e27551137b48165ea3cdb96ec
-size 303049
+oid sha256:6996a64298b456a6ced19fe8526e768c1821264a9647d8faaaf43a81789e06c8
+size 302990

--- a/tests/playwright/product.spec.js-snapshots/product-grouped-1-firefox-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-grouped-1-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:949f78b2eb854510240d99d6b896447ce58997d253a7760d04054aa4307e64d0
-size 401219
+oid sha256:b90abbc4eb1768f7605d9d7f342ecee3dc53ae7f81d4b6df8ae03997c2c8f08a
+size 401121

--- a/tests/playwright/product.spec.js-snapshots/product-grouped-1-webkit-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-grouped-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcd5ed8925a365985d41897f1dc426eb43eeb9282f3aff3fb767dcf0cb1174fa
-size 343823
+oid sha256:626d8bca19011f8cd1e133a2a1266ac324607ce799c78e5985e7f8ef511b72c1
+size 343711


### PR DESCRIPTION
ref: RAP-1912

Note that it turns out `loading.value` is also needed for the v-ifs. See, for example, the test.rapidez cart page when you have an empty cart.