### PR TITLE
Run cleanup functions on before-cache

### DIFF
--- a/resources/js/polyfills/emit.js
+++ b/resources/js/polyfills/emit.js
@@ -1,5 +1,7 @@
 import { useEventListener } from '@vueuse/core'
 
+let autoRemoveCleanupFunctions = []
+
 // Replace old window.app.$emit and window.app.$on
 export const emit = (window.$emit = (event, ...args) => {
     return document.dispatchEvent(new CustomEvent(event, { detail: { args: args } }))
@@ -32,8 +34,13 @@ export const on = (window.$on = (event, callback, options = {}) => {
     }
 
     if (options.autoRemove) {
-        useEventListener(document, event, callbackFn)
+        autoRemoveCleanupFunctions.push(useEventListener(document, event, callbackFn))
     } else {
         document.addEventListener(event, callbackFn)
     }
+})
+
+window.addEventListener('turbo:before-cache', () => {
+    autoRemoveCleanupFunctions.forEach((cleanup) => cleanup())
+    autoRemoveCleanupFunctions = []
 })

--- a/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81347227af88fbf64ac9865d4879b806e5a561bb1d3a745bc00eeb8c8aca9142
-size 277882
+oid sha256:b142c5c3eb8baeaee0cd1a74d6224899887e1202357c54f79b28a7bdfdc847bc
+size 274357

--- a/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-filter-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b142c5c3eb8baeaee0cd1a74d6224899887e1202357c54f79b28a7bdfdc847bc
-size 274357
+oid sha256:81347227af88fbf64ac9865d4879b806e5a561bb1d3a745bc00eeb8c8aca9142
+size 277882


### PR DESCRIPTION
Since Vue 3 functionality regarding unmounting has changed with useEventListener.
This results in the cleanup function only being called for `useEventListener` calls done within a .vue component.

This caused e.g. addToCart listeners of the gtm package to start stacking the same event listener.
Luckily `useEventListener` also returns the cleanup function, we unmount Vue on `turbo:before-cache` so we can cleanup the listeners ourselves.

Ref: FW-2481