### PR TITLE
Fixed double click submit before next

### DIFF
--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -33,7 +33,7 @@
                             @include('rapidez::checkout.steps.shipping-method')
                         </template>
 
-                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start" loader>
+                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
                             @lang('Next')
                         </x-rapidez::button.conversion>
                     </form>

--- a/resources/views/checkout/pages/credentials.blade.php
+++ b/resources/views/checkout/pages/credentials.blade.php
@@ -33,7 +33,7 @@
                             @include('rapidez::checkout.steps.shipping-method')
                         </template>
 
-                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
+                        <x-rapidez::button.conversion type="submit" data-testid="continue" class="self-start" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action (#1370) --}}">
                             @lang('Next')
                         </x-rapidez::button.conversion>
                     </form>

--- a/resources/views/checkout/pages/login.blade.php
+++ b/resources/views/checkout/pages/login.blade.php
@@ -20,7 +20,7 @@
         >
             @include('rapidez::checkout.steps.login')
 
-            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
+            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action (#1370) --}}">
                 @lang('Next')
             </x-rapidez::button.conversion>
         </form>

--- a/resources/views/checkout/pages/login.blade.php
+++ b/resources/views/checkout/pages/login.blade.php
@@ -20,7 +20,7 @@
         >
             @include('rapidez::checkout.steps.login')
 
-            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader>
+            <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
                 @lang('Next')
             </x-rapidez::button.conversion>
         </form>

--- a/resources/views/checkout/steps/place-order.blade.php
+++ b/resources/views/checkout/steps/place-order.blade.php
@@ -8,7 +8,7 @@
     v-slot="{ mutate, variables }"
 >
     <fieldset>
-        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader>
+        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
             @lang('Place order')
         </x-rapidez::button.conversion>
     </fieldset>

--- a/resources/views/checkout/steps/place-order.blade.php
+++ b/resources/views/checkout/steps/place-order.blade.php
@@ -8,7 +8,7 @@
     v-slot="{ mutate, variables }"
 >
     <fieldset>
-        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action --}}">
+        <x-rapidez::button.conversion type="submit" data-testid="continue" class="mt-3" loader v-on:mousedown.prevent="{{-- Do not remove, this prevents requiring double click for the submit action (#1370) --}}">
             @lang('Place order')
         </x-rapidez::button.conversion>
     </fieldset>


### PR DESCRIPTION
This fixes a bug where you have to click the next button twice in the checkout.
If you're editing an input and immediately click the "next" button it disables before you actually click. Preventing the trigger to move to the next page in the form.

It does this because every fieldset syncs it's data to Magento on change, during these network requests the "Next" button gets disabled.
If you try to click the "next" button from a changed input it'll:
1. Trigger the change on the input
2. Do the network request
3. Disable the "next" button due to the network request
4. Trigger the click event on the changed input.

`v-on:mousedown.prevent` is the solution, why?
`mousedown` executes in the same event cycle as the `change` event does, calling `prevent` on that **also** prevents the change event from running.
This doesn't work on the `click` event since `click` is triggered in a later event cycle.

The reason why missing this change event is no problem is because the `click`/`submit` causes all `partial-submit` fieldsets to first push their value to Magento before proceeding to the next step.
Since the inputs have no `v-model.lazy` but `v-model` the data is synced to vue on `input`, not on `change`

So all input will get synced to Magento before proceeding.