### PR TITLE
Clean up leftover product and category page config on navigation

### DIFF
--- a/resources/js/turbolinks.js
+++ b/resources/js/turbolinks.js
@@ -9,6 +9,12 @@ document.addEventListener('turbo:before-visit', function (e) {
     }
 })
 
+document.addEventListener('turbo:visit', () => {
+    // Clean up old config.
+    delete window.config.product
+    delete window.config.category
+})
+
 document.addEventListener('vue:loaded', (e) => {
     // https://github.com/vuejs/core/issues/6154
     // This ensures the `v-bind:muted.attr` attribute is set before vue mounts

--- a/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81347227af88fbf64ac9865d4879b806e5a561bb1d3a745bc00eeb8c8aca9142
-size 277882
+oid sha256:776b8b885c7036af3c934cfcf65b6cb2c0a3b06bbf8102ee91b0c784c7b87ea0
+size 274385


### PR DESCRIPTION
This config would get overwritten when navigating to other category pages and product pages just fine.
However e.g. gtm would use the existence of window.config.product to determine wether you are on a PDP.
Once you visited a pdp once, every page navigation after that would cause a product page view event.

ref: FW-2482