### PR TITLE
Prevent breaking indexer on missing child label on super attribute

### DIFF
--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -42,7 +42,7 @@ trait HasSuperAttributes
                     ->map(fn ($children, $value) => (object) [
                         'children' => $children->pluck('entity_id'),
                         'value'    => $value,
-                        'label'    => $children->first()->label,
+                        'label'    => $children->first()?->label,
                     ]),
             ])
         )->shouldCache();

--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -37,12 +37,13 @@ trait HasSuperAttributes
                     ->mapWithKeys(fn ($child) => [
                         $child->entity_id => $child->getCustomAttribute($attribute->attribute_code),
                     ])
+                    ->filter()
                     ->sortBy('sort_order')
                     ->groupBy('rawValue')
                     ->map(fn ($children, $value) => (object) [
                         'children' => $children->pluck('entity_id'),
                         'value'    => $value,
-                        'label'    => $children->first()?->label,
+                        'label'    => $children->first()->label,
                     ]),
             ])
         )->shouldCache();


### PR DESCRIPTION
This is an error i ran into when indexing. It is most likely a data error, however now a (possibly) single product is breaking the whole indexer.

This fixes it