### PR TITLE
Perform current slide calculation based on child elements

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -151,10 +151,7 @@ export default {
             this.navigate(next)
         },
         navigate(index, behavior = 'smooth') {
-            index = Math.min(
-                Math.max(index, 0),
-                this.container?.children.length - 1
-            )
+            index = Math.min(Math.max(index, 0), this.container?.children.length - 1)
 
             this.vertical
                 ? this.slider.scrollTo({ top: this.container?.children[index]?.offsetTop, behavior: behavior })

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -232,7 +232,8 @@ export default {
             }
 
             return Math.round(
-                (this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth)) * this.container.children.length,
+                (this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth)) *
+                    this.container.children.length,
             )
         },
         slidesTotal() {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -151,13 +151,7 @@ export default {
             this.navigate(next)
         },
         navigate(index, behavior = 'smooth') {
-            index = Math.min(
-                Math.max(
-                    this.loop ? index + this.slides.length : index,
-                    0
-                ),
-                this.container?.children.length - 1
-            )
+            index = Math.min(Math.max(this.loop ? index + this.slides.length : index, 0), this.container?.children.length - 1)
 
             this.vertical
                 ? this.slider.scrollTo({ top: this.container?.children[index]?.offsetTop, behavior: behavior })
@@ -213,25 +207,21 @@ export default {
             const getSlideByGuess = (slide) => {
                 const bestGuessChild = this.container.children[slide]
                 if (!bestGuessChild) {
-                    return slide;
+                    return slide
                 }
-                const bestGuessSpan = this.vertical
-                        ? bestGuessChild.offsetHeight
-                        : bestGuessChild.offsetWidth
-                const bestGuessOffset = this.vertical
-                        ? bestGuessChild.offsetTop
-                        : bestGuessChild.offsetLeft
+                const bestGuessSpan = this.vertical ? bestGuessChild.offsetHeight : bestGuessChild.offsetWidth
+                const bestGuessOffset = this.vertical ? bestGuessChild.offsetTop : bestGuessChild.offsetLeft
 
                 // Past halfway to the slide it will snap
-                if (this.position + (bestGuessSpan / 2) < bestGuessOffset) {
-                    return getSlideByGuess(slide - 1);
+                if (this.position + bestGuessSpan / 2 < bestGuessOffset) {
+                    return getSlideByGuess(slide - 1)
                 }
 
                 if (this.position >= bestGuessOffset + bestGuessSpan) {
-                    return getSlideByGuess(slide + 1);
+                    return getSlideByGuess(slide + 1)
                 }
 
-                return slide;
+                return slide
             }
 
             return getSlideByGuess(bestGuess)
@@ -241,7 +231,9 @@ export default {
                 return 0
             }
 
-            return Math.round(this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth) * this.slides.length)
+            return Math.round(
+                (this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth)) * this.slides.length,
+            )
         },
         slidesTotal() {
             if (!this.mounted) {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -151,7 +151,13 @@ export default {
             this.navigate(next)
         },
         navigate(index, behavior = 'smooth') {
-            index = this.loop ? index + this.slides.length : index
+            index = Math.min(
+                Math.max(
+                    this.loop ? index + this.slides.length : index,
+                    0
+                ),
+                this.container?.children.length - 1
+            )
 
             this.vertical
                 ? this.slider.scrollTo({ top: this.container?.children[index]?.offsetTop, behavior: behavior })
@@ -202,14 +208,40 @@ export default {
             if (!this.mounted) {
                 return 0
             }
-            return Math.round(this.position / this.childSpan) % this.slides.length
+            // First make a calculated guess, improving performance by not having to loop through all slides
+            const bestGuess = Math.round(this.position / this.childSpan) % this.slides.length
+            const getSlideByGuess = (slide) => {
+                const bestGuessChild = this.container.children[slide]
+                if (!bestGuessChild) {
+                    return slide;
+                }
+                const bestGuessSpan = this.vertical
+                        ? bestGuessChild.offsetHeight
+                        : bestGuessChild.offsetWidth
+                const bestGuessOffset = this.vertical
+                        ? bestGuessChild.offsetTop
+                        : bestGuessChild.offsetLeft
+
+                // Past halfway to the slide it will snap
+                if (this.position + (bestGuessSpan / 2) < bestGuessOffset) {
+                    return getSlideByGuess(slide - 1);
+                }
+
+                if (this.position >= bestGuessOffset + bestGuessSpan) {
+                    return getSlideByGuess(slide + 1);
+                }
+
+                return slide;
+            }
+
+            return getSlideByGuess(bestGuess)
         },
         slidesVisible() {
             if (!this.mounted) {
                 return 0
             }
 
-            return Math.round(this.sliderSpan / this.childSpan)
+            return Math.round(this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth) * this.slides.length)
         },
         slidesTotal() {
             if (!this.mounted) {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -64,11 +64,11 @@ export default {
         }
         this.$nextTick(() => {
             useResizeObserver(this.slider, useThrottleFn(this.updateSpan, 150, true, true))
+            setTimeout(() => this.slider.dispatchEvent(new CustomEvent('scroll')))
+            this.mounted = true
             if (this.loop) {
                 this.initLoop()
             }
-            setTimeout(() => this.slider.dispatchEvent(new CustomEvent('scroll')))
-            this.mounted = true
 
             this.initAutoPlay()
         })
@@ -152,10 +152,7 @@ export default {
         },
         navigate(index, behavior = 'smooth') {
             index = Math.min(
-                Math.max(
-                    this.loop ? index + this.slides.length : index,
-                    0
-                ),
+                Math.max(index, 0),
                 this.container?.children.length - 1
             )
 

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -232,7 +232,7 @@ export default {
             }
 
             return Math.round(
-                (this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth)) * this.slides.length,
+                (this.sliderSpan / (this.vertical ? this.container.scrollHeight : this.container.scrollWidth)) * this.container.children.length,
             )
         },
         slidesTotal() {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -191,9 +191,7 @@ export default {
                 }
             }
 
-            const position = this.vertical
-                ? this.container?.children[index]?.offsetTop
-                : this.container?.children[index]?.offsetLeft
+            const position = this.vertical ? this.container?.children[index]?.offsetTop : this.container?.children[index]?.offsetLeft
 
             if (position === undefined) {
                 return
@@ -250,11 +248,11 @@ export default {
     },
     computed: {
         position: {
-            get () {
+            get() {
                 return this.vertical ? this.scrollY : this.scrollX
             },
-            set (position) {
-                return this.vertical ? this.scrollY = position : this.scrollX = position
+            set(position) {
+                return this.vertical ? (this.scrollY = position) : (this.scrollX = position)
             },
         },
         showLeft() {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -203,7 +203,7 @@ export default {
                 return 0
             }
             // First make a calculated guess, improving performance by not having to loop through all slides
-            const bestGuess = Math.round(this.position / this.childSpan) % this.slides.length
+            const bestGuess = Math.round(this.position / ((this.vertical ? this.container.scrollHeight : this.container.scrollWidth) / this.container.children.length))
             const getSlideByGuess = (slide) => {
                 const bestGuessChild = this.container.children[slide]
                 if (!bestGuessChild) {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -307,6 +307,9 @@ export default {
                 return 0
             }
 
+            // TODO: slidesVisible is now calculated by an average so the number does not change and cause issues.
+            // For the slidesTotal only the visible slides at the end of the slider are relevant.
+            // We should replace `this.slidesVisible` with a function that only gets the visible slides at the end.
             return (this.slides?.length ?? 1) - (this.loop ? 0 : this.slidesVisible - 1)
         },
         slides() {

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -1,5 +1,5 @@
 <script>
-import { useElementHover, useIntervalFn, useEventListener, useThrottleFn, useResizeObserver } from '@vueuse/core'
+import { useElementHover, useIntervalFn, useScroll, useThrottleFn, useResizeObserver } from '@vueuse/core'
 
 export default {
     render() {
@@ -43,9 +43,17 @@ export default {
         return {
             slider: '',
             container: '',
-            position: 0,
-            showLeft: false,
-            showRight: false,
+            scrollX: 0,
+            scrollY: 0,
+            isScrolling: false,
+            arrivedState: {
+                left: false,
+                right: false,
+                top: false,
+                bottom: false,
+            },
+            scrollBehavior: 'smooth',
+            resetMeasure: () => {},
             mounted: false,
             hover: false,
             direction: 1,
@@ -58,13 +66,9 @@ export default {
     },
     mounted() {
         this.initSlider()
-        useEventListener(this.slider, 'scroll', useThrottleFn(this.scroll, 150, true, true), { passive: true })
-        if (this.loop) {
-            useEventListener(this.slider, 'scrollend', this.scrollend, { passive: true })
-        }
+        this.initScrollState()
         this.$nextTick(() => {
             useResizeObserver(this.slider, useThrottleFn(this.updateSpan, 150, true, true))
-            setTimeout(() => this.slider.dispatchEvent(new CustomEvent('scroll')))
             this.mounted = true
             if (this.loop) {
                 this.initLoop()
@@ -82,6 +86,32 @@ export default {
                 this.slider = this.slider[0]
             }
             this.container = this.containerReference ? this.$slots.default(this)[0].ctx.refs[this.containerReference] : this.slider
+        },
+        initScrollState() {
+            const { x, y, isScrolling, arrivedState, measure } = useScroll(this.slider, {
+                throttle: 150,
+                idle: 100,
+                eventListenerOptions: { passive: true },
+                behavior: this.scrollBehavior,
+            })
+
+            this.scrollX = x
+            this.scrollY = y
+            this.isScrolling = isScrolling
+            this.arrivedState = arrivedState
+            this.resetMeasure = measure
+        },
+        scrollToPosition(position, behavior = 'smooth') {
+            if (behavior === 'instant') {
+                this.vertical
+                    ? this.slider.scrollTo({ top: position, behavior: 'instant' })
+                    : this.slider.scrollTo({ left: position, behavior: 'instant' })
+                this.resetMeasure()
+                return
+            }
+
+            this.scrollBehavior = behavior
+            this.position = position
         },
         initLoop() {
             if (!this.loop) {
@@ -104,8 +134,7 @@ export default {
                     endClone.dataset.clone = true
                     endClone.dataset.position = 'end'
                 }
-
-                this.slider.dispatchEvent(new CustomEvent('scrollend'))
+                this.handleLoopBoundary()
             })
         },
         initAutoPlay() {
@@ -122,17 +151,18 @@ export default {
             }
             this.hover = useElementHover(this.$el.nextSibling)
         },
-        scroll(event) {
-            this.position = this.vertical ? event.target.scrollTop : event.target.scrollLeft
-            this.showLeft = this.loop || this.position
-            this.showRight = this.loop || this.container?.offsetWidth + this.position < this.container?.scrollWidth - 1
-        },
-        scrollend(event) {
-            let scrollPosition = this.vertical ? event.target.scrollTop : event.target.scrollLeft
+        handleLoopBoundary() {
+            if (!this.loop) {
+                return
+            }
+
+            let scrollPosition = this.position
             if (scrollPosition < this.sliderStart) {
-                this.slider.scrollTo({ [this.vertical ? 'top' : 'left']: scrollPosition + this.sliderStart, behavior: 'instant' })
+                const position = scrollPosition + this.sliderStart
+                this.scrollToPosition(position, 'instant')
             } else if (scrollPosition >= this.sliderEnd) {
-                this.slider.scrollTo({ [this.vertical ? 'top' : 'left']: scrollPosition - this.sliderStart, behavior: 'instant' })
+                const position = scrollPosition - this.sliderStart
+                this.scrollToPosition(position, 'instant')
             }
         },
         autoScroll() {
@@ -151,11 +181,25 @@ export default {
             this.navigate(next)
         },
         navigate(index, behavior = 'smooth') {
+            this.handleLoopBoundary()
             index = Math.min(Math.max(index, 0), this.container?.children.length - 1)
+            if (this.loop) {
+                if (index < this.slides.length - 1) {
+                    index += this.slides.length
+                } else if (index > this.slides.length * 2 + 1) {
+                    index -= this.slides.length
+                }
+            }
 
-            this.vertical
-                ? this.slider.scrollTo({ top: this.container?.children[index]?.offsetTop, behavior: behavior })
-                : this.slider.scrollTo({ left: this.container?.children[index]?.offsetLeft, behavior: behavior })
+            const position = this.vertical
+                ? this.container?.children[index]?.offsetTop
+                : this.container?.children[index]?.offsetLeft
+
+            if (position === undefined) {
+                return
+            }
+
+            requestAnimationFrame(() => this.scrollToPosition(position, behavior))
         },
         handleLoop() {
             requestAnimationFrame(() => {
@@ -193,11 +237,32 @@ export default {
                 this.pause()
             }
         },
+        isScrolling(isScrolling) {
+            if (isScrolling) {
+                return
+            }
+
+            this.handleLoopBoundary()
+        },
         currentSlide() {
             this.initSlider()
         },
     },
     computed: {
+        position: {
+            get () {
+                return this.vertical ? this.scrollY : this.scrollX
+            },
+            set (position) {
+                return this.vertical ? this.scrollY = position : this.scrollX = position
+            },
+        },
+        showLeft() {
+            return !(this.vertical ? this.arrivedState.top : this.arrivedState.left)
+        },
+        showRight() {
+            return !(this.vertical ? this.arrivedState.bottom : this.arrivedState.right)
+        },
         currentSlide() {
             if (!this.mounted) {
                 return 0

--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -203,7 +203,10 @@ export default {
                 return 0
             }
             // First make a calculated guess, improving performance by not having to loop through all slides
-            const bestGuess = Math.round(this.position / ((this.vertical ? this.container.scrollHeight : this.container.scrollWidth) / this.container.children.length))
+            const bestGuess = Math.round(
+                this.position /
+                    ((this.vertical ? this.container.scrollHeight : this.container.scrollWidth) / this.container.children.length),
+            )
             const getSlideByGuess = (slide) => {
                 const bestGuessChild = this.container.children[slide]
                 if (!bestGuessChild) {


### PR DESCRIPTION
This PR does the following to fix the bugs with irregularly sized sliders:
- Fixes the currentSlide to use the child elements to determine the slide number.
This way slides with different sizes no longer interfere with the current slide number
- Clamp the navigate on a min and max, so when sliders are supposed to slide multiple items (say currensSlide + visibleSlides) it can no longer try to go out of bounds.
- Calculate slidesVisible using the average slide width/length instead of the first child

Ref: FW-1849
