### PR TITLE
[5.x] Fix tax on shipping

### DIFF
--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -66,8 +66,8 @@
                 <small class="text-muted">@{{ cart.value.shipping_addresses[0].selected_shipping_method.carrier_title }} - @{{ cart.value.shipping_addresses[0].selected_shipping_method.method_title }}</small>
             </dt>
             <dd>
-                <template v-if="showTax">@{{ window.price(cart.value.shipping_addresses?.[0]?.selected_shipping_method.price_incl_tax.value) }}</template>
-                <template v-else>@{{ window.price(cart.value.shipping_addresses?.[0]?.selected_shipping_method.price_excl_tax.value) }}</template>
+                <template v-if="showTax">@{{ price(cart.value.shipping_addresses[0].selected_shipping_method.price_incl_tax.value) }}</template>
+                <template v-else>@{{ price(cart.value.shipping_addresses[0].selected_shipping_method.price_excl_tax.value) }}</template>
             </dd>
         </div>
         <div v-for="discount in cart.value.prices.discounts" class="border-t pt-3 mt-3">

--- a/resources/views/checkout/partials/sidebar.blade.php
+++ b/resources/views/checkout/partials/sidebar.blade.php
@@ -65,7 +65,10 @@
                 @lang('Shipping')<br>
                 <small class="text-muted">@{{ cart.value.shipping_addresses[0].selected_shipping_method.carrier_title }} - @{{ cart.value.shipping_addresses[0].selected_shipping_method.method_title }}</small>
             </dt>
-            <dd>@{{ price(cart.value.shipping_addresses[0].selected_shipping_method.amount.value) }}</dd>
+            <dd>
+                <template v-if="showTax">@{{ window.price(cart.value.shipping_addresses?.[0]?.selected_shipping_method.price_incl_tax.value) }}</template>
+                <template v-else>@{{ window.price(cart.value.shipping_addresses?.[0]?.selected_shipping_method.price_excl_tax.value) }}</template>
+            </dd>
         </div>
         <div v-for="discount in cart.value.prices.discounts" class="border-t pt-3 mt-3">
             <dt>@{{ discount.label }}</dt>


### PR DESCRIPTION
We can use price_incl_tax and price_excl_tax here, and so we should 🙂 