### PR TITLE
Fixed vite 8 warning

### DIFF
--- a/resources/publishables/vite.config.js
+++ b/resources/publishables/vite.config.js
@@ -18,8 +18,8 @@ export default defineConfig({
     resolve: {
         preserveSymlinks: true,
         alias: {
-            '@': path.resolve(__dirname, './resources/js'),
-            Vendor: path.resolve(__dirname, './vendor'),
+            '@': path.resolve(import.meta.dirname, './resources/js'),
+            Vendor: path.resolve(import.meta.dirname, './vendor'),
             vue: 'vue/dist/vue.esm-bundler.js',
         },
     },


### PR DESCRIPTION
Vite 8 comes with the following warning:
> (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default > in a future major version of Vite:
>   `__dirname` (vite.config.js:37:35). Use `import.meta.dirname` instead
>Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.

This fixes that warning.