### PR TITLE
[4.x] Fix name being empty in indexer

### DIFF
--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -72,7 +72,11 @@ class Category extends Model
 
     protected function name(): Attribute
     {
-        return Attribute::get(fn (?string $value) => trim($value ?? ''));
+        return Attribute::get(function (?string $value) {
+            $value ??= $this->getAttributeFromArray('name');
+
+            return trim($value ?? '');
+        });
     }
 
     public function subcategories()


### PR DESCRIPTION
This is a fix we added into the 5.x version of this function, but not in the 4.x version.