### PR TITLE
[5.x] Actually listen to retryOnCartError

### DIFF
--- a/resources/js/fetch.js
+++ b/resources/js/fetch.js
@@ -178,7 +178,7 @@ export const magentoGraphQL = (window.magentoGraphQL = async (
             })
 
             throw new GraphQLError(data.errors, responseClone)
-        } else if (cartErrors.length) {
+        } else if (cartErrors.length && options.retryOnCartError) {
             // Get a new cart and redo the query with updated cart id
             await fetchCart()
             window.Notify(window.config.translations.errors.cart_expired, 'warning')


### PR DESCRIPTION
As it turns out, someone (me) forgot to actually check for this option. This caused an infinite loop under rare circumstances.