### PR TITLE
Removed possible reactivity between data and variables

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           URL: http://localhost:1234/
           FLAT_TABLES: true
-          CUSTOM_ENTRYPOINT_COMMAND: 'php bin/magento encryption:key:change -k 5AM3SD5SkwT8iwIxL6L1q8XQhzK3wk51; magerun2 config:store:set system/smtp/disable 1; magerun2 config:store:set checkout/options/enable_guest_checkout_login 1; magerun2 config:store:delete design/head/includes; composer require graycore/magento2-cors; magerun2 module:enable Graycore_Cors; magerun2 config:store:set web/graphql/cors_allowed_origins "*"; magerun2 config:store:set web/graphql/cors_allowed_methods "POST, OPTIONS, GET"; magerun2 config:store:set web/graphql/cors_allowed_headers "Content-Currency, Store, X-Magento-Cache-Id, X-Captcha, Content-Type, Authorization, DNT, TE"; magerun2 config:store:set web/api_rest/cors_allowed_origins "*"'
+          CUSTOM_ENTRYPOINT_COMMAND: 'php bin/magento encryption:key:change -k 5AM3SD5SkwT8iwIxL6L1q8XQhzK3wk51; magerun2 config:store:set system/smtp/disable 1; magerun2 config:store:set checkout/options/enable_guest_checkout_login 1; magerun2 config:store:delete design/head/includes'
         ports:
           - 3307:3306
           - 1234:80

--- a/resources/js/components/GraphqlMutation.vue
+++ b/resources/js/components/GraphqlMutation.vue
@@ -100,7 +100,7 @@ export default {
 
     created() {
         this.initialVariables = JSON.parse(JSON.stringify(this.variables))
-        this.data = this.variables
+        this.data = JSON.parse(JSON.stringify(this.variables))
         this.redirectUrl = this.redirect
 
         if (this.debounce) {


### PR DESCRIPTION
This prevents a bug where the unfinished address form gets cleared if the e-mail address is filled in the meantime.

Steps to reproduce:
1. go to https://demo.rapidez.io
2. Enter the onestep checkout
3. Fill in your firstname and lastname **before** filling in an e-mail
4. fill in an e-mail
5. Firstname and lastname are cleared

This only happens once, if you enter the firstname and lastname again. And amend your e-mail address it no longer changes.

It seems to be that `this.data = this.variables` causes unintended reactivity between some fields, circumventing the variables watcher. Causing it to see a change while externally no changes have occurred.

This PR removes any possible reactivity between `this.variables` and `this.data` only allowing the variables watcher to sync data from variables to data