### PR TITLE
Fixed only a single category tree getting indexed

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -157,6 +157,10 @@ trait Searchable
                     ->map(fn ($name) => trim($name))
                     ->join(' > ');
 
+                if ($pathCategories === '') {
+                    continue;
+                }
+
                 $data['category_lvl' . $i][] = $pathCategories;
             }
         }

--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -136,7 +136,8 @@ trait Searchable
             return Category::all()->keyBy('entity_id');
         });
 
-        foreach ($this->breadcrumbCategories as $category) {
+        foreach ($this->category_ids as $category_id) {
+            $category = $categories[$category_id] ?? null;
             if (! $category) {
                 continue;
             }


### PR DESCRIPTION
breadcrumbCategories only returns the deepest string of categories.

When a product is in multiple categories this means it will not get indexed properly, `category_ids` does contain all categories and matches the filter on the category page