### PR TITLE
[5.x] Make sure event listener gets removed

### DIFF
--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -80,6 +80,7 @@ export default {
         data: {},
         mutate: () => null,
         redirectUrl: '',
+        stopMutateListener: () => null,
     }),
 
     render() {
@@ -129,7 +130,7 @@ export default {
     mounted() {
         if (this.mutateEvent) {
             this.$nextTick(() =>
-                window.$on(
+                this.stopMutateListener = window.$on(
                     this.mutateEvent,
                     () => {
                         this.mutate()
@@ -138,6 +139,10 @@ export default {
                 ),
             )
         }
+    },
+
+    unmounted() {
+        this.stopMutateListener()
     },
 
     methods: {

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -129,14 +129,15 @@ export default {
 
     mounted() {
         if (this.mutateEvent) {
-            this.$nextTick(() =>
-                this.stopMutateListener = window.$on(
-                    this.mutateEvent,
-                    () => {
-                        this.mutate()
-                    },
-                    { defer: false },
-                ),
+            this.$nextTick(
+                () =>
+                    (this.stopMutateListener = window.$on(
+                        this.mutateEvent,
+                        () => {
+                            this.mutate()
+                        },
+                        { defer: false },
+                    )),
             )
         }
     },

--- a/resources/js/polyfills/emit.js
+++ b/resources/js/polyfills/emit.js
@@ -32,8 +32,9 @@ export const on = (window.$on = (event, callback, options = {}) => {
     }
 
     if (options.autoRemove) {
-        useEventListener(document, event, callbackFn)
+        return useEventListener(document, event, callbackFn)
     } else {
         document.addEventListener(event, callbackFn)
+        return () => document.removeEventListener(event, callbackFn)
     }
 })


### PR DESCRIPTION
ref: HDB-1129

We ran into a rare issue where sometimes, an event listener just doesn't get removed properly on unmount when `useEventListener` is used. Specifically this seems to happen to the billing address graphql-mutation component. There doesn't seem to be any clear reason why this one bugs out but not the shipping address one, which is essentially exactly the same.

This is reproducible by going to the payment step and back to the credentials step, and then monitoring the event listener calls. You will see that every time you do this, another event listener will be added.

In this PR, I've added an extra code path that removes the event listener (and allowed this to be done manually with `window.$on`).

Ideally, this bug itself should be fixed, but I wasn't able to find it. My guess is that some very specific circumstance causes Vue3 to not properly call the cleanup callback that vueUse relies on.