### PR TITLE
Fixed text to long error during indexing

### DIFF
--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -53,7 +53,7 @@ trait HasSuperAttributes
     {
         return $this->superAttributeValues
             ->mapWithKeys(fn ($values, $attribute) => [
-                "super_{$attribute}"        => $values->pluck('value'),
+                "super_{$attribute}"        => $values->pluck('value')->filter()->values(),
                 "super_{$attribute}_values" => $values,
             ])
             ->toArray();

--- a/src/Models/Traits/Product/HasSuperAttributes.php
+++ b/src/Models/Traits/Product/HasSuperAttributes.php
@@ -37,7 +37,7 @@ trait HasSuperAttributes
                     ->mapWithKeys(fn ($child) => [
                         $child->entity_id => $child->getCustomAttribute($attribute->attribute_code),
                     ])
-                    ->filter()
+                    ->filter(fn ($value, $key) => $value && $key)
                     ->sortBy('sort_order')
                     ->groupBy('rawValue')
                     ->map(fn ($children, $value) => (object) [
@@ -53,7 +53,7 @@ trait HasSuperAttributes
     {
         return $this->superAttributeValues
             ->mapWithKeys(fn ($values, $attribute) => [
-                "super_{$attribute}"        => $values->pluck('value')->filter()->values(),
+                "super_{$attribute}"        => $values->pluck('value'),
                 "super_{$attribute}_values" => $values,
             ])
             ->toArray();


### PR DESCRIPTION
This error has been occurring in one of my shops
> mapper [super_xxx] cannot be changed from type [text] to [long]

The reason still appears to the `$child->entity_id` returning null, this is most likely caused by a data issue but shouldn't cause crashes