### PR TITLE
Added collapsible filter configuration

### DIFF
--- a/resources/views/components/accordion/filter.blade.php
+++ b/resources/views/components/accordion/filter.blade.php
@@ -1,7 +1,7 @@
 @slots(['content', 'label', 'icon'])
 @props(['canToggleShowMore' => false])
 
-<x-rapidez::accordion open class="border-t" :$attributes :$icon>
+<x-rapidez::accordion v-bind:open="!window.config.collapsed_attributes?.includes(filter?.code?.replace('super_', '')) || items.some(item => item.isRefined)" class="border-t" :$attributes :$icon>
     <x-slot:label>
         @slotdefault('label')
             @{{ filter?.name?.replace('_', ' ') }}

--- a/resources/views/listing/partials/filter/category.blade.php
+++ b/resources/views/listing/partials/filter/category.blade.php
@@ -3,6 +3,7 @@
     @attributes(['root-path' => $rootPath?->join(' > ')])
     show-more
     :limit="6"
+    :set="filter = null"
 >
     <template v-slot="{ items, refine, createURL, isShowingMore, toggleShowMore, canToggleShowMore }">
         <x-rapidez::accordion.filter v-show="items.length" canToggleShowMore>

--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -67,6 +67,8 @@ class ConfigController
             'street_lines'         => Rapidez::config('customer/address/street_lines', 2),
             'show_swatches'        => (bool) Rapidez::config('catalog/frontend/show_swatches_in_product_list'),
             'show_tax'             => in_array(Rapidez::config('tax/display/type', 1), [2, 3]),
+            // Compadre config data
+            'collapsed_attributes' => explode(',', Rapidez::config('rapidez/catalog/collapsed_attributes', '')),
         ];
     }
 


### PR DESCRIPTION
Depends on (but does not require) https://github.com/rapidez/magento2-compadre/pull/16

If compadre is not installed, default functionality is restored meaning all filters are open by default
Ref: FW-2421