### PR TITLE
Fix multiselect setting incorrect type mapping

### DIFF
--- a/src/Models/Traits/Product/Searchable.php
+++ b/src/Models/Traits/Product/Searchable.php
@@ -194,7 +194,7 @@ trait Searchable
                     return false;
                 }
 
-                if ($attribute['input'] === 'select') {
+                if ($attribute['input'] === 'select' || $attribute['input'] === 'multiselect') {
                     // Select means that while the type may be an int, the data won't be an int.
                     return false;
                 }


### PR DESCRIPTION
This ensures multiselect gets no hardcoded type set, same as select