### PR TITLE
[5.x] Check for searchquery being undefined

### DIFF
--- a/resources/views/layouts/partials/header/autocomplete/history.blade.php
+++ b/resources/views/layouts/partials/header/autocomplete/history.blade.php
@@ -1,6 +1,6 @@
 <ais-state-results v-slot="{ state: { query: searchQuery } }">
     <div>
-        <div v-if="autocompleteSlotProps.searchHistory && autocompleteSlotProps.searchHistory?.filter(([query, metadata]) => query.includes(searchQuery.toLowerCase())).length" class="border-b py-2">
+        <div v-if="autocompleteSlotProps.searchHistory && searchQuery !== undefined && autocompleteSlotProps.searchHistory?.filter(([query, metadata]) => query.includes(searchQuery.toLowerCase())).length" class="border-b py-2">
             <x-rapidez::autocomplete.title>
                 @lang('Previous Searches')
             </x-rapidez::autocomplete.title>


### PR DESCRIPTION
We saw this happening in our Sentry logging. Although it didn't break anything, it did cause some errors.