### PR TITLE
[5.x] Add useNotifications store for notifications

### DIFF
--- a/resources/js/components/Notifications/Notifications.vue
+++ b/resources/js/components/Notifications/Notifications.vue
@@ -34,7 +34,7 @@ export default {
             })
 
             clearNotifications()
-        }
+        },
     },
 }
 </script>

--- a/resources/js/components/Notifications/Notifications.vue
+++ b/resources/js/components/Notifications/Notifications.vue
@@ -1,4 +1,7 @@
 <script>
+import { pendingNotifications, clearNotifications, notificationCount } from '../../stores/useNotifications.js'
+import { watch } from 'vue'
+
 import notification from './Notification.vue'
 document.addEventListener('vue:loaded', function (event) {
     event.detail.vue.component('notification', notification)
@@ -14,15 +17,24 @@ export default {
         return this.$slots.default(this)
     },
     mounted() {
-        window.$on('notification-message', (message, type, params, link) => {
-            this.notifications.push({
-                message: message,
-                type: type,
-                params: params,
-                link: link,
-                show: true,
+        this.triggerNotifications()
+        watch(notificationCount, this.triggerNotifications)
+    },
+    methods: {
+        triggerNotifications() {
+            if (notificationCount.value == 0) {
+                return
+            }
+
+            pendingNotifications.value.forEach((notification) => {
+                this.notifications.push({
+                    show: true,
+                    ...notification,
+                })
             })
-        })
+
+            clearNotifications()
+        }
     },
 }
 </script>

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,6 +1,15 @@
+import { pushNotification } from './stores/useNotifications'
+
 window.debug = import.meta.env.VITE_DEBUG == 'true'
-window.Notify = (message, type = 'info', params = [], link = null) =>
-    setTimeout(() => window.$emit('notification-message', message, type, params, link), window.app ? 0 : 500)
+window.Notify = (message, type = 'info', params = [], link = null) => {
+    pushNotification({
+        message: message,
+        type: type,
+        params: params,
+        link: link,
+        timestamp: +new Date(),
+    })
+}
 
 if (!window.process) {
     // Workaround for process missing, if data is actually needed from here you should apply the following polyfill.
@@ -10,7 +19,7 @@ if (!window.process) {
 
 import './polyfills'
 import { useLocalStorage, StorageSerializers, useScrollLock } from '@vueuse/core'
-import useOrder from './stores/useOrder.js'
+import useOrder from './stores/useOrder'
 import { cart } from './stores/useCart'
 import { user } from './stores/useUser'
 import useMask from './stores/useMask'
@@ -22,7 +31,7 @@ import './cookies'
 import './callbacks'
 import './vue-components'
 import './instantsearch'
-import { fetchCount } from './stores/useFetches.js'
+import { fetchCount } from './stores/useFetches'
 import { computed, createApp, ref, watch } from 'vue'
 ;(() => import('./turbolinks'))()
 

--- a/resources/js/stores/useNotifications.js
+++ b/resources/js/stores/useNotifications.js
@@ -1,0 +1,23 @@
+export let pendingNotifications = []
+
+export function pushNotification(notification) {
+    let hasPreviousNotifications = pendingNotifications.length > 0
+    pendingNotifications.push(notification)
+
+    // Immediately trigger notifications if possible
+    if (window.app && window.$emit) {
+        triggerNotifications()
+    }
+}
+
+export function triggerNotifications() {
+    // Use a temp variable and insta-clear to avoid race conditions as much as possible
+    let notifications = pendingNotifications
+    pendingNotifications = []
+
+    notifications.forEach(notification => {
+        window.$emit('notification-message', notification.message ?? '', notification.type ?? 'info', notification.params ?? [], notification.link ?? null)
+    })
+}
+
+window.document.addEventListener('vue:loaded', triggerNotifications)

--- a/resources/js/stores/useNotifications.js
+++ b/resources/js/stores/useNotifications.js
@@ -15,8 +15,14 @@ export function triggerNotifications() {
     let notifications = pendingNotifications
     pendingNotifications = []
 
-    notifications.forEach(notification => {
-        window.$emit('notification-message', notification.message ?? '', notification.type ?? 'info', notification.params ?? [], notification.link ?? null)
+    notifications.forEach((notification) => {
+        window.$emit(
+            'notification-message',
+            notification.message ?? '',
+            notification.type ?? 'info',
+            notification.params ?? [],
+            notification.link ?? null,
+        )
     })
 }
 

--- a/resources/js/stores/useNotifications.js
+++ b/resources/js/stores/useNotifications.js
@@ -1,29 +1,15 @@
-export let pendingNotifications = []
+import { ref, computed } from 'vue'
+
+export let pendingNotifications = ref([])
+
+export const notificationCount = computed(() => {
+    return pendingNotifications.value.length
+})
 
 export function pushNotification(notification) {
-    let hasPreviousNotifications = pendingNotifications.length > 0
-    pendingNotifications.push(notification)
-
-    // Immediately trigger notifications if possible
-    if (window.app && window.$emit) {
-        triggerNotifications()
-    }
+    pendingNotifications.value.push(notification)
 }
 
-export function triggerNotifications() {
-    // Use a temp variable and insta-clear to avoid race conditions as much as possible
-    let notifications = pendingNotifications
-    pendingNotifications = []
-
-    notifications.forEach((notification) => {
-        window.$emit(
-            'notification-message',
-            notification.message ?? '',
-            notification.type ?? 'info',
-            notification.params ?? [],
-            notification.link ?? null,
-        )
-    })
+export function clearNotifications() {
+    pendingNotifications.value = []
 }
-
-window.document.addEventListener('vue:loaded', triggerNotifications)

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,11 +46,9 @@
 
     @if (session('notifications'))
         <script async>
-            document.addEventListener('vue:loaded', function() {
-                @foreach (session('notifications') ?? [] as $notification)
-                    window.Notify('{{ $notification['message'] }}', '{{ $notification['type'] ?? 'success' }}')
-                @endforeach
-            });
+            @foreach (session('notifications') ?? [] as $notification)
+                window.Notify('{{ $notification['message'] }}', '{{ $notification['type'] ?? 'success' }}')
+            @endforeach
         </script>
     @endif
     @stack('foot')


### PR DESCRIPTION
ref: RAP-1708, BORDEX-1395

This store allows for notifications to be pushed regardless of Vue being loaded in or not. If Vue is not loaded, these will then get triggered upon vue being loaded in.