### PR TITLE
[5.x] Clear cart on unmount

### DIFF
--- a/resources/js/components/Checkout/CheckoutSuccess.vue
+++ b/resources/js/components/Checkout/CheckoutSuccess.vue
@@ -32,7 +32,7 @@ export default {
         useEventListener(window, 'beforeunload', this.beforeUnloadCallback, { once: true })
     },
 
-    destroyed() {
+    unmounted() {
         this.beforeUnloadCallback()
     },
 

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -65,7 +65,7 @@ export default {
         return this.$slots.default(this)
     },
 
-    destroyed() {
+    unmounted() {
         this.destroyed = true
     },
 


### PR DESCRIPTION
The `destroyed` lifecycle hook no longer exists in Vue3 apparently. Replaced this with `unmounted`, which does exist and is the last hook in the lifecycle.
