### PR TITLE
Fixed attribute option sort order

### DIFF
--- a/src/Models/AbstractAttribute.php
+++ b/src/Models/AbstractAttribute.php
@@ -88,11 +88,6 @@ class AbstractAttribute extends Model
         });
     }
 
-    protected function sortOrder(): Attribute
-    {
-        return Attribute::get(fn () => $this->options[$this->rawValue]->sort_order ?? null);
-    }
-
     public function __toString(): string
     {
         return (string) $this->label;

--- a/src/Models/Scopes/AttributeOptionsScope.php
+++ b/src/Models/Scopes/AttributeOptionsScope.php
@@ -16,6 +16,7 @@ class AttributeOptionsScope implements Scope
             ->select([
                 'eav_attribute.*',
                 'catalog_eav_attribute.*',
+                DB::raw('MIN(eav_attribute_option.sort_order) AS sort_order'),
                 $model->qualifyColumn('*'),
                 DB::raw('IF(COUNT(eav_attribute_option_value.value) = 0, NULL, CAST(CONCAT(\'[\', GROUP_CONCAT( JSON_QUOTE(eav_attribute_option_value.value) ORDER BY eav_attribute_option.sort_order ASC), \']\') AS JSON)) AS option_values'),
             ])


### PR DESCRIPTION
ref: FW-2527

`$this->options` hasn't existed since the flat table migration so sort order would always be null and the values would never get sorted