### PR TITLE
Fixed productlist causing errors when value is false

### DIFF
--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -9,9 +9,9 @@ Examples:
 <x-rapidez::productlist :value="false" v-bind:base-filters="() => [{dslQuery}}]"/>
 --}}
 
-@if (!is_iterable($value) || count($value))
+@if (is_string($value) || count($value))
     <lazy v-slot="{ intersected }">
-        @if (!is_iterable($value)) <template v-if="{{ $value }}.length"> @endif
+        @if (is_string($value)) <template v-if="{{ $value }}.length"> @endif
             <listing
                 {{ $attributes }}
                 v-if="intersected"

--- a/resources/views/components/productlist.blade.php
+++ b/resources/views/components/productlist.blade.php
@@ -9,7 +9,7 @@ Examples:
 <x-rapidez::productlist :value="false" v-bind:base-filters="() => [{dslQuery}}]"/>
 --}}
 
-@if (is_string($value) || count($value))
+@if (!is_iterable($value) || count($value))
     <lazy v-slot="{ intersected }">
         @if (is_string($value)) <template v-if="{{ $value }}.length"> @endif
             <listing
@@ -52,6 +52,6 @@ Examples:
                     </ais-instant-search>
                 </div>
             </listing>
-        @if (!is_iterable($value)) </template> @endif
+        @if (is_string($value)) </template> @endif
     </lazy>
 @endif


### PR DESCRIPTION
https://github.com/rapidez/core/pull/1312 changed the checks. Adding an additional template check.

However due to the check only being for !is_iterable it activates on "false" as well.
This will render `<template v-if=".length"` causing a syntax error in Vue

We should instead check if it is a string