### PR TITLE
Use super labels instead of their int values

### DIFF
--- a/src/Http/Controllers/ConfigController.php
+++ b/src/Http/Controllers/ConfigController.php
@@ -117,7 +117,7 @@ class ConfigController
         return collect($attributes)
             ->map(fn ($attribute) => [
                 ...$attribute,
-                'code'      => ($attribute['prefix'] ?? '') . $attribute['code'],
+                'code'      => ($attribute['prefix'] ?? '') . $attribute['code'] . ($attribute['super'] ? '_labels' : ''),
                 'base_code' => $attribute['code'],
             ])
             ->sortBy('position')

--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -4,6 +4,7 @@ namespace Rapidez\Core\Models\Traits\Product;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 use Rapidez\Core\Models\Traits\HasToArrayData;
 
 trait HasSuperAttributes
@@ -30,7 +31,7 @@ trait HasSuperAttributes
 
     public function superAttributeValues(): Attribute
     {
-        return Attribute::get(fn () => $this->superAttributes
+        return Attribute::get(fn (): Collection => $this->superAttributes
             ->sortBy('position')
             ->mapWithKeys(fn ($attribute) => [
                 $attribute->attribute_code => $this->children
@@ -52,8 +53,9 @@ trait HasSuperAttributes
     public function superAttributesToArrayData(): array
     {
         return $this->superAttributeValues
-            ->mapWithKeys(fn ($values, $attribute) => [
+            ->mapWithKeys(fn (Collection $values, $attribute) => [
                 "super_{$attribute}"        => $values->pluck('value'),
+                "super_{$attribute}_labels" => $values->pluck('label')->filter(),
                 "super_{$attribute}_values" => $values,
             ])
             ->toArray();
@@ -65,6 +67,7 @@ trait HasSuperAttributes
             ->pluck('attribute_code')->map(fn ($attribute) => [
                 $attribute,
                 "super_{$attribute}",
+                "super_{$attribute}_labels",
                 "super_{$attribute}_values",
             ])
             ->flatten()

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-chromium-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ae0a1dadac2615405718584f31833b1b10dedcc4656e1c158ef10c749a2eca2
-size 571814
+oid sha256:a18cf6d932440680fa60451c78ddd0cf2e897172cbee7d4e2e93815506627014
+size 568413

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-firefox-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-firefox-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ab8d24800db56598bf5a9c456d1a3153055af79340e52713abfcfd53ad95159
-size 718014
+oid sha256:6283814b9fadf9838cb5b9af3fe718ea3e3a750c364d1cde7c5cce9871a701cb
+size 713587

--- a/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-webkit-linux.png
+++ b/tests/playwright/category.spec.js-snapshots/category-with-configurable-products-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac8d4c055efc4a4a4af1b9e20b5205c071b5df132e7fa4e6965838deaa65238c
-size 637398
+oid sha256:e7eb67823a130f5d5d37da4737d0f2a13456726459e781cef821bb26314e15b4
+size 633950

--- a/tests/playwright/checkout.spec.js-snapshots/incorrect-password-login-1-Mobile-Chrome-linux.png
+++ b/tests/playwright/checkout.spec.js-snapshots/incorrect-password-login-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b51a69da606d7a66046985e31729afef082077929ae6a7c4a1d41e5d451ae0a
-size 64409
+oid sha256:58393291e4184e28fabe38e71cb29faea8e4fa49de421b72e8c52a7d6479c9be
+size 64431


### PR DESCRIPTION
As a quick example. this is what gets indexed:
<img width="489" height="973" alt="image" src="https://github.com/user-attachments/assets/98305ebc-bc9a-46b5-a73c-86bfae208c23" />
meaning the following shows up as filter:
<img width="329" height="236" alt="image" src="https://github.com/user-attachments/assets/5cabf841-d267-4f2e-ac0b-0c3490f1bfcd" />
After this change it will show up as:
<img width="317" height="237" alt="image" src="https://github.com/user-attachments/assets/5ae4588f-21f6-4e31-864d-56dd856131aa" />


Both the super_xxx and super_xxx_values are used in the AddToCart.vue
(though we could remove the need for `super_xxx` by using `Object.keys("super_xxx_values")` but that will be a breaking change)