### PR TITLE
[5.x] Move cachekey to Rapidez facade

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,7 @@
     <meta name="robots" content="@yield('robots', Rapidez::config('design/search_engine_robots/default_robots'))"/>
     <link rel="canonical" href="@yield('canonical', url()->current())" />
 
-    @php($configPath = route('config') . '?v=' . Cache::rememberForever('cachekey', fn () => md5(Str::random())) . '&s=' . config('rapidez.store'))
+    @php($configPath = route('config') . '?v=' . Rapidez::getCacheKey() . '&s=' . config('rapidez.store'))
     <link href="{{ $configPath }}" rel="preload" as="script">
     <script defer src="{{ $configPath }}" onerror="window.app?.config ? window.$emit('configError') : window.configError = true"></script>
 

--- a/src/Facades/Rapidez.php
+++ b/src/Facades/Rapidez.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static ?string config(string $path, $default = null, bool $sensitive = false)
  * @method static ?string content($content)
  * @method static object fancyMagentoSyntaxDecoder(string $encodedString)
+ * @method static string getCacheKey()
  * @method static array getStores($storeId = null)
  * @method static array getStore($storeId)
  * @method static void setStore($store)

--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -4,7 +4,6 @@ namespace Rapidez\Core\Http\Controllers;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Str;
 use Rapidez\Core\Facades\Rapidez;
 use Rapidez\Core\Models\Attribute;
 use Rapidez\Core\Models\Category;
@@ -44,7 +43,7 @@ class ConfigController
     public function getConfig(): array
     {
         return [
-            'cachekey'     => Cache::rememberForever('cachekey', fn () => md5(Str::random())),
+            'cachekey'     => Rapidez::getCacheKey(),
             'translations' => __('rapidez::frontend'),
 
             'index'                        => $this->getIndexNames(),

--- a/src/Rapidez.php
+++ b/src/Rapidez.php
@@ -7,9 +7,11 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Rapidez\Core\Exceptions\StoreNotFoundException;
 use Rapidez\Core\Models\Config;
 use Rapidez\Core\Models\ConfigScopes;
@@ -84,6 +86,11 @@ class Rapidez
         ];
 
         return json_decode(str_replace(array_values($mapping), array_keys($mapping), $encodedString));
+    }
+
+    public function getCacheKey(): string
+    {
+        return Cache::rememberForever('cachekey', fn () => md5(Str::random()));
     }
 
     public function getStores(callable|array|int|string|null $store = null): array


### PR DESCRIPTION
ref: RAP-1944

This simple change allows for the usage of the cache key outside of the config. For example, this can be useful for turbo frames that need to change when the cache gets cleared.