### PR TITLE
[2.x] Make sure no NaN comes out of the slider calculation

### DIFF
--- a/resources/js/components/Elements/Slider.vue
+++ b/resources/js/components/Elements/Slider.vue
@@ -209,6 +209,10 @@ export default {
                 return 0
             }
 
+            if (this.childSpan <= 0) {
+                return 0
+            }
+
             return Math.round(this.sliderSpan / this.childSpan)
         },
         slidesTotal() {


### PR DESCRIPTION
ref: VGB-1067

We saw a Sentry error that was caused by a NaN in a v-for. This ultimately led me to this piece of code, which would return a NaN because the child span was (temporarily) 0.