### PR TITLE
[5.x] Fix v-else

### DIFF
--- a/resources/views/components/input/password/password.blade.php
+++ b/resources/views/components/input/password/password.blade.php
@@ -9,7 +9,7 @@
             @if (!$attributes['disabled'] ?? false)
                 <div v-on:click="() => toggle()" class="absolute right-5 top-1/2 -translate-y-1/2 cursor-pointer">
                     <x-heroicon-o-eye-slash v-if="isOpen" class="h-5"/>
-                    <x-heroicon-o-eye v-else class="h-5" v-cloak/>
+                    <x-heroicon-o-eye v-else="" class="h-5" v-cloak/>
                 </div>
             @endif
         </div>

--- a/resources/views/components/input/password/password.blade.php
+++ b/resources/views/components/input/password/password.blade.php
@@ -9,7 +9,7 @@
             @if (!$attributes['disabled'] ?? false)
                 <div v-on:click="() => toggle()" class="absolute right-5 top-1/2 -translate-y-1/2 cursor-pointer">
                     <x-heroicon-o-eye-slash v-if="isOpen" class="h-5"/>
-                    <x-heroicon-o-eye v-else="" class="h-5" v-cloak/>
+                    <x-heroicon-o-eye v-else="" class="h-5" v-cloak=""/>
                 </div>
             @endif
         </div>


### PR DESCRIPTION
Without this, the generated html contains `v-else="v-else"` which then tries to parse `v-else` as if it were javascript code. This gives warnings/errors.