### PR TITLE
Make query count check non-breaking

### DIFF
--- a/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
+++ b/src/Listeners/Healthcheck/MagentoSettingsHealthcheck.php
@@ -90,7 +90,6 @@ class MagentoSettingsHealthcheck extends Base
         $joinCount = ($superAttributesCount * 2) + (count($nonFlatAttributes) * 3) + 4;
 
         if ($joinCount > 58) {
-            $response['healthy'] = false;
             $response['messages'][] = ['type' => 'error', 'value' => __('Most likely the queries needed for Rapidez will exceed 58 joins when indexing or viewing products so you have to reduce them by adding more attributes to the flat tables')];
         }
 


### PR DESCRIPTION
The 58  joins may not always be true, in often cases the shop works fine but health checks fail due to the check
Ref: RAP-1963