### PR TITLE
Preload instantsearch-components on listing pages

### DIFF
--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -2,7 +2,7 @@
 
 @pushOnce('head', 'es_url-preconnect')
     <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
-    @vite(vite_filename_paths(['Listing.vue', 'InstantSearch']))
+    @vite(vite_filename_paths(['Listing.vue', 'InstantSearch', 'instantsearch-components']))
 @endPushOnce
 
 <div class="min-h-screen">


### PR DESCRIPTION
This ensures instantsearch shows as quick as possible on a category page