### PR TITLE
[5.x] Fix props on global slideover

### DIFF
--- a/resources/views/components/slideover/global.blade.php
+++ b/resources/views/components/slideover/global.blade.php
@@ -13,10 +13,9 @@ Standard usage may look like this:
 ```
 --}}
 
-@props(['title', 'position' => 'left'])
 @slots(['label'])
 
-<global-slideover title="{{ $title }}" position="{{ $position }}" v-slot="slideover">
+<global-slideover {{ $attributes->merge(['position' => 'left']) }} v-slot="slideover">
     <div>
         <label {{ $label->attributes->class('global-slideover-label cursor-pointer') }} v-on:click="slideover.open">
             {{ $label }}


### PR DESCRIPTION
Because of the way this was originally set up, even if you had a `v-bind:title` you still needed to define the static `title` attribute. By doing it this way it's more flexible.