### PR TITLE
[5.x] Use cart.value everywhere

### DIFF
--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -12,7 +12,7 @@
                 <div class="w-full rounded-sm bg p-4 xl:p-8 xl:w-3/4">
                     <form
                         v-on:submit.prevent="(e) => {
-                            window.app.config.globalProperties.submitPartials(e.target?.form ?? e.target, (cart?.billing_address?.same_as_shipping ?? true))
+                            window.app.config.globalProperties.submitPartials(e.target?.form ?? e.target, (cart?.value?.billing_address?.same_as_shipping ?? true))
                                 .then((result) =>
                                     window.$emit('checkout-credentials-saved')
                                     && window.Turbo.visit(url('{{ route('checkout', ['step' => 'payment']) }}'))

--- a/resources/views/checkout/steps/billing-address.blade.php
+++ b/resources/views/checkout/steps/billing-address.blade.php
@@ -19,7 +19,7 @@
     <div partial-submit v-on:partial-submit="(e) => mutate().then(e.detail.resolve).catch(e.detail.reject)">
         <fieldset v-on:change="function (e) {
             e.target.closest('fieldset').querySelector(':invalid') === null
-            && (!variables.same_as_shipping || !!cart?.shipping_addresses?.[0]?.postcode)
+            && (!variables.same_as_shipping || !!cart?.value?.shipping_addresses?.[0]?.postcode)
             && window.$emit('setBillingAddressOnCart')
         }">
             <template v-if="!cart.value.is_virtual">

--- a/resources/views/checkout/steps/shipping-address.blade.php
+++ b/resources/views/checkout/steps/shipping-address.blade.php
@@ -16,7 +16,7 @@
     v-if="!cart.value.is_virtual"
     key="checkout-shipping-address"
 >
-    <fieldset partial-submit v-on:partial-submit="(e) => mutate().then(e.detail.resolve).catch(e.detail.reject)" v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && mutate().then(() => (cart?.billing_address?.same_as_shipping ?? true) && window.$emit('setBillingAddressOnCart'))}">
+    <fieldset partial-submit v-on:partial-submit="(e) => mutate().then(e.detail.resolve).catch(e.detail.reject)" v-on:change="function (e) {e.target.closest('fieldset').querySelector(':invalid') === null && mutate().then(() => (cart?.value?.billing_address?.same_as_shipping ?? true) && window.$emit('setBillingAddressOnCart'))}">
         @include('rapidez::checkout.partials.address', ['type' => 'shipping'])
     </fieldset>
 </graphql-mutation>


### PR DESCRIPTION
ref: HDB-1126

These were missed, presumably because of the optional chaining operator `?.`.