### PR TITLE
Fixed attribute sorting to prioritise position

### DIFF
--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -24,8 +24,8 @@ trait HasSuperAttributes
             config('rapidez.models.super_attribute'),
             'product_id',
         )
-            ->orderBy('eav_attribute.attribute_code')
-            ->orderBy('catalog_product_super_attribute.position');
+            ->orderBy('catalog_product_super_attribute.position')
+            ->orderBy('eav_attribute.attribute_code');
     }
 
     public function superAttributeValues(): Attribute

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a59d4e0ada3ff1de9c776b1e4f2b2c9b3122d7fe17afc419e379c76c674deb4
-size 496171
+oid sha256:c29f8097d554843168f00f70a73cca731b69466513b7740ce35cc29bf55096e3
+size 496152

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-Mobile-Safari-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-Mobile-Safari-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10f8d9713fb54c6b69c3b03db5ad430e85af47ea6858b82727438b48e1ad1f48
-size 544933
+oid sha256:974a3da0cfb799811b78eff11b202a8ba5ef7330c3e47225cb8615503e66262e
+size 544900

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-chromium-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5f31fa5e83fbd06a762f0ed159fb349312c785fc489991f8b0005ecae0edd59
-size 572928
+oid sha256:2ae0a1dadac2615405718584f31833b1b10dedcc4656e1c158ef10c749a2eca2
+size 571814

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-firefox-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fea49d2628cc10fb2569972b26d008866891aa44586a4339a3c647f7d3dbf8c
-size 719530
+oid sha256:5ab8d24800db56598bf5a9c456d1a3153055af79340e52713abfcfd53ad95159
+size 718014

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-webkit-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b575a92a1ae2655e9506361561c14feecfd2dff84da525ac58619cd0bd2c4d5
-size 652803
+oid sha256:fe2deac451ece98a21762fb87dac622c02967c10c2098b8d5399e6c14ac44481
+size 651529

--- a/tests/playwright/product.spec.js-snapshots/product-configurable-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-configurable-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f18d8cab1c00f19a13a08f31e6fc711a7b2e17e783b7575be042c6e3e945a33
-size 285337
+oid sha256:1c1b796eccb9463c675528247e0c01f689e42f2ed2c7cfc74670fddeead644b1
+size 285325

--- a/tests/playwright/product.spec.js-snapshots/product-configurable-1-Mobile-Safari-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-configurable-1-Mobile-Safari-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8d15b00b4c92b46cd8c601d677acbdd66272e84bbb8bc878c6c24d3b76f9e97
-size 313869
+oid sha256:12827b6243c611629a2ba98eb2478e3d274ce9d1e646f6062e66740f42b6a461
+size 313901

--- a/tests/playwright/product.spec.js-snapshots/product-configurable-1-chromium-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-configurable-1-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18cbda6860a60a403623b60bff5e34ac14f381cb6a01ddbe7f83a4254185b7ad
-size 377891
+oid sha256:b809f7c3d5d79ae8b3ea6fd107b5541e90c5f7907219d46280f9301f57217f5c
+size 377817

--- a/tests/playwright/product.spec.js-snapshots/product-configurable-1-firefox-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-configurable-1-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e3d2ed38046933e68bf54d58b3d49fdbf5143cbb8033dfec3e19a445f96fc56
-size 467917
+oid sha256:b4b7554837605685074bc7ab1bc9b42fc93d6cbd58768134db05c98d1fda7a9e
+size 468006

--- a/tests/playwright/product.spec.js-snapshots/product-configurable-1-webkit-linux.png
+++ b/tests/playwright/product.spec.js-snapshots/product-configurable-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0973c94ec95d6cbb2cdadee6a61666934b0b24121f457f0659fa8753ecaac556
-size 426309
+oid sha256:5667c7d0156cc4277a3b9f77ca414d73f2ad7e40091c5f47509727b34b4cc7e0
+size 426439


### PR DESCRIPTION
By setting attribute_code as the first sortby it will prioritise the code first.
Causing position to be the tie breaker, we want this the other way around.