### PR TITLE
SSR on categories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "rapidez/composer-template-diff-plugin": "^1.0",
         "rapidez/laravel-multi-cache": "^2.1",
         "rapidez/laravel-scout-elasticsearch": "^1.0",
+        "spatie/browsershot": "^5.0",
         "tormjens/eventy": "^0.8"
     },
     "require-dev": {

--- a/config/rapidez/listing_snapshot.php
+++ b/config/rapidez/listing_snapshot.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    // Anchor category pages get a static HTML snapshot -  captured with a headless
+    // browser from the real, fully Vue-rendered page - shown until Vue itself has
+    // taken over. It's a literal copy of Vue's own output, so there's no separate
+    // template to keep in sync with the real listing.
+    //
+    // This requires `spatie/browsershot` with Node and a Chrome/Chromium binary
+    // available wherever the queue worker runs, so it's opt-in.
+    'enabled' => env('RAPIDEZ_LISTING_SNAPSHOT', false),
+
+    // How long a captured snapshot is served before it's considered stale and a
+    // new one gets queued for the next visitor.
+    'ttl' => env('RAPIDEZ_LISTING_SNAPSHOT_TTL', 60),
+
+    // Browsershot/Puppeteer options, see https://spatie.be/docs/browsershot.
+    'node_binary'      => env('BROWSERSHOT_NODE_BINARY'),
+    'npm_binary'       => env('BROWSERSHOT_NPM_BINARY'),
+    'node_module_path' => env('BROWSERSHOT_NODE_MODULE_PATH'),
+    'chrome_path'      => env('BROWSERSHOT_CHROME_PATH'),
+
+    // Usually needed when Chrome runs as root, e.g. in most Docker containers.
+    'no_sandbox' => env('BROWSERSHOT_NO_SANDBOX', false),
+];

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -144,7 +144,18 @@ export default {
                         // it can hand over: it's kept around until real results have actually rendered,
                         // rather than as soon as Vue mounts, to avoid a flash of empty content between the two.
                         subscribe: () => {
-                            instantSearchInstance.once('render', () => {
+                            // InstantSearch emits 'render' as soon as a search is *kicked off* (before
+                            // the request resolves), not just once results are back - on a fast
+                            // connection the real one follows near-instantly so it's easy to miss, but
+                            // on a slow one this would swap in an empty/loading state well before the
+                            // real results arrive. `helper.lastResults` is only set once a response has
+                            // actually been processed, so wait for a render pass that has it.
+                            const onRender = () => {
+                                if (!instantSearchInstance.helper?.lastResults) {
+                                    return
+                                }
+
+                                instantSearchInstance.removeListener('render', onRender)
                                 this.rendered = true
 
                                 // Wait for Vue to have actually applied the `rendered` change (i.e. the

--- a/resources/js/components/Listing/Listing.vue
+++ b/resources/js/components/Listing/Listing.vue
@@ -61,6 +61,11 @@ export default {
         destroyed: false,
         utmFields: [],
         instantSearchInstance: null,
+        // Stays false until the first real results have rendered, so the listing
+        // can be kept hidden (rather than briefly showing an empty/no-results
+        // state) while the SSR snapshot is still covering for it - see
+        // `listingSlotProps.rendered` in resources/views/components/listing.blade.php.
+        rendered: false,
     }),
 
     render() {
@@ -135,7 +140,22 @@ export default {
                     this.instantSearchInstance = instantSearchInstance
                     return {
                         onStateChange: () => {},
-                        subscribe: () => {},
+                        // Tells the SSR listing snapshot (resources/views/components/listing.blade.php)
+                        // it can hand over: it's kept around until real results have actually rendered,
+                        // rather than as soon as Vue mounts, to avoid a flash of empty content between the two.
+                        subscribe: () => {
+                            instantSearchInstance.once('render', () => {
+                                this.rendered = true
+
+                                // Wait for Vue to have actually applied the `rendered` change (i.e. the
+                                // real listing becoming visible) before swapping the snapshot out, so
+                                // the two DOM changes land in the same paint instead of the snapshot
+                                // disappearing a frame before the real listing appears underneath it.
+                                this.$nextTick(() => {
+                                    document.dispatchEvent(new CustomEvent('listing:rendered'))
+                                })
+                            })
+                        },
                         unsubscribe: () => {},
                     }
                 },

--- a/resources/views/category/overview.blade.php
+++ b/resources/views/category/overview.blade.php
@@ -17,6 +17,7 @@
             @else
                 <x-rapidez::listing
                     :root-path="$category->parentcategories->pluck('name')"
+                    :ssr="$ssrListing ?? null"
                     v-bind:category-id="{{ $category->entity_id }}"
                 />
             @endif

--- a/resources/views/components/listing.blade.php
+++ b/resources/views/components/listing.blade.php
@@ -1,4 +1,4 @@
-@props(['rootPath' => null])
+@props(['rootPath' => null, 'ssr' => null])
 
 @pushOnce('head', 'es_url-preconnect')
     <link rel="preconnect" href="{{ config('rapidez.es_url') }}">
@@ -6,6 +6,32 @@
 @endPushOnce
 
 <div class="min-h-screen">
+    {{-- Static snapshot of the last time this listing was captured (see
+         GenerateCategoryListingSnapshot) - a literal copy of #listing-content's own
+         rendered markup below, shown until the real, interactive listing has results
+         (see the `listing:rendered` event dispatched from Listing.vue), so filters
+         and products are visible before Vue and vue-instantsearch have booted. --}}
+    @if ($ssr)
+        <div id="listing-ssr" data-testid="listing-ssr">
+            <div class="flex gap-x-20 gap-y-5 max-lg:flex-col min-h-screen">
+                {!! $ssr !!}
+            </div>
+        </div>
+        <script>
+            {{-- The captured markup includes real forms/buttons (add to cart, ...) that
+                 aren't wired up to anything until Vue mounts; without this, clicking one
+                 would fall back to the browser's native (and useless) form submission. --}}
+            document.getElementById('listing-ssr')?.addEventListener('submit', function (event) {
+                event.preventDefault()
+            })
+
+            document.addEventListener('listing:rendered', function once() {
+                document.removeEventListener('listing:rendered', once)
+                document.getElementById('listing-ssr')?.remove()
+            })
+        </script>
+    @endif
+
     <listing
         {{ $attributes }}
         v-slot="listingSlotProps"
@@ -24,7 +50,13 @@
                 {{ $before ?? '' }}
 
                 @slotdefault('slot')
-                    <div class="flex gap-x-20 gap-y-5 max-lg:flex-col min-h-screen" ref="root">
+                    {{-- id is the capture target for GenerateCategoryListingSnapshot; keep its
+                         direct children as just the filters/products so the snapshot swaps in
+                         without a layout shift. `v-show` (not `v-if`) keeps the widgets inside
+                         mounted so they can actually run their search - it just keeps this
+                         hidden until they have real results, instead of briefly showing empty
+                         filters/a "no results" state while the SSR snapshot is still visible. --}}
+                    <div id="listing-content" v-show="listingSlotProps.rendered" class="flex gap-x-20 gap-y-5 max-lg:flex-col min-h-screen" ref="root">
                         <div class="lg:w-80 shrink-0" data-testid="listing-filters">
                             @include('rapidez::listing.filters')
                         </div>

--- a/src/Http/Controllers/CategoryController.php
+++ b/src/Http/Controllers/CategoryController.php
@@ -2,6 +2,8 @@
 
 namespace Rapidez\Core\Http\Controllers;
 
+use Rapidez\Core\Search\CategoryListingSnapshotStore;
+
 class CategoryController
 {
     public function show(int $categoryId)
@@ -11,7 +13,12 @@ class CategoryController
 
         config(['frontend.category' => $category->only('entity_id')]);
 
-        $response = response()->view('rapidez::category.overview', compact('category'));
+        // Some fallback routes (e.g. UrlRewriteController) call this controller
+        // directly rather than through the router, so this can't rely on method
+        // dependency injection to get here.
+        $ssrListing = $category->is_anchor ? app(CategoryListingSnapshotStore::class)->get($category) : null;
+
+        $response = response()->view('rapidez::category.overview', compact('category', 'ssrListing'));
 
         return $response
             ->setEtag(md5($response->getContent() ?? ''))

--- a/src/Jobs/GenerateCategoryListingSnapshot.php
+++ b/src/Jobs/GenerateCategoryListingSnapshot.php
@@ -31,9 +31,7 @@ class GenerateCategoryListingSnapshot implements ShouldQueue
 
     public int $timeout = 60;
 
-    public function __construct(public int $categoryId)
-    {
-    }
+    public function __construct(public int $categoryId) {}
 
     public function handle(CategoryListingSnapshotStore $store): void
     {

--- a/src/Jobs/GenerateCategoryListingSnapshot.php
+++ b/src/Jobs/GenerateCategoryListingSnapshot.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Rapidez\Core\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Rapidez\Core\Search\CategoryListingSnapshotStore;
+use Spatie\Browsershot\Browsershot;
+use Throwable;
+
+/**
+ * Visits a category page with a headless browser, waits for the real,
+ * client-rendered listing to have results, and stores the rendered markup
+ * as an HTML snapshot to be shown to future visitors before Vue boots.
+ *
+ * This deliberately captures Vue's own output rather than re-implementing the
+ * listing in PHP, so the snapshot can never drift from what the real listing
+ * looks like.
+ */
+class GenerateCategoryListingSnapshot implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 60;
+
+    public function __construct(public int $categoryId)
+    {
+    }
+
+    public function handle(CategoryListingSnapshotStore $store): void
+    {
+        $categoryModel = config('rapidez.models.category');
+        $category = $categoryModel::withoutGlobalScopes()->find($this->categoryId);
+
+        if (! $category) {
+            return;
+        }
+
+        try {
+            $html = $this->render($category->url);
+        } catch (Throwable $e) {
+            report($e);
+
+            return;
+        }
+
+        if (! trim($html)) {
+            return;
+        }
+
+        $store->put($category, $html);
+    }
+
+    protected function render(string $categoryUrl): string
+    {
+        $browsershot = Browsershot::url(url($categoryUrl))
+            ->windowSize(1440, 900)
+            ->waitUntilNetworkIdle()
+            // `#listing-content` (resources/views/components/listing.blade.php) always
+            // exists once Vue mounts the listing, but an actual product means real
+            // results made it back from Elasticsearch and got rendered into it.
+            ->waitForSelector('[data-testid="listing-item"]', ['timeout' => 15000]);
+
+        if (config('rapidez.listing_snapshot.no_sandbox')) {
+            $browsershot->noSandbox();
+        }
+
+        if ($nodeBinary = config('rapidez.listing_snapshot.node_binary')) {
+            $browsershot->setNodeBinary($nodeBinary);
+        }
+
+        if ($npmBinary = config('rapidez.listing_snapshot.npm_binary')) {
+            $browsershot->setNpmBinary($npmBinary);
+        }
+
+        if ($nodeModulePath = config('rapidez.listing_snapshot.node_module_path')) {
+            $browsershot->setNodeModulePath($nodeModulePath);
+        }
+
+        if ($chromePath = config('rapidez.listing_snapshot.chrome_path')) {
+            $browsershot->setChromePath($chromePath);
+        }
+
+        return $browsershot->evaluate("document.getElementById('listing-content').innerHTML");
+    }
+}

--- a/src/RapidezServiceProvider.php
+++ b/src/RapidezServiceProvider.php
@@ -58,6 +58,7 @@ class RapidezServiceProvider extends ServiceProvider
         'frontend',
         'healthcheck',
         'jwt',
+        'listing_snapshot',
         'magento-defaults',
         'models',
         'routing',

--- a/src/Search/CategoryListingSnapshotStore.php
+++ b/src/Search/CategoryListingSnapshotStore.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rapidez\Core\Search;
+
+use Illuminate\Support\Facades\Cache;
+use Rapidez\Core\Jobs\GenerateCategoryListingSnapshot;
+use Rapidez\Core\Models\Category;
+
+/**
+ * Serves a cached HTML snapshot of a category's default (unfiltered) listing,
+ * captured with a headless browser from the real, fully client-rendered page
+ * (see GenerateCategoryListingSnapshot). It's a literal copy of Vue's own
+ * output, so there's no separate template to keep in sync with it.
+ */
+class CategoryListingSnapshotStore
+{
+    /**
+     * Returns the cached snapshot, or null if there isn't one (yet). On a miss,
+     * a job is queued to generate one for the *next* visitor - this request
+     * just falls back to the regular, fully client-rendered listing.
+     */
+    public function get(Category $category): ?string
+    {
+        if (! config('rapidez.listing_snapshot.enabled')) {
+            return null;
+        }
+
+        $snapshot = Cache::get($this->snapshotKey($category));
+
+        if ($snapshot === null) {
+            $this->queueGeneration($category);
+        }
+
+        return $snapshot ?: null;
+    }
+
+    public function put(Category $category, string $html): void
+    {
+        Cache::put(
+            $this->snapshotKey($category),
+            $html,
+            now()->addMinutes((int) config('rapidez.listing_snapshot.ttl', 60)),
+        );
+    }
+
+    protected function queueGeneration(Category $category): void
+    {
+        // Debounce: while a generation job is pending/running for this category,
+        // don't queue another one for every visitor hitting the same cache miss.
+        $lockKey = 'category-listing-snapshot-lock-' . config('rapidez.store') . '-' . $category->entity_id;
+
+        if (! Cache::add($lockKey, true, now()->addMinutes(5))) {
+            return;
+        }
+
+        GenerateCategoryListingSnapshot::dispatch($category->entity_id);
+    }
+
+    protected function snapshotKey(Category $category): string
+    {
+        return 'category-listing-snapshot-' . config('rapidez.store') . '-' . $category->entity_id;
+    }
+}


### PR DESCRIPTION
A POC for "SSR" on categories (generated by Claude). Real SSR is handled by Vue but we can't use that as our templates aren't within Vue files. We're using Blade Components so Vue is parsing the complete DOM each request. How this is working:

- First category visit renders the listing client side and triggers a job
- The job opens the same page with [Puppeteer](https://pptr.dev/) and captures the listing DOM (by using [spatie/browsershot](https://github.com/spatie/browsershot)) and saves it in the cache
- The next category visit renders the HTML from the cache and when Vue is ready it replaces it

Questions:
- How long should we keep the HTML and when should we clear it? Only on `rapidez:index` and `rapidez:index:update`?
- Do we also want this on categories with active filters? Cache will explode...
- Does this also improve the LCP?
- Does this impact the server performance?
- Does Chrome cleans up nicely? Previously with Dusk we'd some /tmp size issues.

Example with "slow 4G" throttling:

**Before**

https://github.com/user-attachments/assets/9113949a-54fb-4aa4-be68-622d5cf01283

**After** (watch the ms speed to see when it replaces)

https://github.com/user-attachments/assets/b9b73b9a-f0e9-44e5-aee6-b854b9f8c257

Ref: FW-2594