### PR TITLE
Removed duplicate if check for wrapping div

### DIFF
--- a/resources/views/product/overview.blade.php
+++ b/resources/views/product/overview.blade.php
@@ -62,24 +62,22 @@
         </div>
     @endif
 
-    @if ($product->relationProducts->count() || $product->upsells->count())
-        <div class="container flex flex-col gap-5 mt-14">
-            @if (count($ids = $product->relationProducts->pluck('linked_product_id')))
-                <x-rapidez::productlist
-                    title="Related products"
-                    field="entity_id"
-                    :value="$ids"
-                />
-            @endif
-            @if (count($ids = $product->upsells->pluck('linked_product_id')))
-                <x-rapidez::productlist
-                    title="We found other products you might like!"
-                    field="entity_id"
-                    :value="$ids"
-                />
-            @endif
-        </div>
-    @endif
+    <div class="container has-[*]:flex hidden flex-col gap-5  mt-14">
+        @if (count($ids = $product->relationProducts->pluck('linked_product_id')))
+            <x-rapidez::productlist
+                title="Related products"
+                field="entity_id"
+                :value="$ids"
+            />
+        @endif
+        @if (count($ids = $product->upsells->pluck('linked_product_id')))
+            <x-rapidez::productlist
+                title="We found other products you might like!"
+                field="entity_id"
+                :value="$ids"
+            />
+        @endif
+    </div>
 
     @include('rapidez::product.partials.widget')
 @endsection


### PR DESCRIPTION
By replacing the if check with `has-[*]:flex hidden` we essentially get the same effect where it is removed if no sliders are available to be shown 