### PR TITLE
[5.x] Check if history state is not null

### DIFF
--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -3,7 +3,7 @@ import * as Turbo from '@hotwired/turbo'
 Turbo.config.drive.progressBarDelay = 5
 
 document.addEventListener('turbo:before-visit', function (e) {
-    if (typeof history.state.turbo === 'undefined') {
+    if (!history?.state || typeof history.state.turbo === 'undefined') {
         // Trigger turbo to add the state.
         Turbo?.navigator?.history?.replace(window.location)
     }


### PR DESCRIPTION
ref: BORDEX-1447

In rare cases, [this state could still be null](https://developer.mozilla.org/en-US/docs/Web/API/History/state) when this event gets triggered (specifically this seems to be possible only in recent versions of mobile safari, based on our Sentry logging).

By adding this check here we make sure that this isn't an issue.