### PR TITLE
[5.x] Limit search query count when there are a lot of them

### DIFF
--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -3,6 +3,8 @@
 namespace Rapidez\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Rapidez\Core\Models\Scopes\IsActiveScope;
 use Rapidez\Core\Models\Traits\Searchable;
 
@@ -24,9 +26,22 @@ class SearchQuery extends Model
 
     protected function makeAllSearchableUsing(Builder $query)
     {
+        // Decide on a minimum popularity to make sure we don't index too much.
+        // Simply using an orderBy with a limit on the query doesn't work as the limit gets stripped off.
+        $minPopularity = Cache::driver('array')->rememberForever(
+            'minPopularity',
+            fn() => DB::table('search_query')
+                ->orderByDesc('popularity')
+                ->limit(1)
+                ->offset(10000)
+                ->first()
+                ->popularity ?? 0
+        );
+
         return $query
-            ->where(fn ($subQuery) => $subQuery
-                ->where('num_results', '>', 0)
+            ->where(
+                fn($subQuery) => $subQuery
+                ->where(fn($subSubQuery) => $subSubQuery->where('num_results', '>', 0)->where('popularity', '>', $minPopularity))
                 ->orWhereNotNull('redirect')
             );
     }

--- a/src/Models/SearchQuery.php
+++ b/src/Models/SearchQuery.php
@@ -30,7 +30,7 @@ class SearchQuery extends Model
         // Simply using an orderBy with a limit on the query doesn't work as the limit gets stripped off.
         $minPopularity = Cache::driver('array')->rememberForever(
             'minPopularity',
-            fn() => DB::table('search_query')
+            fn () => DB::table('search_query')
                 ->orderByDesc('popularity')
                 ->limit(1)
                 ->offset(10000)
@@ -40,9 +40,9 @@ class SearchQuery extends Model
 
         return $query
             ->where(
-                fn($subQuery) => $subQuery
-                ->where(fn($subSubQuery) => $subSubQuery->where('num_results', '>', 0)->where('popularity', '>', $minPopularity))
-                ->orWhereNotNull('redirect')
+                fn ($subQuery) => $subQuery
+                    ->where(fn ($subSubQuery) => $subSubQuery->where('num_results', '>', 0)->where('popularity', '>', $minPopularity))
+                    ->orWhereNotNull('redirect')
             );
     }
 }


### PR DESCRIPTION
ref: AN-425

We ran into an issue on a site that had 300k+ search queries in the search_query table. While this table should probably be cleaned up, this also presented an issue where the indexer would break due to too many items being indexed, causing the indexing to take too long (and wasting resources).

Originally, I had wanted to do this with a simple `orderByDesc('popularity')->limit(10000)` directly on the query itself. However, that didn't work as scout will modify the query stripping off the limit in the process.

Instead, this PR sets a minimum popularity value based on what the 10000th highest popularity value is.