### PR TITLE
Reduce the data returned from children by ElasticSearch

### DIFF
--- a/config/rapidez/searchkit.php
+++ b/config/rapidez/searchkit.php
@@ -31,7 +31,17 @@ return [
         'media',
         'url',
         'stock',
-        'children',
+
+        // Used child attributes in listings
+        'children.*.entity_id',
+        'children.*.sku',
+        'children.*.name',
+        'children.*.stock.is_in_stock',
+        'children.*.thumbnail',
+        'children.*.prices',
+        'children.*.price',
+        'children.*.special_price',
+
         'super_*',
         'review_summary',
         'parents',


### PR DESCRIPTION
Previously all data from children was returned, currently only these are used / useful. This reduces the data by 40 to 60%

Ref: FW-2596