### PR TITLE
[5.x] Support multiple categories in indexer

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -339,6 +339,20 @@ class Product extends Model
         });
     }
 
+    protected function allCategories(): Attribute
+    {
+        return Attribute::get(function (): Collection {
+            $this->loadMissing('categoryProducts');
+
+            $categories = $this->categoryProducts
+                ->where('category_id', '!=', config('rapidez.root_category_id'))
+                ->pluck('category')
+                ->whereNotNull();
+
+            return $categories->map(fn($category) => $category->parentcategories ?? collect());
+        });
+    }
+
     protected function breadcrumbCategories(): Attribute
     {
         return Attribute::get(function (): Collection {

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -349,7 +349,7 @@ class Product extends Model
                 ->pluck('category')
                 ->whereNotNull();
 
-            return $categories->map(fn($category) => $category->parentcategories ?? collect());
+            return $categories->map(fn ($category) => $category->parentcategories ?? collect());
         });
     }
 

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -136,7 +136,7 @@ trait Searchable
             return Category::all()->keyBy('entity_id');
         });
 
-        foreach ($this->breadcrumbCategories as $category) {
+        foreach ($this->allCategories->flatten() as $category) {
             if (! $category) {
                 continue;
             }


### PR DESCRIPTION
This was written wrong, using `breadcrumbCategories` which only uses the longest path. I've added an attribute that can be used to get the same data in a collection from not just the longest path. Flattening this gives us the same data in the indexer, but then for all categories.