### PR TITLE
[5.x] Use subtotal_incl/excl_tax

### DIFF
--- a/resources/views/checkout/queries/fragments/orderV2.graphql
+++ b/resources/views/checkout/queries/fragments/orderV2.graphql
@@ -51,7 +51,10 @@ fragment orderV2 on CustomerOrder {
         ...orderItem
     }
     total {
-        subtotal {
+        subtotal_incl_tax {
+            value
+        }
+        subtotal_excl_tax {
             value
         }
         shipping_handling {


### PR DESCRIPTION
ref: HDB-1129

`subtotal` is deprecated in favor of `subtotal_incl_tax` and `subtotal_excl_tax`, see https://developer.adobe.com/commerce/webapi/reference/graphql/latest/types-k-p#ordertotal