### PR TITLE
[5.x] Fix button without loader

### DIFF
--- a/resources/views/components/button/tag.blade.php
+++ b/resources/views/components/button/tag.blade.php
@@ -7,7 +7,7 @@
 
 <x-rapidez::tag
     is="{{ $tag }}"
-    :v-bind:class="$loader ? '{ \'button-loading\': $root.loading }' : ''"
+    :v-bind:class="$loader ? '{ \'button-loading\': $root.loading }' : null"
     {{ $attributes->merge([
         ':disabled' => $attributes->has('href') || $attributes->has(':href') || !$disableWhenLoading ? null : '$root.loading',
     ]) }}


### PR DESCRIPTION
ref: AN-423

This broke because an empty v-bind:class is not allowed. Setting it to null instead fixes that.