### PR TITLE
Fixed recursion caused by view hint reordering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "laravel/scout": "^10.14",
         "lcobucci/clock": "^2.0|^3.2",
         "lcobucci/jwt": "^4.2|^5.3",
-        "rapidez/blade-components": "^2.0",
+        "rapidez/blade-components": "^2.0 >=2.2.2",
         "rapidez/blade-directives": "^1.1",
         "rapidez/laravel-multi-cache": "^2.1",
         "rapidez/laravel-scout-elasticsearch": "^1.0",

--- a/resources/views/components/input/input.blade.php
+++ b/resources/views/components/input/input.blade.php
@@ -1,1 +1,1 @@
-<x-rapidez::input v-bind:disabled="loading.value" />
+<x-blade-components::input v-bind:disabled="loading.value" />

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -195,8 +195,6 @@ class RapidezServiceProvider extends ServiceProvider
 
     protected function bootViews(): self
     {
-        // Make sure that we always prioritize any views from this package over others with the same namespace
-        // For example: blade-components uses the same namespace
         $this->prependViewsFrom(__DIR__ . '/../resources/views', 'rapidez');
 
         View::addExtension('graphql', 'blade');

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -185,7 +185,7 @@ class RapidezServiceProvider extends ServiceProvider
             if (isset($this->app->config['view']['paths']) &&
                 is_array($this->app->config['view']['paths'])) {
                 foreach (array_reverse($this->app->config['view']['paths']) as $viewPath) {
-                    if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
+                    if (is_dir($appPath = $viewPath . '/vendor/' . $namespace)) {
                         $view->prependNamespace($namespace, $appPath);
                     }
                 }

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -177,14 +177,27 @@ class RapidezServiceProvider extends ServiceProvider
         return $this;
     }
 
+    protected function prependViewsFrom($path, $namespace)
+    {
+        $this->callAfterResolving('view', function ($view) use ($path, $namespace) {
+            $view->prependNamespace($namespace, $path);
+
+            if (isset($this->app->config['view']['paths']) &&
+                is_array($this->app->config['view']['paths'])) {
+                foreach (array_reverse($this->app->config['view']['paths']) as $viewPath) {
+                    if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
+                        $view->prependNamespace($namespace, $appPath);
+                    }
+                }
+            }
+        });
+    }
+
     protected function bootViews(): self
     {
         // Make sure that we always prioritize any views from this package over others with the same namespace
         // For example: blade-components uses the same namespace
-        View::prependNamespace('rapidez', [
-            resource_path('views/vendor/rapidez'),
-            __DIR__ . '/../resources/views',
-        ]);
+        $this->prependViewsFrom(__DIR__ . '/../resources/views', 'rapidez');
 
         View::addExtension('graphql', 'blade');
 


### PR DESCRIPTION
Requires: https://github.com/rapidez/blade-components/pull/44

https://github.com/rapidez/core/pull/1318 caused infinite recursion for https://github.com/rapidez/core/blob/61cbb206fd0ddec4054a2184ffb276cddaf953c6/resources/views/components/input/input.blade.php

Causing https://test.rapidez.io/ to break, actions to break since the input component tried to load itself due to the reordering of namespace hints.
The change in blade components allows us to explicitly request a blade-components component to escape infinite recursion.

Also updated the namespace registration to respect all view paths including themes.