### PR TITLE
[5.x] Prioritize core for rapidez namespace

### DIFF
--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -179,8 +179,6 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function bootViews(): self
     {
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'rapidez');
-
         // Make sure that we always prioritize any views from this package over others with the same namespace
         // For example: blade-components uses the same namespace
         View::prependNamespace('rapidez', [

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -181,6 +181,13 @@ class RapidezServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'rapidez');
 
+        // Make sure that we always prioritize any views from this package over others with the same namespace
+        // For example: blade-components uses the same namespace
+        View::prependNamespace('rapidez', [
+            resource_path('views/vendor/rapidez'),
+            __DIR__ . '/../resources/views',
+        ]);
+
         View::addExtension('graphql', 'blade');
 
         Vite::useScriptTagAttributes(fn (string $src, string $url, ?array $chunk, ?array $manifest) => [


### PR DESCRIPTION
ref: RAP-1916

This PR makes sure that when using a component under the Rapidez namespace, the component from the core always gets prioritized over other packages. Note that I added an extra hint path to make sure any custom overwrites within the project do still come first.

We ran into this issue specifically because of the `blade-components` package having a `button/tag` component that differed too much from the core's `button/tag` component. I'm not sure why we decided this should be the case.

It may be useful to use this same trick for the `core-overwrites` in checkout-theme.