### PR TITLE
Lock turbo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "devDependencies": {
         "@axe-core/playwright": "^4.10.2",
         "@babel/core": "^8.0.1",
-        "@hotwired/turbo": "8.0.21",
+        "@hotwired/turbo": "8.0.20",
         "@playwright/test": "^1.53.0",
         "@searchkit/instantsearch-client": "^4.14.1",
         "@tailwindcss/forms": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "devDependencies": {
         "@axe-core/playwright": "^4.10.2",
         "@babel/core": "^8.0.1",
-        "@hotwired/turbo": "^8.0.2",
+        "@hotwired/turbo": "8.0.21",
         "@playwright/test": "^1.53.0",
         "@searchkit/instantsearch-client": "^4.14.1",
         "@tailwindcss/forms": "^0.5.3",


### PR DESCRIPTION
See: https://github.com/hotwired/turbo/issues/1496#issuecomment-5524000689
since 8.0.21 Turbo added a feature that breaks category page back navigation after filtering.

A workaround is not possible yet, thus we should lock the version to 8.0.20 for now.