### PR TITLE
[4.x] Get latest timestamp from indexer

### DIFF
--- a/src/Actions/GetLatestIndexTimestamp.php
+++ b/src/Actions/GetLatestIndexTimestamp.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rapidez\Core\Actions;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class GetLatestIndexTimestamp
+{
+    public function get(): Carbon
+    {
+        $reindexAllInvalidTime = new Carbon(DB::scalar('SELECT scheduled_at FROM cron_schedule WHERE `job_code` = \'indexer_reindex_all_invalid\' AND `status` = \'success\' ORDER BY `scheduled_at` DESC LIMIT 1') ?? 0);
+        $latestFullIndexTime = new Carbon(DB::scalar('SELECT updated FROM indexer_state WHERE `indexer_id` = \'catalog_product_flat\' OR `indexer_id` = \'catalog_category_flat\' ORDER BY updated LIMIT 1') ?? 0);
+
+        $latest = $reindexAllInvalidTime > $latestFullIndexTime ? $reindexAllInvalidTime : $latestFullIndexTime;
+        if ($latest->timestamp == 0) {
+            return null;
+        }
+
+        return $latest;
+    }
+}

--- a/src/Actions/GetLatestIndexTimestamp.php
+++ b/src/Actions/GetLatestIndexTimestamp.php
@@ -9,8 +9,8 @@ class GetLatestIndexTimestamp
 {
     public function get(): Carbon
     {
-        $reindexAllInvalidTime = new Carbon(DB::scalar('SELECT scheduled_at FROM cron_schedule WHERE `job_code` = \'indexer_reindex_all_invalid\' AND `status` = \'success\' ORDER BY `scheduled_at` DESC LIMIT 1') ?? 0);
-        $latestFullIndexTime = new Carbon(DB::scalar('SELECT updated FROM indexer_state WHERE `indexer_id` = \'catalog_product_flat\' OR `indexer_id` = \'catalog_category_flat\' ORDER BY updated LIMIT 1') ?? 0);
+        $reindexAllInvalidTime = new Carbon(DB::scalar("SELECT scheduled_at FROM cron_schedule WHERE `job_code` = 'indexer_reindex_all_invalid' AND `status` = 'success' ORDER BY `scheduled_at` DESC LIMIT 1") ?? 0);
+        $latestFullIndexTime = new Carbon(DB::scalar("SELECT updated FROM indexer_state WHERE `indexer_id` = 'catalog_product_flat' OR `indexer_id` = 'catalog_category_flat' ORDER BY updated LIMIT 1") ?? 0);
 
         $latest = $reindexAllInvalidTime > $latestFullIndexTime ? $reindexAllInvalidTime : $latestFullIndexTime;
         if ($latest->timestamp == 0) {

--- a/src/Commands/UpdateIndexCommand.php
+++ b/src/Commands/UpdateIndexCommand.php
@@ -5,6 +5,7 @@ namespace Rapidez\Core\Commands;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
+use Rapidez\Core\Actions\GetLatestIndexTimestamp;
 use Rapidez\Core\Events\IndexAfterEvent;
 use Rapidez\Core\Events\IndexBeforeEvent;
 use Rapidez\Core\Facades\Rapidez;
@@ -23,6 +24,13 @@ class UpdateIndexCommand extends Command
         if (! $this->getLatestIndexDate()) {
             $this->error(__('No latest index date has been found yet, please run php artisan rapidez:index first.'));
 
+            return;
+        }
+
+        $latest = resolve(GetLatestIndexTimestamp::class)->get();
+
+        if ($latest <= $this->getLatestIndexDate()) {
+            $this->info(__('The latest index date has not changed.'));
             return;
         }
 

--- a/src/Commands/UpdateIndexCommand.php
+++ b/src/Commands/UpdateIndexCommand.php
@@ -31,6 +31,7 @@ class UpdateIndexCommand extends Command
 
         if ($latest <= $this->getLatestIndexDate()) {
             $this->info(__('The latest index date has not changed.'));
+
             return;
         }
 

--- a/src/Listeners/UpdateLatestIndexDate.php
+++ b/src/Listeners/UpdateLatestIndexDate.php
@@ -2,9 +2,9 @@
 
 namespace Rapidez\Core\Listeners;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
+use Rapidez\Core\Actions\GetLatestIndexTimestamp;
 use Rapidez\Core\Events\IndexAfterEvent;
 
 class UpdateLatestIndexDate
@@ -13,9 +13,7 @@ class UpdateLatestIndexDate
     {
         return Storage::disk('local')->put(
             '/.last-index',
-            // With this we're just making sure the comparison
-            // is done within the same timezone in MySQL.
-            DB::scalar('SELECT NOW()')
+            resolve(GetLatestIndexTimestamp::class)->get(),
         );
     }
 


### PR DESCRIPTION
ref: RAP-1998

This is not an issue in 5.x because we don't use the flat table there anymore.

We need to know when the flat table has been actually updated last, because otherwise changes my fall through the cracks. This is more relevant for the code that clears the cache in rapidez/statamic.