### PR TITLE
Fix collection being turned into array bracket string

### DIFF
--- a/src/Models/AbstractAttribute.php
+++ b/src/Models/AbstractAttribute.php
@@ -62,13 +62,13 @@ class AbstractAttribute extends Model
     {
         return Attribute::get(function ($value) {
             $value = $this->option_values ?? $this->rawValue ?? $value;
-            $value = array_map(function ($val) {
+            $value = collect($value)->map(function ($val) {
                 if ($this->is_html_allowed_on_front) {
                     return $val;
                 }
 
                 return e(htmlspecialchars_decode($val), false);
-            }, Arr::wrap($value));
+            })->all();
 
             // NOTE: doing it this way properly returns null when there are no values
             if (count($value) <= 1) {


### PR DESCRIPTION
`Arr::wrap` only checks is_array, if a collection is passed it is not an array and thus it gets wrapped into a new array.
causing an empty collection to turn into `['[]']` by wrapping it into a collection it can correctly identify other collections and ensure this is no problem